### PR TITLE
chore: format rotated agent secrets

### DIFF
--- a/secrets/agent-box-codex-forgejo-tea-token.yaml
+++ b/secrets/agent-box-codex-forgejo-tea-token.yaml
@@ -2,14 +2,14 @@ rotated_at_unencrypted: "2026-07-05T01:35:20Z"
 rotate_after_days_unencrypted: 30
 repository_access_unencrypted: all
 scopes_unencrypted:
-    - write:activitypub
-    - write:issue
-    - write:misc
-    - write:notification
-    - write:organization
-    - write:package
-    - write:repository
-    - write:user
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
 token_id_unencrypted: 3
 token_name_unencrypted: forgejo-tea-agent-box-codex-20260705013520311321
 token_last_eight_unencrypted: eb03ec38
@@ -17,67 +17,67 @@ username: ENC[AES256_GCM,data:CugEhpONyEPrmx4tO/kH,iv:Sjtm6U9Far+8f+w9qu52Io+h93
 url: ENC[AES256_GCM,data:TOaEn6HV5FXZ+7mja4dCst5xjbaxU9YeCKJn,iv:gn2lNEnbyNFvUZ44jOqf5s4FJb4g0aPDZmsik55V/5o=,tag:fcYf4RCA7y4A5+0aCUAnPg==,type:str]
 token: ENC[AES256_GCM,data:Xs9h8zeEm/IrDxSYkrmH+gIA3VBI45H9ZfqXzkLU39MFRV3yRTHq4g==,iv:ZHYv21F15GpT/lCkPfZuWedp9grVSsRHQug2MnGbAys=,tag:gTPLPVT0h/eo70KdfJ9SmQ==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4M1FMMEpTRVZYZmE1RG1L
-            RzErYU03U21xWXZPb3VUM1dsRGZsNGVBQ0FZCkhOZ3o0dWxNK2RIOHl1Z0FVME1y
-            WUVVbmxoeTFRYTdRY1BvU1FBRGlESTAKLS0tIEZ3cEowd2VwKzJBMHdDYmZGbkIz
-            Q1RCTUl4RWpmVnFSbjJ4MmVtQUgwUWcKlAZpRdTt+LPY53RUEMfgSXQL+iMI+ehg
-            V5VuyWeOGLe3WfqsklFGUDezqARHOZPnxAAY+VOHaNiUBkQfDzKqQQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age16madmg3yjv39dekr6dscqr2slv0haxcw7lw25v8vmly4wl95td4qwev54u
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5bE96bXZDczRKcVlpWVAz
-            bkYydjRjNHFOOGgreWliOXZZWnB4SkdMTFhFCmc0YmFGVEZ1TEthQkdRSy8zUzJH
-            ZG83aVhPemJCdEZxaFJoR3BFQm1sTDQKLS0tIC8wZkJUcVR2d3IrcEhjWVZWcHJ3
-            Sk05dUZqY1UxbExVMHZJa1EvYXhqMFEK01EAn7LS/KeuB5Q0aDqmd0oAVMRHc4GD
-            FYdE6RKivWIZe/o/ZnsowZEOHpt0PkPHUSkZkic9Z7Qr98w+CKSULg==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuVTZUVUNoTlJxSEZ0cjdm
-            T3Bsb3FWYnFBNmN2WU5XYjNSbWdDdzZyblFRCjYwbU5pT3cwL3d6cW9DRVpPTTNl
-            ZmxQL2tuT3Nsd0g5SkhYbjNQcFlyRlEKLS0tIGJzRktpRjQzWmdjU09xZGNlbTI3
-            SUhPc2kzRi9kVXhnZEZKMnJBSFFIYUEKxEKVR54qCdS0pJ1mDowb94oR2Lub2m9y
-            xpWyxApUIQJ9LNcK9D2x7Z6eg4azDX2Anp53KVG8rUOXW3HXwcXTGA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtZUNQaHZNVmg1ZHQzZ0pP
-            a3c5aVhzUFMrRXhzUE9td3FqandEdy9DSDNFCm9iUUlwM2puTjV1U3BqMklNbUZO
-            RlNHOHl4dGx0UlhRZGdRWjVHdVA5dUUKLS0tIFA1TkhsSXFtdHQ1eDd1L0c3eWVo
-            THJ5RHhscW4vcVdHRm1FQWpGNDczT28KsOB5N536DHY8waKnhgor0s+aAhYwhsGB
-            BN1P7odfaqeBflNaWGT5QYCv8IFtaOS1BMJjcCQKn/W0ocxz7odv4A==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrbWlRUXY3MWlTR2VTZ0FC
-            SjRxVkJGbWtCdjdiK1JWTDhXTmdQeSs1M2dFCjgxbG1vSmlFY1BwK2Z5QllWcXNn
-            bjdZeDVKZnVCT3BaM09mZmx5YWZZQ2cKLS0tIDRiQ0huZmJ4cTY2N2c4aGJhMERp
-            SjQwUWs5TzJaYnNXZnc3TG1hQmYzNGcKDFE8xNSBjSnSlOmX2fYCC55QMCscPxF+
-            a2EaNAlbDn/7KGQRAuVRgheEEIYcrq6LvKMjRAu4yt3VbfpEDtu3eA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoY1VKWlBtRHhSM0Q2N1Y1
-            cEprdHIyRU0zM1BGWGdFeVRXTUdNV0RMbjNJCkdWQnh3bTZyTWdEWjY3QTFjWTlp
-            UFBXMk9zSDNrU3N3NW9hQWdXT0VlY00KLS0tIEhJQnhxTHdPSGZlMmdxOUV0bndY
-            MFBQZnMvVHh5OHRUdjVvMTNBVmxpY0kKPlJly+GA1OynEw2uDSsGcuJMJ3CKv5Zg
-            +2P4J7q/Q2zKxv4bN9bthmDp13fIykiLi4d2GvQIgGeuWGoaWsDlMQ==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-05T01:35:20Z"
-    mac: ENC[AES256_GCM,data:QcEv7FUprmaw3mQrNktF2Eo3B+3zhtmTXkue5xgP6xwick/5xcvLaZ7ldpm3dz/Klb2fRg2XELePKGLrEz3MCcQd420JgZVOsKo32k0K+erXIFtoRsw7n9P6ggrGxGi0IhV4KEJaIcRYYWXAxgRS6EUUMTjjtV1NaoA6uPO7NBI=,iv:gNK685sZVqju5X6KxxyJCLCq3YtUuI7+tH4u8keOCKY=,tag:Ocp6/vz9rlkw70JnwuLU8Q==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4M1FMMEpTRVZYZmE1RG1L
+        RzErYU03U21xWXZPb3VUM1dsRGZsNGVBQ0FZCkhOZ3o0dWxNK2RIOHl1Z0FVME1y
+        WUVVbmxoeTFRYTdRY1BvU1FBRGlESTAKLS0tIEZ3cEowd2VwKzJBMHdDYmZGbkIz
+        Q1RCTUl4RWpmVnFSbjJ4MmVtQUgwUWcKlAZpRdTt+LPY53RUEMfgSXQL+iMI+ehg
+        V5VuyWeOGLe3WfqsklFGUDezqARHOZPnxAAY+VOHaNiUBkQfDzKqQQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age16madmg3yjv39dekr6dscqr2slv0haxcw7lw25v8vmly4wl95td4qwev54u
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5bE96bXZDczRKcVlpWVAz
+        bkYydjRjNHFOOGgreWliOXZZWnB4SkdMTFhFCmc0YmFGVEZ1TEthQkdRSy8zUzJH
+        ZG83aVhPemJCdEZxaFJoR3BFQm1sTDQKLS0tIC8wZkJUcVR2d3IrcEhjWVZWcHJ3
+        Sk05dUZqY1UxbExVMHZJa1EvYXhqMFEK01EAn7LS/KeuB5Q0aDqmd0oAVMRHc4GD
+        FYdE6RKivWIZe/o/ZnsowZEOHpt0PkPHUSkZkic9Z7Qr98w+CKSULg==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuVTZUVUNoTlJxSEZ0cjdm
+        T3Bsb3FWYnFBNmN2WU5XYjNSbWdDdzZyblFRCjYwbU5pT3cwL3d6cW9DRVpPTTNl
+        ZmxQL2tuT3Nsd0g5SkhYbjNQcFlyRlEKLS0tIGJzRktpRjQzWmdjU09xZGNlbTI3
+        SUhPc2kzRi9kVXhnZEZKMnJBSFFIYUEKxEKVR54qCdS0pJ1mDowb94oR2Lub2m9y
+        xpWyxApUIQJ9LNcK9D2x7Z6eg4azDX2Anp53KVG8rUOXW3HXwcXTGA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtZUNQaHZNVmg1ZHQzZ0pP
+        a3c5aVhzUFMrRXhzUE9td3FqandEdy9DSDNFCm9iUUlwM2puTjV1U3BqMklNbUZO
+        RlNHOHl4dGx0UlhRZGdRWjVHdVA5dUUKLS0tIFA1TkhsSXFtdHQ1eDd1L0c3eWVo
+        THJ5RHhscW4vcVdHRm1FQWpGNDczT28KsOB5N536DHY8waKnhgor0s+aAhYwhsGB
+        BN1P7odfaqeBflNaWGT5QYCv8IFtaOS1BMJjcCQKn/W0ocxz7odv4A==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrbWlRUXY3MWlTR2VTZ0FC
+        SjRxVkJGbWtCdjdiK1JWTDhXTmdQeSs1M2dFCjgxbG1vSmlFY1BwK2Z5QllWcXNn
+        bjdZeDVKZnVCT3BaM09mZmx5YWZZQ2cKLS0tIDRiQ0huZmJ4cTY2N2c4aGJhMERp
+        SjQwUWs5TzJaYnNXZnc3TG1hQmYzNGcKDFE8xNSBjSnSlOmX2fYCC55QMCscPxF+
+        a2EaNAlbDn/7KGQRAuVRgheEEIYcrq6LvKMjRAu4yt3VbfpEDtu3eA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoY1VKWlBtRHhSM0Q2N1Y1
+        cEprdHIyRU0zM1BGWGdFeVRXTUdNV0RMbjNJCkdWQnh3bTZyTWdEWjY3QTFjWTlp
+        UFBXMk9zSDNrU3N3NW9hQWdXT0VlY00KLS0tIEhJQnhxTHdPSGZlMmdxOUV0bndY
+        MFBQZnMvVHh5OHRUdjVvMTNBVmxpY0kKPlJly+GA1OynEw2uDSsGcuJMJ3CKv5Zg
+        +2P4J7q/Q2zKxv4bN9bthmDp13fIykiLi4d2GvQIgGeuWGoaWsDlMQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-05T01:35:20Z"
+  mac: ENC[AES256_GCM,data:QcEv7FUprmaw3mQrNktF2Eo3B+3zhtmTXkue5xgP6xwick/5xcvLaZ7ldpm3dz/Klb2fRg2XELePKGLrEz3MCcQd420JgZVOsKo32k0K+erXIFtoRsw7n9P6ggrGxGi0IhV4KEJaIcRYYWXAxgRS6EUUMTjjtV1NaoA6uPO7NBI=,iv:gNK685sZVqju5X6KxxyJCLCq3YtUuI7+tH4u8keOCKY=,tag:Ocp6/vz9rlkw70JnwuLU8Q==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4

--- a/secrets/agent-box-zai-forgejo-tea-token.yaml
+++ b/secrets/agent-box-zai-forgejo-tea-token.yaml
@@ -2,14 +2,14 @@ rotated_at_unencrypted: "2026-07-05T01:35:21Z"
 rotate_after_days_unencrypted: 30
 repository_access_unencrypted: all
 scopes_unencrypted:
-    - write:activitypub
-    - write:issue
-    - write:misc
-    - write:notification
-    - write:organization
-    - write:package
-    - write:repository
-    - write:user
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
 token_id_unencrypted: 4
 token_name_unencrypted: forgejo-tea-agent-box-zai-20260705013521157114
 token_last_eight_unencrypted: e6910f90
@@ -17,67 +17,67 @@ username: ENC[AES256_GCM,data:1iX/CFas7qjJAAQfqA==,iv:iMPZU8I+b2ATV6rPEx5V6h+2dC
 url: ENC[AES256_GCM,data:dw2vy0rpXztDa146z77anIuzMtzxCjBAmkij,iv:n0G4DOr2BwWrIS8QejzUihj+D+rvkH88V1lDQKBbOtw=,tag:+8/fJCqNUpSPG6NKd3vg7Q==,type:str]
 token: ENC[AES256_GCM,data:GaYOInhwV4Ae8Q91tIZSMzLZmODuWANXG5LZAliFVQE1ODB2q/znIQ==,iv:/IzzniwvquWmj26x+e8v277p3AiE/UHRfe3FHnN/U/E=,tag:bMEKeNDn08avSrYXiFSDlQ==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2K0FOSjF5MnhaZzk3WERI
-            SVlhNmErakwzb3NCcG04aDVzSmN3MU0yNkZNCkt3OHZSclpmSmtuRDl3bjIyNnpl
-            RHhnRTBhN0RaMFZucG9xNjNtRGxOQ0UKLS0tIFQxODZ0eHZWMjRMR3dtdG5hQzUv
-            Z3dldGVCa095RzBtMjhYSnQ0Y1NWVncKxQQqPkkqwguzJe5HmvxGZmnUMUg4BBr5
-            RPGoYaj+F47xT8xssEIqTNKCU+B/jqCP6RQ16hWfcjpRonyHfqsSZg==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age14zkdx3rku2yp9zv8ejrlv0yd53yx7rmmtfzxmxhawvc5hp2gxf7sxnv4sv
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdUo1VlE1MWdhQVhlRW5F
-            YW05NTVETkFQRWpoYmR6K08zaXVzaE5YZURZCjM2eFFzNi9iTFkxTy9lcGdhemhn
-            MVBWRDE3bWFGaDIrc2cxR0wwVmZIMjQKLS0tIDdmUXpwSWNVUW05RlpEd01odlhp
-            bEtpN21CSUliYnlMc0g5S0NaTDF6SmMKcgjsWUTbjGhfGAva0bd/Uc+ZZC8jqNWP
-            ayrBMUtYvi9boPR4lbvVi/EJ3Dir2LQH/ikFo3hiblaqfj0+tFnJuw==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtTkVwSVN1QzBCcE9iL0lV
-            Q2VTbTljMnh3QTRBeWlrVk0xSmN6UmxjQ3g0Ci9xU3pBTmRZNW16Q0xYQUVKU0t5
-            VDFJOEh1SU1aY2trVFFJblJFSkdyM28KLS0tIFJkRzlpbUF2eVVNNndJU200Vlc0
-            ajVoKzRWR0trUHRoUEczL1laSEtwL00K+fuYLhmeIkC3iAAFkLGZXDbaFm4o2B89
-            qHtnY7zAQSNaTyULyTlOyOKy0De+DQ38FQatRgAxoHzRDPJ68Q1ybg==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDaGlwdHlYZXBCN3ZyQktQ
-            dll6bEN1VWk4Q21zYVBsQU5iL2thMmltZVRZCk4zNklGeVpwblN3S1lsVjNadytU
-            dVBrQ09Hbnp5V2hOZkxjOENhckF3ekUKLS0tIGhFdGdRczVicmlvSTRTNmViOUVG
-            VnJKRXdqTUdVQTM0WEdNVmtmZ3NkTlUKvyUP63vcDLzurU2gXlNd9ag8o2QExpl0
-            UZjICliIZfLQdjLqkjfE9npfnqbIWMptiG/4NWxOnckTqUjKCyC4Sw==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkMTg3Q2p6SmVzM2NjQk1K
-            Q3dTdGozTldsSG10TUYvNkRwRmpmcHp0RTB3CktRZ0cxZVVCWWp0TkpXK2J2SGov
-            Sk82eXBETXdlMk92MTJvelp3L3F3M2sKLS0tIFV1dkRQOGIraFJrTUNlZ214VDFn
-            VUJiQjBocCt4WWY0YlVtQTVJRy9yTFUKg7Picr7NAtotOrHf9TmKfG38tpLjg2ks
-            XS8E2GJXg4YXmXurJvhv0Py+WqyyfH8sUIjw5lVyczq7GjGxeX2S0w==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrUFNVTmJ5YjI3bWFXa3Rt
-            QjZ4TWN6M0djc2xTNEo2WkFscWxibXU5NlZRCnJPaUhVQlNlMS83MmxEMjg2Ym1l
-            NlA5bEVkSW4xV01oVk1EOVJBcGhxZjQKLS0tIGJhV0VXTXAwODBjVEpvRnAvaExG
-            c1FPQTByU0RCY0tWcXlIYjJyL0lGdUUK/S4EaqkfHmxZgeibl2qCKvgehmPSUjlE
-            6LqPMzmlQ4HFj1nVUXzb77VOkvuqjRS/uyIoDmDKun/elo2HI7Hy/w==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-05T01:35:21Z"
-    mac: ENC[AES256_GCM,data:VaO9sBOJqRN94OwTUOE4UIO30gHkctR8pzt3NOUDdJmpTjAPgw3Fp72I53dK24UekM3gJGbiFQ8ErrLzq7+CVZN1TXubPBPNUmoWK4f1nQIbQkIPxefxtWzUJv9FPGe5SisU9Ia8aGEIMaOKvHaFPLc4un29rFLFdEyvq3mm7f8=,iv:ZHI6KxUCgcb9iZxUineOqp0BZfMlD6X6b+uo1OpKdjc=,tag:0kPfhFr7BWxWTcRU+2n3CA==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2K0FOSjF5MnhaZzk3WERI
+        SVlhNmErakwzb3NCcG04aDVzSmN3MU0yNkZNCkt3OHZSclpmSmtuRDl3bjIyNnpl
+        RHhnRTBhN0RaMFZucG9xNjNtRGxOQ0UKLS0tIFQxODZ0eHZWMjRMR3dtdG5hQzUv
+        Z3dldGVCa095RzBtMjhYSnQ0Y1NWVncKxQQqPkkqwguzJe5HmvxGZmnUMUg4BBr5
+        RPGoYaj+F47xT8xssEIqTNKCU+B/jqCP6RQ16hWfcjpRonyHfqsSZg==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age14zkdx3rku2yp9zv8ejrlv0yd53yx7rmmtfzxmxhawvc5hp2gxf7sxnv4sv
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdUo1VlE1MWdhQVhlRW5F
+        YW05NTVETkFQRWpoYmR6K08zaXVzaE5YZURZCjM2eFFzNi9iTFkxTy9lcGdhemhn
+        MVBWRDE3bWFGaDIrc2cxR0wwVmZIMjQKLS0tIDdmUXpwSWNVUW05RlpEd01odlhp
+        bEtpN21CSUliYnlMc0g5S0NaTDF6SmMKcgjsWUTbjGhfGAva0bd/Uc+ZZC8jqNWP
+        ayrBMUtYvi9boPR4lbvVi/EJ3Dir2LQH/ikFo3hiblaqfj0+tFnJuw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtTkVwSVN1QzBCcE9iL0lV
+        Q2VTbTljMnh3QTRBeWlrVk0xSmN6UmxjQ3g0Ci9xU3pBTmRZNW16Q0xYQUVKU0t5
+        VDFJOEh1SU1aY2trVFFJblJFSkdyM28KLS0tIFJkRzlpbUF2eVVNNndJU200Vlc0
+        ajVoKzRWR0trUHRoUEczL1laSEtwL00K+fuYLhmeIkC3iAAFkLGZXDbaFm4o2B89
+        qHtnY7zAQSNaTyULyTlOyOKy0De+DQ38FQatRgAxoHzRDPJ68Q1ybg==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDaGlwdHlYZXBCN3ZyQktQ
+        dll6bEN1VWk4Q21zYVBsQU5iL2thMmltZVRZCk4zNklGeVpwblN3S1lsVjNadytU
+        dVBrQ09Hbnp5V2hOZkxjOENhckF3ekUKLS0tIGhFdGdRczVicmlvSTRTNmViOUVG
+        VnJKRXdqTUdVQTM0WEdNVmtmZ3NkTlUKvyUP63vcDLzurU2gXlNd9ag8o2QExpl0
+        UZjICliIZfLQdjLqkjfE9npfnqbIWMptiG/4NWxOnckTqUjKCyC4Sw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkMTg3Q2p6SmVzM2NjQk1K
+        Q3dTdGozTldsSG10TUYvNkRwRmpmcHp0RTB3CktRZ0cxZVVCWWp0TkpXK2J2SGov
+        Sk82eXBETXdlMk92MTJvelp3L3F3M2sKLS0tIFV1dkRQOGIraFJrTUNlZ214VDFn
+        VUJiQjBocCt4WWY0YlVtQTVJRy9yTFUKg7Picr7NAtotOrHf9TmKfG38tpLjg2ks
+        XS8E2GJXg4YXmXurJvhv0Py+WqyyfH8sUIjw5lVyczq7GjGxeX2S0w==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrUFNVTmJ5YjI3bWFXa3Rt
+        QjZ4TWN6M0djc2xTNEo2WkFscWxibXU5NlZRCnJPaUhVQlNlMS83MmxEMjg2Ym1l
+        NlA5bEVkSW4xV01oVk1EOVJBcGhxZjQKLS0tIGJhV0VXTXAwODBjVEpvRnAvaExG
+        c1FPQTByU0RCY0tWcXlIYjJyL0lGdUUK/S4EaqkfHmxZgeibl2qCKvgehmPSUjlE
+        6LqPMzmlQ4HFj1nVUXzb77VOkvuqjRS/uyIoDmDKun/elo2HI7Hy/w==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-05T01:35:21Z"
+  mac: ENC[AES256_GCM,data:VaO9sBOJqRN94OwTUOE4UIO30gHkctR8pzt3NOUDdJmpTjAPgw3Fp72I53dK24UekM3gJGbiFQ8ErrLzq7+CVZN1TXubPBPNUmoWK4f1nQIbQkIPxefxtWzUJv9FPGe5SisU9Ia8aGEIMaOKvHaFPLc4un29rFLFdEyvq3mm7f8=,iv:ZHI6KxUCgcb9iZxUineOqp0BZfMlD6X6b+uo1OpKdjc=,tag:0kPfhFr7BWxWTcRU+2n3CA==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4

--- a/secrets/claude-forgejo-tea-token.yaml
+++ b/secrets/claude-forgejo-tea-token.yaml
@@ -2,14 +2,14 @@ rotated_at_unencrypted: "2026-07-05T01:35:19Z"
 rotate_after_days_unencrypted: 30
 repository_access_unencrypted: all
 scopes_unencrypted:
-    - write:activitypub
-    - write:issue
-    - write:misc
-    - write:notification
-    - write:organization
-    - write:package
-    - write:repository
-    - write:user
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
 token_id_unencrypted: 2
 token_name_unencrypted: forgejo-tea-claude-20260705013519486449
 token_last_eight_unencrypted: 6952b6dc
@@ -17,67 +17,67 @@ username: ENC[AES256_GCM,data:cqBIS3yt,iv:QyuBtMFdqZYUI3SjBHPIkttaGzjfc078c7i4TB
 url: ENC[AES256_GCM,data:iT1bdFCWbjO4CyhfeDTZhFNGKnWhfP1vIJ+Y,iv:Y/AfK6pZjjA8lvPA56eMDUc5L+uLr7ZCDPaL5Bpj7KM=,tag:5BAKwYGSup8OA9nRGB4iNA==,type:str]
 token: ENC[AES256_GCM,data:dn/1eGfPHSs5oMte0dV62xMWb+z9kT/3HLPT03xCZeAqd7LimSjc1g==,iv:rFaQhA1KQKj3R2E6NE3U3zqeJyx4oAAUzBBk4byH6kU=,tag:Ahb+Au3geYXOuoIn0RRAPQ==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKMWVIU2E1SjVYVWpNVzBx
-            Q1RsQ1hCYWdSMWM3aVI2MkM3T2xSWlFWcHlBCmc4UUJxdTJ4TXdYVk1iMkh2S3Rp
-            c0U1c0toVGVaeXRhRm92ejQwK0ZJSFkKLS0tIHFiTU9aQWVLR0xJdWFLWnF1ZXBh
-            MEVkemlXMjZkY25wZms4Q2w0Tlp0VmcKupLN2E9DGwiemf0r2tIUB7QbY9Cs+xxB
-            z70hjGRlziq8paHocIh5aMyaWe+NWyCeC0GVHZO/J8DpMCXH8IGAjA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5UDRodGYxa3dMK0txRXZH
-            UThoSGpnZnpxOUlXTmlVbHdYWkpMQkxPY2hzCnVNT3FPY21zakIxbjdycVMyR0Zi
-            NkFhT2FzZkZ1d2podFF2NGFOcURZTVEKLS0tIDBJTlBlZWV3NDVFcGxyanNEZXZI
-            Y1NHalVtS3FNeUNGQzVPeGRYcFFINGMKGQamWcgkUxWItcvwniYP+iyw9MJNkakE
-            5Is+EwrzfOI2zyW1jfrt/t5WxEHlgQ62xZot91kfrnnxjoE+WuehnQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIY1FPSE0rZ0lzeS9Wd3Jk
-            TkV4NjBUMGtibjVMdUxvNHZaVDJQZzVMWWdNCmM1U3Z1UGFmMUQ2M0F4Qm5KU3JC
-            RG45MGxsNUx3cTI5bFVuMXVMeU4yN3cKLS0tIGgvTnRTakhScEhNMllUNTRrVjlG
-            MW5FSE5TYzdadDN5eGRhVWtJc1cxK3cK0WW4Tztw+1FCL0NzwHvT4OJa0fiVJnbB
-            MSPqFimn9rWXVreI9uydBiOH4j2W69FIpaxiYT6TLp24p06KOCa/+g==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4RDNIc01kTVZMWDlnbEQ1
-            TDNwTDZEaGd0U3cwN1RUNTBJVGxpbk9vdml3CjY5VHAycHl0MTM4UXFYeDhUV3Rt
-            WnpzWjYxT3Y4K3NpV0MwdlBFTTRoOHcKLS0tIDFDY0xZOFcybGNLRnFKNkpJT2lm
-            ZlQ4UXdpcHRlUlZCQVJJL3hrMGRsME0KduZOOWhZRHlPoMoz6L+BmgoE0k/aCo14
-            1tKCEkg0v18KpccioEMoRzB69CGwgKvlUTpmFeJQMkibPwSZ3GXYTw==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyNmttcU9xNHEzWVBKV1Vz
-            djUxWERQa3NobS93TlV2RGNRaEpiSFBLYUcwClV3WEJUQnNFd2FONUFKeTNxQzJo
-            elM5TXJodDBwYmFhYlZ3NEJzUnNvQ3cKLS0tIFVOc25SckY2NGNQYUZiaDZPVjRW
-            US9IdTVrNGNQOWxWTTRLOE00bkpPWk0Kxd69kvWuSCxIdbDvYaq1Sea3fbq99mYE
-            kEe0UdntDuP+G8rdoGBDh9uXXpHeeWYYWMM1oAcvfrV8bvO1NKzP9w==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3bzdVaDVnYWlQY1diOEVU
-            MlhwWFFSa3VnNzA3MUYwMkVZYlNDa3MvVUcwCnZSdVNwMW1aZXFUVEZWUmJCQVZj
-            dUVTWHpJUG1wVVJ1aUZLQTRhOXBPY0kKLS0tIGVxTnBlYy9hck9sQlVuUVFLQ0x3
-            WXN1K3AyWnE3SHJGblhOclQ1eXhxSUEK6fuPGBpN2JJM9oQMdyRO8nRa5CzbrhfP
-            TueUN4qGyDIM7tsnynhZKtesv54hnp45Lb1vDUlbzlth2gBGFsXFAg==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-05T01:35:19Z"
-    mac: ENC[AES256_GCM,data:y93VCSc+W4KTxZcsg1zfWsqsuMQq8ElRmxMwG0l+/skjRCjnL1DkDnMg50Hplloe6uV9MBi6+qrjqRaG8iR+giKoqomVLRk7oYCjgEWHzVvcznLdY1TsDiunBXwVavFIFDxb7tOdHQGMMnUesc2idRF7j1YJ/PKEC97Rh/dZOqg=,iv:RLzCWbkdwoVBnF5ZxqLdVMptGVQGGESrv4bKqcGBUZE=,tag:k3A5FvW3zETOZH1+HhFfew==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKMWVIU2E1SjVYVWpNVzBx
+        Q1RsQ1hCYWdSMWM3aVI2MkM3T2xSWlFWcHlBCmc4UUJxdTJ4TXdYVk1iMkh2S3Rp
+        c0U1c0toVGVaeXRhRm92ejQwK0ZJSFkKLS0tIHFiTU9aQWVLR0xJdWFLWnF1ZXBh
+        MEVkemlXMjZkY25wZms4Q2w0Tlp0VmcKupLN2E9DGwiemf0r2tIUB7QbY9Cs+xxB
+        z70hjGRlziq8paHocIh5aMyaWe+NWyCeC0GVHZO/J8DpMCXH8IGAjA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5UDRodGYxa3dMK0txRXZH
+        UThoSGpnZnpxOUlXTmlVbHdYWkpMQkxPY2hzCnVNT3FPY21zakIxbjdycVMyR0Zi
+        NkFhT2FzZkZ1d2podFF2NGFOcURZTVEKLS0tIDBJTlBlZWV3NDVFcGxyanNEZXZI
+        Y1NHalVtS3FNeUNGQzVPeGRYcFFINGMKGQamWcgkUxWItcvwniYP+iyw9MJNkakE
+        5Is+EwrzfOI2zyW1jfrt/t5WxEHlgQ62xZot91kfrnnxjoE+WuehnQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIY1FPSE0rZ0lzeS9Wd3Jk
+        TkV4NjBUMGtibjVMdUxvNHZaVDJQZzVMWWdNCmM1U3Z1UGFmMUQ2M0F4Qm5KU3JC
+        RG45MGxsNUx3cTI5bFVuMXVMeU4yN3cKLS0tIGgvTnRTakhScEhNMllUNTRrVjlG
+        MW5FSE5TYzdadDN5eGRhVWtJc1cxK3cK0WW4Tztw+1FCL0NzwHvT4OJa0fiVJnbB
+        MSPqFimn9rWXVreI9uydBiOH4j2W69FIpaxiYT6TLp24p06KOCa/+g==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4RDNIc01kTVZMWDlnbEQ1
+        TDNwTDZEaGd0U3cwN1RUNTBJVGxpbk9vdml3CjY5VHAycHl0MTM4UXFYeDhUV3Rt
+        WnpzWjYxT3Y4K3NpV0MwdlBFTTRoOHcKLS0tIDFDY0xZOFcybGNLRnFKNkpJT2lm
+        ZlQ4UXdpcHRlUlZCQVJJL3hrMGRsME0KduZOOWhZRHlPoMoz6L+BmgoE0k/aCo14
+        1tKCEkg0v18KpccioEMoRzB69CGwgKvlUTpmFeJQMkibPwSZ3GXYTw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyNmttcU9xNHEzWVBKV1Vz
+        djUxWERQa3NobS93TlV2RGNRaEpiSFBLYUcwClV3WEJUQnNFd2FONUFKeTNxQzJo
+        elM5TXJodDBwYmFhYlZ3NEJzUnNvQ3cKLS0tIFVOc25SckY2NGNQYUZiaDZPVjRW
+        US9IdTVrNGNQOWxWTTRLOE00bkpPWk0Kxd69kvWuSCxIdbDvYaq1Sea3fbq99mYE
+        kEe0UdntDuP+G8rdoGBDh9uXXpHeeWYYWMM1oAcvfrV8bvO1NKzP9w==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3bzdVaDVnYWlQY1diOEVU
+        MlhwWFFSa3VnNzA3MUYwMkVZYlNDa3MvVUcwCnZSdVNwMW1aZXFUVEZWUmJCQVZj
+        dUVTWHpJUG1wVVJ1aUZLQTRhOXBPY0kKLS0tIGVxTnBlYy9hck9sQlVuUVFLQ0x3
+        WXN1K3AyWnE3SHJGblhOclQ1eXhxSUEK6fuPGBpN2JJM9oQMdyRO8nRa5CzbrhfP
+        TueUN4qGyDIM7tsnynhZKtesv54hnp45Lb1vDUlbzlth2gBGFsXFAg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-05T01:35:19Z"
+  mac: ENC[AES256_GCM,data:y93VCSc+W4KTxZcsg1zfWsqsuMQq8ElRmxMwG0l+/skjRCjnL1DkDnMg50Hplloe6uV9MBi6+qrjqRaG8iR+giKoqomVLRk7oYCjgEWHzVvcznLdY1TsDiunBXwVavFIFDxb7tOdHQGMMnUesc2idRF7j1YJ/PKEC97Rh/dZOqg=,iv:RLzCWbkdwoVBnF5ZxqLdVMptGVQGGESrv4bKqcGBUZE=,tag:k3A5FvW3zETOZH1+HhFfew==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4

--- a/secrets/codex-pod-forgejo-tea-token.yaml
+++ b/secrets/codex-pod-forgejo-tea-token.yaml
@@ -2,14 +2,14 @@ rotated_at_unencrypted: "2026-07-05T01:35:22Z"
 rotate_after_days_unencrypted: 30
 repository_access_unencrypted: all
 scopes_unencrypted:
-    - write:activitypub
-    - write:issue
-    - write:misc
-    - write:notification
-    - write:organization
-    - write:package
-    - write:repository
-    - write:user
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
 token_id_unencrypted: 5
 token_name_unencrypted: forgejo-tea-codex-pod-20260705013522050497
 token_last_eight_unencrypted: 5.02324e+11
@@ -17,58 +17,58 @@ username: ENC[AES256_GCM,data:kkz7GQqVNKZp,iv:8+idDIpRTRXOOU6LCYAsFY+7LQjpzF5WaR
 url: ENC[AES256_GCM,data:FEmEk+9n49TFTP2Ix0ml80G9eIggi0VopXfP,iv:3n7HyvLZ1OBgwxSND+k9prKKPcrh3rCJHvAsWiXQsns=,tag:vJNCaE2KLJ1UrAcVse8dxw==,type:str]
 token: ENC[AES256_GCM,data:sySDgWr6SPd2/23XCo3gyEvRVqFe/kTqVXS15Rc6eQWSum7u5QuM7A==,iv:l/t96cqnYq+x6MZS+VQg0ZOmVx0xscjyxyEhJZoQbBM=,tag:cks4VfxMh4bQd7FxlhW8ZA==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzVklOUzdBNHRUUnAyc0g3
-            QWZnNmhuclV4S3RQMGNPeFN3SHdmTURla2h3Ckw3aHpwYmJGZ0djQ3oyeGVNS1lz
-            ekc5UmYxZWgyRXRGUTYyeHd2MVIyRXMKLS0tIEhiQXdGeVNYdkhsRlgwVE5oZTZp
-            V1l0ejE5VFp2cFBOVUdKK3I2QzFLNWMKdw/iZEM95v9IA6KM0ti/VFK6cXvISpDk
-            MktCPwL1JpHTwRdF/ncafZG5WJKn5ETHGDedp74lPmlshSBCd/gBcw==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPZDBVWGZqQUdta2owcmJD
-            YnhDaGpyWk42VVVqbnRXeTkzRE5MV0d4REdFCjV1cmpURGZmc2xjbjB5Y09Uc3d5
-            SnI1OG9qaGZFK3VLNDdpTGZTQ3BpajgKLS0tIEFTb3daVTJaNW1QZ0lOMnZ2aENn
-            bnl3ZkhLTkJmZkU4bk5HZHc4Q09YSW8KdDKKhuZdEMqXjAtoamysHZiDBJxbUR9t
-            Eeiw0CbclCx2bl0kXX3rqwYULTRSRKw/T75hTvdCwHwP6UEa5HGxUQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFQTlPaGdqaXV6c2o0WFZo
-            OFlPVWlwZXNQcUo1NUxHNHJuczdnZXJsbHhFCnZsWWNpMSttT2ZONEN4Z1hqV0xk
-            UWtGZHFIcmpIOVNUdUE3NDFyRWpWc28KLS0tIGRpVGNWQlJ4SVg4clB3bWtvd2Fx
-            RnlPd3AyY1hXUzV6cnJzTndGL1d2NmMKdRHfNL0AGpOluAOke3jlMOxB6yWYSdfv
-            wzGZZJsI4K16qGV9fFpbrwvBziQLWUCql36XPsten70VAEuprXSLuw==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXTGQ1TTZmeFlRaXhnaFIx
-            c1VudHl4Rkl1R2lTSlJQcXpCbTVEQ3VrQ0VJCnpQa3hJUTBxTXA5SXBmNlgvMnRs
-            MG5WVFFjSXppMmxFeUZxTnFQdHhaa0UKLS0tIHFXejN0YjZqdmZYMG4yS0tOL2JU
-            VVVNNlp0SVNheCtmSUI2eGFndVBRMzgKNEaQnONgmtSaPA/jEfu62gM1cnXFj3Vj
-            2YjIWKCkbcMrNQlIbai/y8NwzWKOUuPg0dR7LwklLtH9sbfRuA3+nQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMb3FmSFZrYktmOTRsUmVK
-            K1huSHd5RHZscVNHYVllUWJlUWZBcSttUG04ClVZWDdwTFFmbHNFU3YzL01HeHQ0
-            Ri8rVjc4aGZvaHVZKzZBQU0vcEVhVU0KLS0tIDc5RHg3Y05lZy9NNVdTNjRqM0cw
-            Vm40MXlxaTlCQy9BcEpud0xWN0FsZkUKDMFuJOEduIawpW/SuBtZUEzU38t1X4qf
-            ucnPK3ENA9IfkmN3IC7SXB1YP5JUqPNJORN5qr+SuUPNHd1DVuSKZg==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-05T01:35:22Z"
-    mac: ENC[AES256_GCM,data:jdG+OtSG8H0oRs/jzZ3/NMwBqg1WMIhlxvPvvUD1KfDjFBPInlBgJAHtdCyoPqjyufyNWYB1DU98jG+ZKvP3728lvFDFde8WG6zb3UVCD+vRR/REMZCalPc0xSuXYlRM4EQIot4UcKAfp1b64dYQAUu9HDXwxW6H7Nm6YXF6Vqc=,iv:T42kIn/zecH1Fxljg3LXyqVFoXZ4bH9AuyCqBZ5s0ns=,tag:r68j1cm9VzpJqLCfJdDlrQ==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzVklOUzdBNHRUUnAyc0g3
+        QWZnNmhuclV4S3RQMGNPeFN3SHdmTURla2h3Ckw3aHpwYmJGZ0djQ3oyeGVNS1lz
+        ekc5UmYxZWgyRXRGUTYyeHd2MVIyRXMKLS0tIEhiQXdGeVNYdkhsRlgwVE5oZTZp
+        V1l0ejE5VFp2cFBOVUdKK3I2QzFLNWMKdw/iZEM95v9IA6KM0ti/VFK6cXvISpDk
+        MktCPwL1JpHTwRdF/ncafZG5WJKn5ETHGDedp74lPmlshSBCd/gBcw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPZDBVWGZqQUdta2owcmJD
+        YnhDaGpyWk42VVVqbnRXeTkzRE5MV0d4REdFCjV1cmpURGZmc2xjbjB5Y09Uc3d5
+        SnI1OG9qaGZFK3VLNDdpTGZTQ3BpajgKLS0tIEFTb3daVTJaNW1QZ0lOMnZ2aENn
+        bnl3ZkhLTkJmZkU4bk5HZHc4Q09YSW8KdDKKhuZdEMqXjAtoamysHZiDBJxbUR9t
+        Eeiw0CbclCx2bl0kXX3rqwYULTRSRKw/T75hTvdCwHwP6UEa5HGxUQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFQTlPaGdqaXV6c2o0WFZo
+        OFlPVWlwZXNQcUo1NUxHNHJuczdnZXJsbHhFCnZsWWNpMSttT2ZONEN4Z1hqV0xk
+        UWtGZHFIcmpIOVNUdUE3NDFyRWpWc28KLS0tIGRpVGNWQlJ4SVg4clB3bWtvd2Fx
+        RnlPd3AyY1hXUzV6cnJzTndGL1d2NmMKdRHfNL0AGpOluAOke3jlMOxB6yWYSdfv
+        wzGZZJsI4K16qGV9fFpbrwvBziQLWUCql36XPsten70VAEuprXSLuw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXTGQ1TTZmeFlRaXhnaFIx
+        c1VudHl4Rkl1R2lTSlJQcXpCbTVEQ3VrQ0VJCnpQa3hJUTBxTXA5SXBmNlgvMnRs
+        MG5WVFFjSXppMmxFeUZxTnFQdHhaa0UKLS0tIHFXejN0YjZqdmZYMG4yS0tOL2JU
+        VVVNNlp0SVNheCtmSUI2eGFndVBRMzgKNEaQnONgmtSaPA/jEfu62gM1cnXFj3Vj
+        2YjIWKCkbcMrNQlIbai/y8NwzWKOUuPg0dR7LwklLtH9sbfRuA3+nQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMb3FmSFZrYktmOTRsUmVK
+        K1huSHd5RHZscVNHYVllUWJlUWZBcSttUG04ClVZWDdwTFFmbHNFU3YzL01HeHQ0
+        Ri8rVjc4aGZvaHVZKzZBQU0vcEVhVU0KLS0tIDc5RHg3Y05lZy9NNVdTNjRqM0cw
+        Vm40MXlxaTlCQy9BcEpud0xWN0FsZkUKDMFuJOEduIawpW/SuBtZUEzU38t1X4qf
+        ucnPK3ENA9IfkmN3IC7SXB1YP5JUqPNJORN5qr+SuUPNHd1DVuSKZg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-05T01:35:22Z"
+  mac: ENC[AES256_GCM,data:jdG+OtSG8H0oRs/jzZ3/NMwBqg1WMIhlxvPvvUD1KfDjFBPInlBgJAHtdCyoPqjyufyNWYB1DU98jG+ZKvP3728lvFDFde8WG6zb3UVCD+vRR/REMZCalPc0xSuXYlRM4EQIot4UcKAfp1b64dYQAUu9HDXwxW6H7Nm6YXF6Vqc=,iv:T42kIn/zecH1Fxljg3LXyqVFoXZ4bH9AuyCqBZ5s0ns=,tag:r68j1cm9VzpJqLCfJdDlrQ==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4

--- a/secrets/haku-attic.yaml
+++ b/secrets/haku-attic.yaml
@@ -1,67 +1,67 @@
 expires_unencrypted: "2027-07-05T08:20:42Z"
 attic_token: ENC[AES256_GCM,data:r8IxLt6zLVlfYKD7MYVB1DcccOpY5WMU+g9paK5HKKDMIfMhZ/gSZICH0BbnwEDKNRveEIrsBQTsppEK3ACmDux8vqweeGHOasjgYxnIQaa0ItQaKHRB1F3BgCRXtrc8dQdQMjjg1TM8QTMeHl9Ye+CUsCsRG94NEKN9NqMpjArgVlZ22WDvNCKcMMKcfEc9wuGR1Z+56hkP5z051nIIwnsNF0k91DOWYKXj6n1IrYVCKIv6VpjT4YQsKww9/qlXb/FxXvYrRUe/nPBbUir44mHtha4ELSjXindJDhn6IfE97Epc06Ux1Y4n0SA8AJdT,iv:TNqrbFd8ELV4lFeH4FGtTJayNzz0ZJRg19zKUtHiwpE=,tag:ENRAK72auxI+vYhouDBD6g==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOM3FCVFdqT2R4cmdYVFY3
-            dy9qSm1rVVRMUjNheXN4T2NURmI2ajlkZXlZCjlZUnJjTkZpd3pnNlVLVjM4cFJk
-            ZXNiVURpSnd1VE11Q2Z3RnhUVS94MjAKLS0tIDNMRTZVbVZZdnhXdXpDUi9aTGdL
-            bDBqN3VrS0lpMXg5bms3SkNJLzhtbWcKDtDdVUZhD47YjST+4LZYhSRWVJqCoY49
-            A2x/pDXgDN0COF+r9Uwdn4bivex6yi/v5mWE8kKwp1VhQftNHChdng==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1756xpy6yg7r8vdducm5cdn4cqt3m5qkcncxumsh8htlfdzpae4cq0c6gqf
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2bGZVRUYzOGN3c25VN1lk
-            Q3MwRDIxQUtFdGRrS2NMSDJaZERaV1lYYVU4CkNGNzZoVVZpSS9zZ2dMTUI5T0pn
-            UUMyaXhtdTBBeDlBYXJVUzVsdWhTdEkKLS0tIENwSjJXUGFOQnYzUmxRVkNsc2xr
-            VGJNT3FXZzBuOUpIdzBRWHBtejVFcG8KA6joGUCP0ClbXvHpezzs412cG3gm6PMr
-            WbNFoLvcJttoUL6Z6AV9cD6E6c4xLFkrVF7VNdX3cCiiIubvA8fgSg==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDMmRZczVDWGlIbzhyT1p2
-            S3B3WUJzVzVXa3pCeEZRcDNIMzU2TCtZZUF3CnVaMmhWQ1RXUE9tc1ZxSnhoMGJZ
-            VVpNMStTYk9oTmE1RzhkM1dCa2dleEkKLS0tIE1NQzkrMUJvTENmdWV1V3VNeklG
-            Vk1DWEdpRVJkR0l6ckR0c1dJT2ZwQ2MK6SNqfNj439hZApWOIiwvOUA9PrNItzx+
-            vDLiXVaG+VjXT7Stxqe5W4SnVt0pL8yK/90CSuGKIth96RbSLWte/g==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzb3dZQXdaRlp4bFFRaHZR
-            VHVyWG1rM2FSREpIQTN1dkxGR254Wi91Z1EwCkpCL2c3bU5NbmNwNElsd3VLUkVB
-            ald5Zm5TTXdud2w1VDBEZERFR2VLWmsKLS0tIERxOEJyQk1kNDRrVENCV1E2NnRI
-            SVU3aUlVbCtYL1dNQmUrM0djWTBROVEKkJTf0VgOWw7aylFlk64o/JrtugLrWM7r
-            KSmKpxYtjFgV7q1u3p4LFAS4OfC03MD5Wul6arNYK0kcVPmoSy8kCQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOTU9EOVVwS1ZONmhsOEJ6
-            VGxoTTNRdVJjOXhOdlAxVU5LZXNVS1ZUNlhRCllDU2NocExaVXZaT1B4WXZ1ZlFJ
-            SG5CS05OdVJORXlYa0U3a2l4SExFdk0KLS0tIHNBR2J2UmN0VEtkMWZZZVY2R3Zp
-            bStPRXdUZHViWGRVVDBwZVBNblBwZ0kKSgwXJ3q+pzCNOtTxwPzkSXkvxpcdCNxi
-            Jev/zzUMs+ClUE0EfsbhGhKyB5klMEDJ4VSpcuunGxjQONmiCt+jlQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2MTJ1RTAyNkp2MkVtSDh1
-            aGpFc2s1elBHamRjNCtPUFJmd1BHcm4xRlJ3CnJzZGQ1QUJSQ2lDSjNFZmcyTi9K
-            SW5XNFZtTWpuaitkVnVpL0lZTERGNVkKLS0tIHBPcnBvNTYzU1g1eW5xZFYzUk85
-            QTBGNjcrTmVYd0IyaDVubGEvRGlESlUK25z2Dxd0fCSlOfsfKiDJOg4wt0rNxK3H
-            zn9TAaK0cYE6+OMdLyi1HIM7HbACRo+oWbeO3QkhzSaAX2O2yRKzsg==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-05T02:20:42Z"
-    mac: ENC[AES256_GCM,data:FtArdUpVx3g+07dhMXd4GBL6mzlcCLkbDFJmJngl3ItzbUktg8r9LPRgnWLYRppo1qL4mjIv1KNZwCw2Jmq4PkVqrE2DVVUgTt9bgk4fwtOSscTu2w7vAdDz/dLoGwouZopta1Qdw0uC8awog1Hhv8B3JOQ2XhArKaF/3WAiUGo=,iv:ILvtnxJ6gb/len791IixUG7TvMF0nhEfFv8mWZiJ0wk=,tag:HUsT8wuffTNxUKWzSMMVBQ==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOM3FCVFdqT2R4cmdYVFY3
+        dy9qSm1rVVRMUjNheXN4T2NURmI2ajlkZXlZCjlZUnJjTkZpd3pnNlVLVjM4cFJk
+        ZXNiVURpSnd1VE11Q2Z3RnhUVS94MjAKLS0tIDNMRTZVbVZZdnhXdXpDUi9aTGdL
+        bDBqN3VrS0lpMXg5bms3SkNJLzhtbWcKDtDdVUZhD47YjST+4LZYhSRWVJqCoY49
+        A2x/pDXgDN0COF+r9Uwdn4bivex6yi/v5mWE8kKwp1VhQftNHChdng==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1756xpy6yg7r8vdducm5cdn4cqt3m5qkcncxumsh8htlfdzpae4cq0c6gqf
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2bGZVRUYzOGN3c25VN1lk
+        Q3MwRDIxQUtFdGRrS2NMSDJaZERaV1lYYVU4CkNGNzZoVVZpSS9zZ2dMTUI5T0pn
+        UUMyaXhtdTBBeDlBYXJVUzVsdWhTdEkKLS0tIENwSjJXUGFOQnYzUmxRVkNsc2xr
+        VGJNT3FXZzBuOUpIdzBRWHBtejVFcG8KA6joGUCP0ClbXvHpezzs412cG3gm6PMr
+        WbNFoLvcJttoUL6Z6AV9cD6E6c4xLFkrVF7VNdX3cCiiIubvA8fgSg==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDMmRZczVDWGlIbzhyT1p2
+        S3B3WUJzVzVXa3pCeEZRcDNIMzU2TCtZZUF3CnVaMmhWQ1RXUE9tc1ZxSnhoMGJZ
+        VVpNMStTYk9oTmE1RzhkM1dCa2dleEkKLS0tIE1NQzkrMUJvTENmdWV1V3VNeklG
+        Vk1DWEdpRVJkR0l6ckR0c1dJT2ZwQ2MK6SNqfNj439hZApWOIiwvOUA9PrNItzx+
+        vDLiXVaG+VjXT7Stxqe5W4SnVt0pL8yK/90CSuGKIth96RbSLWte/g==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzb3dZQXdaRlp4bFFRaHZR
+        VHVyWG1rM2FSREpIQTN1dkxGR254Wi91Z1EwCkpCL2c3bU5NbmNwNElsd3VLUkVB
+        ald5Zm5TTXdud2w1VDBEZERFR2VLWmsKLS0tIERxOEJyQk1kNDRrVENCV1E2NnRI
+        SVU3aUlVbCtYL1dNQmUrM0djWTBROVEKkJTf0VgOWw7aylFlk64o/JrtugLrWM7r
+        KSmKpxYtjFgV7q1u3p4LFAS4OfC03MD5Wul6arNYK0kcVPmoSy8kCQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOTU9EOVVwS1ZONmhsOEJ6
+        VGxoTTNRdVJjOXhOdlAxVU5LZXNVS1ZUNlhRCllDU2NocExaVXZaT1B4WXZ1ZlFJ
+        SG5CS05OdVJORXlYa0U3a2l4SExFdk0KLS0tIHNBR2J2UmN0VEtkMWZZZVY2R3Zp
+        bStPRXdUZHViWGRVVDBwZVBNblBwZ0kKSgwXJ3q+pzCNOtTxwPzkSXkvxpcdCNxi
+        Jev/zzUMs+ClUE0EfsbhGhKyB5klMEDJ4VSpcuunGxjQONmiCt+jlQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2MTJ1RTAyNkp2MkVtSDh1
+        aGpFc2s1elBHamRjNCtPUFJmd1BHcm4xRlJ3CnJzZGQ1QUJSQ2lDSjNFZmcyTi9K
+        SW5XNFZtTWpuaitkVnVpL0lZTERGNVkKLS0tIHBPcnBvNTYzU1g1eW5xZFYzUk85
+        QTBGNjcrTmVYd0IyaDVubGEvRGlESlUK25z2Dxd0fCSlOfsfKiDJOg4wt0rNxK3H
+        zn9TAaK0cYE6+OMdLyi1HIM7HbACRo+oWbeO3QkhzSaAX2O2yRKzsg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-05T02:20:42Z"
+  mac: ENC[AES256_GCM,data:FtArdUpVx3g+07dhMXd4GBL6mzlcCLkbDFJmJngl3ItzbUktg8r9LPRgnWLYRppo1qL4mjIv1KNZwCw2Jmq4PkVqrE2DVVUgTt9bgk4fwtOSscTu2w7vAdDz/dLoGwouZopta1Qdw0uC8awog1Hhv8B3JOQ2XhArKaF/3WAiUGo=,iv:ILvtnxJ6gb/len791IixUG7TvMF0nhEfFv8mWZiJ0wk=,tag:HUsT8wuffTNxUKWzSMMVBQ==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4

--- a/secrets/haku-forgejo-tea-token.yaml
+++ b/secrets/haku-forgejo-tea-token.yaml
@@ -2,14 +2,14 @@ rotated_at_unencrypted: "2026-07-05T01:35:18Z"
 rotate_after_days_unencrypted: 30
 repository_access_unencrypted: all
 scopes_unencrypted:
-    - write:activitypub
-    - write:issue
-    - write:misc
-    - write:notification
-    - write:organization
-    - write:package
-    - write:repository
-    - write:user
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
 token_id_unencrypted: 1
 token_name_unencrypted: forgejo-tea-haku-20260705013518518478
 token_last_eight_unencrypted: 57b2f82a
@@ -17,67 +17,67 @@ username: ENC[AES256_GCM,data:UxvV4A==,iv:O7YnRMkoLgbkekjPLtLAo8yT5b3ExUuafSKdZl
 url: ENC[AES256_GCM,data:QkpDNszgi2dKtmDy9q0nrQZ22iO2EEmuUz5/,iv:Wl8fEkD9+pLIcxDFoLBBPmkts/SS0BldBSrGwc1SD3s=,tag:yVTNoW5lkTYviG83zQ+1xg==,type:str]
 token: ENC[AES256_GCM,data:9IcVM0PKWdbVnffl0668BaX7W0RDU6Z1VmwvBqP0KhTj8OloN+mhSw==,iv:GL1//Au/15HOrbWYYE3/k+4thEbQPNliGoQKraywhaE=,tag:HxEMyoaZK1V+Z6ViI4FflA==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxZHNaVmZUUzBQNGgxN0Mz
-            bmdYcVR5TGlOUVhuZ3JCLzFxbDBERW1PYlgwCkNsYlJhMG9aVXM5NU8yRmpxejlX
-            azYyd3UrVmVLM3JlUHl2NkQ0VWVIeWcKLS0tIHk2OXBVb3lXWVhUWWVxQlQ2cTBI
-            ZHQyY3c0YXpwbkNueWtpT0RLZEE3blUK7I7TMDG2BQetGfPe/gefLedbjF//JWHp
-            44lrhZKaKZekv58On4WsQDnovPR06oMC1LankiQXqe9+SSIc2t+DxQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1756xpy6yg7r8vdducm5cdn4cqt3m5qkcncxumsh8htlfdzpae4cq0c6gqf
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNczlOVnBBRmF5bXdWbGRE
-            elNUa3RiUzFNZlJwNHdwYlFhL214MUhqYWpzClBlM21QOFE3T0V3WTJwdlp4MGd6
-            cHB3Y3hZY0oyZWoyVDBaUVBqSlpteUEKLS0tIEI1citnWC9qMFdqbGFJV0M1ZGtQ
-            SUE5VmY1TU5meVZXR0tUQWJjbTQvUDAKJYeY53b40a7mE43wUJ/Dd+E+bwL3Sdfa
-            iL4Fg0JcGzQ9tWeoGV0s/yf39TUmsgpTjqwh0cOaD27h7DnA4rZ1tw==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJUGxKc1MrMFZZVjFYa2hM
-            aFFEVXUwbDNubnlYejhXT0VnU3lGb0dQU1Y4Ci9mYnpmdTlxM0tlWis1cmJpOXlZ
-            b0FTVDZWZ0xqZmxiK0FyY3dySncyNEkKLS0tIG1OdFNEeitYM1dsU29sdkpTcmxN
-            cWYwdUlTQUF6VDJzNW1JcEhXUFNndUkKa+alY/nHcCGq33i7MOYHAtlT99tVnbkx
-            WF7V5Er71K5+9P0cA6tVdJf/Tz7MpG+t3UJmTk4B6c74fQUEtuN83w==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYblRNek85LytuWXFjejVw
-            VFZScUljc01TQW8zL1JwOHlGRGJ0NjZ5KzE0CjBpL1FpZnFkZ2FGbkhBNmdrbHF2
-            R2sydkRmRi94WlhWZjdMUXU1eEp2SU0KLS0tIDU5T0N1Vk93YVZhOTB5WjRuV1pH
-            MG8venpJQmhpS0FRNzlPSEJDZmx1cWsKxI6AiX17hRsZaHdZHUiuNclpkfXLiWPR
-            yMHa0kVtaGQnSkqHDy3ZlMYzFf3oU7o9fDJrumt7ODiXk1MXWO91hQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxWk0yVjdPTlVXUHJnOVBw
-            ZVVoOUhNQ1gvZXJrN0hVcUxMcmtHWFRVckg4CnR0UWFtTFFwcVpmbm1jL0p2bmQ4
-            bFRSSXUwem00KzZjcFFCSzlXcllzMG8KLS0tIFVGMUlpSXo2TllYVElqWnBEdHRY
-            djU0OS9FZUdKNEFhTzI3eUVKWWZwSnMKeZqfoxhAEbGPUKSbgamuX2yUb+r3W0UD
-            VzMhnLlj2Bol/sItqaaheiezi0MzEfASfubcUISVl2pePqy2ndFHMQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZZEdVeEdFelViKzdoMEM2
-            YklrNFh1dldsalRDazFpTlNMSElqeHpybmtJCmxKOHMyT09OMWMxK0t4M1VVYWUy
-            aFpLMjJiTkZ2eDRDWTFRc1M4M2kxMUEKLS0tIEpVUzB2SVBnUTdqQXBqOVQzMG9V
-            ejN4NmZmbDlLM3lmb1Q1NGdUQmpsQk0KaZhX5kgo792cJrjlQAwZktqUbioC9/9M
-            2+ygK+7rajObxe84AqT0wlYfRqGIBJcwEVLst9/BJLyW+22ZxYR2QQ==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-05T01:35:19Z"
-    mac: ENC[AES256_GCM,data:mJWYdId8klw6+pSZswYhkGwHKXAKJO2W7tLwcfYB2OXr/lhmv6K5EDP+gzlilm6MqXRa72eYmdhaywdJQxCs02RmHOPUzlp4R6ifD5D9O15+10VAPq/P+IKhAtJ813HHTlreaQ0d473eXQjmj+x57GxssC9hq/M4XyR+uy4y+8Y=,iv:Q+t7ffaGsDoW8h5jqd3EbFVrZZMJmSZdGXY5gexEF3k=,tag:yAXpMi6jV8tmTrCwlrQFUA==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxZHNaVmZUUzBQNGgxN0Mz
+        bmdYcVR5TGlOUVhuZ3JCLzFxbDBERW1PYlgwCkNsYlJhMG9aVXM5NU8yRmpxejlX
+        azYyd3UrVmVLM3JlUHl2NkQ0VWVIeWcKLS0tIHk2OXBVb3lXWVhUWWVxQlQ2cTBI
+        ZHQyY3c0YXpwbkNueWtpT0RLZEE3blUK7I7TMDG2BQetGfPe/gefLedbjF//JWHp
+        44lrhZKaKZekv58On4WsQDnovPR06oMC1LankiQXqe9+SSIc2t+DxQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1756xpy6yg7r8vdducm5cdn4cqt3m5qkcncxumsh8htlfdzpae4cq0c6gqf
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNczlOVnBBRmF5bXdWbGRE
+        elNUa3RiUzFNZlJwNHdwYlFhL214MUhqYWpzClBlM21QOFE3T0V3WTJwdlp4MGd6
+        cHB3Y3hZY0oyZWoyVDBaUVBqSlpteUEKLS0tIEI1citnWC9qMFdqbGFJV0M1ZGtQ
+        SUE5VmY1TU5meVZXR0tUQWJjbTQvUDAKJYeY53b40a7mE43wUJ/Dd+E+bwL3Sdfa
+        iL4Fg0JcGzQ9tWeoGV0s/yf39TUmsgpTjqwh0cOaD27h7DnA4rZ1tw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJUGxKc1MrMFZZVjFYa2hM
+        aFFEVXUwbDNubnlYejhXT0VnU3lGb0dQU1Y4Ci9mYnpmdTlxM0tlWis1cmJpOXlZ
+        b0FTVDZWZ0xqZmxiK0FyY3dySncyNEkKLS0tIG1OdFNEeitYM1dsU29sdkpTcmxN
+        cWYwdUlTQUF6VDJzNW1JcEhXUFNndUkKa+alY/nHcCGq33i7MOYHAtlT99tVnbkx
+        WF7V5Er71K5+9P0cA6tVdJf/Tz7MpG+t3UJmTk4B6c74fQUEtuN83w==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYblRNek85LytuWXFjejVw
+        VFZScUljc01TQW8zL1JwOHlGRGJ0NjZ5KzE0CjBpL1FpZnFkZ2FGbkhBNmdrbHF2
+        R2sydkRmRi94WlhWZjdMUXU1eEp2SU0KLS0tIDU5T0N1Vk93YVZhOTB5WjRuV1pH
+        MG8venpJQmhpS0FRNzlPSEJDZmx1cWsKxI6AiX17hRsZaHdZHUiuNclpkfXLiWPR
+        yMHa0kVtaGQnSkqHDy3ZlMYzFf3oU7o9fDJrumt7ODiXk1MXWO91hQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxWk0yVjdPTlVXUHJnOVBw
+        ZVVoOUhNQ1gvZXJrN0hVcUxMcmtHWFRVckg4CnR0UWFtTFFwcVpmbm1jL0p2bmQ4
+        bFRSSXUwem00KzZjcFFCSzlXcllzMG8KLS0tIFVGMUlpSXo2TllYVElqWnBEdHRY
+        djU0OS9FZUdKNEFhTzI3eUVKWWZwSnMKeZqfoxhAEbGPUKSbgamuX2yUb+r3W0UD
+        VzMhnLlj2Bol/sItqaaheiezi0MzEfASfubcUISVl2pePqy2ndFHMQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZZEdVeEdFelViKzdoMEM2
+        YklrNFh1dldsalRDazFpTlNMSElqeHpybmtJCmxKOHMyT09OMWMxK0t4M1VVYWUy
+        aFpLMjJiTkZ2eDRDWTFRc1M4M2kxMUEKLS0tIEpVUzB2SVBnUTdqQXBqOVQzMG9V
+        ejN4NmZmbDlLM3lmb1Q1NGdUQmpsQk0KaZhX5kgo792cJrjlQAwZktqUbioC9/9M
+        2+ygK+7rajObxe84AqT0wlYfRqGIBJcwEVLst9/BJLyW+22ZxYR2QQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-05T01:35:19Z"
+  mac: ENC[AES256_GCM,data:mJWYdId8klw6+pSZswYhkGwHKXAKJO2W7tLwcfYB2OXr/lhmv6K5EDP+gzlilm6MqXRa72eYmdhaywdJQxCs02RmHOPUzlp4R6ifD5D9O15+10VAPq/P+IKhAtJ813HHTlreaQ0d473eXQjmj+x57GxssC9hq/M4XyR+uy4y+8Y=,iv:Q+t7ffaGsDoW8h5jqd3EbFVrZZMJmSZdGXY5gexEF3k=,tag:yAXpMi6jV8tmTrCwlrQFUA==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4


### PR DESCRIPTION
## Summary
- format the Forgejo tea-token SOPS YAML files with the repo's pinned prettier hook
- also format the newly rotated haku Attic token secret that landed while this fix was in flight
- fixes devel branch-push pre-commit, which runs all files and was rewriting these secrets

## Validation
- pre-commit run --files secrets/codex-pod-forgejo-tea-token.yaml secrets/agent-box-codex-forgejo-tea-token.yaml secrets/claude-forgejo-tea-token.yaml secrets/agent-box-zai-forgejo-tea-token.yaml secrets/haku-forgejo-tea-token.yaml
- pre-commit run --all-files --show-diff-on-failure -v