### PR TITLE
feat(wyrm2): repurpose vdb → 500GB SSD Steam library at /games

### DIFF
--- a/cluster/terraform/main/proxmox-vms.tf
+++ b/cluster/terraform/main/proxmox-vms.tf
@@ -148,19 +148,20 @@ resource "proxmox_virtual_environment_vm" "wyrm2" {
     size         = 500
     file_format  = "raw"
   } # local-path provisioner (/var/local-path-provisioner)
-  # TODO(2026-06-09): remove this disk — Longhorn was decommissioned and its k8s wiring
-  # deleted, so /dev/vdb is unused. Removing it DESTROYS the disk on `tofu apply`, so do
-  # it when wyrm2 is back online. Drop together with the `/var/mnt/longhorn` mount +
-  # `node.longhorn.io/create-default-disk` label in nix/nixos/hosts/wyrm2/default.nix and
-  # `openiscsi` in nix/nixos/modules/k8s-worker.nix.
+  # Repurposed from the decommissioned Longhorn disk (was 100GB, /var/mnt/longhorn).
+  # NOTE: the actual grow was applied imperatively via `qm` on atlas (see
+  # debug/atlas/direct_display_bringup.md); this keeps the TF source in sync.
+  # backup/replicate off — games are re-downloadable, not worth snapshotting.
   disk {
     datastore_id = var.storage
     interface    = "virtio1"
     iothread     = true
     discard      = "on"
-    size         = 100
+    size         = 500
+    backup       = false
+    replicate    = false
     file_format  = "raw"
-  } # Longhorn (/var/mnt/longhorn) — redundant, see TODO above
+  } # Steam library (/games) — SSD, gaming seat
   disk {
     datastore_id = var.storage
     interface    = "virtio2"

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -47,9 +47,6 @@ in
       "topology.kubernetes.io/region" = "proxmox";
       "topology.kubernetes.io/zone" = "atlas";
       "csi.proxmox.sinextra.dev/max-volume-attachments" = "29";
-      # TODO(2026-06-09): remove — Longhorn decommissioned (see the Longhorn disk TODO in
-      # cluster/terraform/main/proxmox-vms.tf).
-      "node.longhorn.io/create-default-disk" = "true";
     };
     # nodeTaints = [ "node-role.kubernetes.io/roaming=true:NoSchedule" ];
   };
@@ -314,10 +311,11 @@ in
     autoFormat = true;
     autoResize = true;
   };
-  # TODO(2026-06-09): remove this mount — Longhorn decommissioned; /dev/vdb (the 100GB
-  # Longhorn disk in cluster/terraform/main/proxmox-vms.tf) is unused. Drop together with
-  # that disk and the node.longhorn.io label above.
-  fileSystems."/var/mnt/longhorn" = {
+  # /dev/vdb (virtio1): 500GB SSD (local-zfs) — Steam library for the gaming seat.
+  # Repurposed from the decommissioned Longhorn disk. Games + Proton prefixes must be
+  # on SSD: the small-file prefix I/O crawls on the tank-hdd virtiofs share
+  # (/mnt/tankshare). See debug/atlas/direct_display_bringup.md.
+  fileSystems."/games" = {
     device = "/dev/vdb";
     fsType = "ext4";
     autoFormat = true;
@@ -425,6 +423,9 @@ in
     "d /home/agentydragon/.cache/bazel/_bazel_agentydragon/cache 0755 agentydragon users -"
     "d /home/agentydragon/.cache/bazel/_bazel_agentydragon/cache/repos 0755 agentydragon users -"
     "d /tmp 1777 root root -"
+    # Steam library mount (/dev/vdb) must be user-writable; the fresh ext4 root
+    # is created root:root, so chown it after the mount lands.
+    "d /games 0755 agentydragon users -"
   ];
 
   # virtiofs shared from Proxmox host (atlas)


### PR DESCRIPTION
## Why
The gaming-seat Steam library is on `/mnt/tankshare` — a **virtiofs mount of atlas's `tank-hdd` (HDD) pool**. Large game reads are tolerable, but **Proton prefix creation is thousands of tiny file ops** over virtiofs+HDD → the multi-minute "Starting launch" crawl (hit while trying Stellaris under Proton).

## What
Repurpose the **decommissioned Longhorn disk** (`vdb` / `virtio1`, on the fast `local-zfs` SSD pool, currently empty at `/var/mnt/longhorn`) into a **500 GB Steam library mounted at `/games`** (`autoFormat`/`autoResize`, owned by agentydragon). `backup`/`replicate` off — games are re-downloadable.

- `nix/nixos/hosts/wyrm2/default.nix`: `vdb` mount `/var/mnt/longhorn` → `/games`; add tmpfiles chown; drop the `node.longhorn.io/create-default-disk` label + Longhorn TODOs.
- `cluster/terraform/main/proxmox-vms.tf`: `virtio1` 100 → 500 GB, `backup=false`, `replicate=false`.

## Applied imperatively on atlas
Per the existing tofu-sync pattern, the real disk change is done via `qm` on `root@atlas` (this PR keeps the source in sync). **The `virtio1` slot is reused** so `/dev/vdb` doesn't rename — critical, since the nix mounts key off `/dev/vdX` order.

```
qm shutdown 110
qm set 110 --delete virtio1
pvesm free local-zfs:vm-110-disk-5
qm set 110 --virtio1 local-zfs:500,discard=on,iothread=1,backup=0,replicate=0
qm start 110
```

## Follow-ups (not here)
- Harden wyrm2 mounts to key off filesystem labels / `by-id` instead of `/dev/vdX` (removes the rename fragility this dance works around).
- Drop `openiscsi` in `k8s-worker.nix` (Longhorn leftover) — separate, affects all workers.
- Move the existing 19 GB library into `/games` and set it default in Steam.