### PR TITLE
[codex] fix OCI cache Docker schema2 sync

### DIFF
--- a/cluster/k8s/oci-cache/app/config.json
+++ b/cluster/k8s/oci-cache/app/config.json
@@ -40,7 +40,8 @@
   },
   "http": {
     "address": "0.0.0.0",
-    "port": "5000"
+    "port": "5000",
+    "compat": ["docker2s2"]
   },
   "log": {
     "level": "info"


### PR DESCRIPTION
## Summary

- enable Zot Docker schema2 compatibility on the OCI cache HTTP listener
- keep the change minimal: no `preserveDigest` change is required for the observed failure

## Root cause

Haku CI already points Docker at `http://oci-cache.oci-cache.svc.cluster.local`, and the Kubernetes Service/Endpoint wiring is healthy: service port 80 reaches the Zot pod on target port 5000. The failure is inside Zot sync, not the port path.

For `catthehacker/ubuntu:act-latest`, Zot v2.1.11 pulls an OCI index from Docker Hub whose child platform manifests use Docker schema2 media type `application/vnd.docker.distribution.manifest.v2+json`. With the current config, Zot rejects those child manifests during the final local store commit as `invalid manifest content`; Docker then falls back to direct Docker Hub, which haku-ci cannot reach.

Zot only accepts that Docker schema2 manifest type when HTTP compatibility includes `docker2s2`, so this adds:

```json
"compat": ["docker2s2"]
```

## Validation

- Reproduced the current config locally with the exact Zot v2.1.11 image/binary: the manifest request returned HTTP 404 and Zot logged `bad manifest media type` for `application/vnd.docker.distribution.manifest.v2+json`.
- Re-ran the same local request with only `http.compat: ["docker2s2"]` added and `PreserveDigest:false`: Zot logged `successfully synced image` and returned HTTP 200 for `/v2/catthehacker/ubuntu/manifests/act-latest` with digest `sha256:8a141fe91b8afc03c793085c8fcc6bba93f5dd9ce6fde7680f4651fd7f3aa827`.
- Ran `jq . cluster/k8s/oci-cache/app/config.json`.
- Commit hooks passed.