### PR TITLE
fix: write rotator SOPS YAML with stable indent

### DIFF
--- a/cluster/rotators/attic_jwt_rotation/rotate.py
+++ b/cluster/rotators/attic_jwt_rotation/rotate.py
@@ -142,6 +142,10 @@ def mint_attic_token(token: Token, config: Config) -> str:
     return jwt
 
 
+def encrypt_sops_file(path: Path) -> None:
+    subprocess.run(["sops", "encrypt", "--indent", "2", "--in-place", str(path)], check=True)
+
+
 def rotate_one(token: Token, config: Config) -> bool:
     """Mint + write a fresh JWT for one token. Returns True if it wrote."""
     remaining = remaining_hours(token.sops_file)
@@ -162,7 +166,7 @@ def rotate_one(token: Token, config: Config) -> bool:
     stamps = {"expires_unencrypted": expires_iso, config.token_field: jwt}
     token.sops_file.parent.mkdir(parents=True, exist_ok=True)
     token.sops_file.write_text(yaml.safe_dump(stamps, sort_keys=False, width=2**31))
-    subprocess.run(["sops", "encrypt", "--in-place", str(token.sops_file)], check=True)
+    encrypt_sops_file(token.sops_file)
     logger.info("%s: wrote token expiring %s", token.name, expires_iso)
     return True
 

--- a/cluster/rotators/attic_jwt_rotation/test_rotate.py
+++ b/cluster/rotators/attic_jwt_rotation/test_rotate.py
@@ -152,7 +152,7 @@ def test_rotate_one_mints_and_writes_when_absent(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(rotate.subprocess, "run", fake)
     assert rotate_one(token, Config(tokens=[])) is True
     assert any("atticadm" in c for c in fake.calls)
-    assert fake.calls[-1][0] == "sops"  # encrypt --in-place runs last
+    assert fake.calls[-1] == ["sops", "encrypt", "--indent", "2", "--in-place", str(sops_file)]
     written = yaml.safe_load(sops_file.read_text())
     assert written["attic_token"] == jwt
     assert "expires_unencrypted" in written

--- a/cluster/rotators/authentik_jwt_rotation/rotate.py
+++ b/cluster/rotators/authentik_jwt_rotation/rotate.py
@@ -217,6 +217,10 @@ def exchange_jwt(client: httpx.Client, rotation: Rotation, source_jwt: str, exch
     return token
 
 
+def encrypt_sops_file(path: Path) -> None:
+    subprocess.run(["sops", "encrypt", "--indent", "2", "--in-place", str(path)], check=True)
+
+
 def rotate_one(client: httpx.Client, rotation: Rotation, config: Config) -> bool:
     """Mint + write a fresh token for one rotation. Returns True if it wrote."""
     remaining = remaining_hours(rotation.sops_file)
@@ -309,7 +313,7 @@ def rotate_one(client: httpx.Client, rotation: Rotation, config: Config) -> bool
     stamps[rotation.token_field] = final_jwt
     rotation.sops_file.parent.mkdir(parents=True, exist_ok=True)
     rotation.sops_file.write_text(yaml.safe_dump(stamps, sort_keys=False, width=2**31))
-    subprocess.run(["sops", "encrypt", "--in-place", str(rotation.sops_file)], check=True)
+    encrypt_sops_file(rotation.sops_file)
     logger.info("%s: wrote token expiring %s", rotation.name, expires_iso)
 
     if rotation.k8s_secret:
@@ -342,7 +346,7 @@ def write_k8s_secret(out: K8sSecretOutput, token: str, exp_epoch: int) -> None:
     """
     out.path.parent.mkdir(parents=True, exist_ok=True)
     out.path.write_text(yaml.safe_dump(build_secret_manifest(out, token, exp_epoch), sort_keys=False, width=2**31))
-    subprocess.run(["sops", "encrypt", "--in-place", str(out.path)], check=True)
+    encrypt_sops_file(out.path)
 
 
 def sparse_clone(config: Config, github_pat: str) -> None:

--- a/cluster/rotators/authentik_jwt_rotation/test_rotate.py
+++ b/cluster/rotators/authentik_jwt_rotation/test_rotate.py
@@ -8,11 +8,13 @@ import pytest
 import pytest_bazel
 from pydantic import ValidationError
 
+from cluster.rotators.authentik_jwt_rotation import rotate
 from cluster.rotators.authentik_jwt_rotation.rotate import (
     Config,
     K8sSecretOutput,
     Rotation,
     build_secret_manifest,
+    encrypt_sops_file,
     jwt_payload,
     mint_jwt,
     remaining_hours,
@@ -186,6 +188,19 @@ def test_build_secret_manifest_carries_token_exp_under_configured_keys():
     manifest = build_secret_manifest(out, token="the-jwt", exp_epoch=1750000000)
     assert manifest["stringData"] == {"jwt": "the-jwt", "token-exp": "1750000000"}
     assert list(manifest["metadata"]["annotations"]) == ["description"]
+
+
+def test_encrypt_sops_file_uses_prettier_compatible_yaml_indent(monkeypatch, tmp_path: Path):
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((list(args), kwargs))
+
+    monkeypatch.setattr(rotate.subprocess, "run", fake_run)
+    path = tmp_path / "secret.yaml"
+    encrypt_sops_file(path)
+
+    assert calls == [(["sops", "encrypt", "--indent", "2", "--in-place", str(path)], {"check": True})]
 
 
 def test_rotation_expected_issuer_derived_from_slug():

--- a/cluster/rotators/forgejo_token_rotation/rotate.py
+++ b/cluster/rotators/forgejo_token_rotation/rotate.py
@@ -256,6 +256,10 @@ def tea_config_yaml(rotation: Rotation, creds: ForgejoCredentials, token: str) -
     )
 
 
+def encrypt_sops_file(path: Path) -> None:
+    subprocess.run(["sops", "encrypt", "--indent", "2", "--in-place", str(path)], check=True)
+
+
 def write_raw_token_sops_file(
     rotation: Rotation, creds: ForgejoCredentials, token_data: dict[str, Any], now: datetime | None = None
 ) -> None:
@@ -275,7 +279,7 @@ def write_raw_token_sops_file(
     }
     rotation.sops_file.parent.mkdir(parents=True, exist_ok=True)
     rotation.sops_file.write_text(yaml.safe_dump(stamps, sort_keys=False, width=2**31))
-    subprocess.run(["sops", "encrypt", "--in-place", str(rotation.sops_file)], check=True)
+    encrypt_sops_file(rotation.sops_file)
 
 
 def build_secret_manifest(
@@ -311,7 +315,7 @@ def write_tea_secret(rotation: Rotation, creds: ForgejoCredentials, token_data: 
             build_secret_manifest(rotation.tea_secret, rotation, creds, token_data), sort_keys=False, width=2**31
         )
     )
-    subprocess.run(["sops", "encrypt", "--in-place", str(rotation.tea_secret.path)], check=True)
+    encrypt_sops_file(rotation.tea_secret.path)
 
 
 def rotate_one(client: httpx.Client, rotation: Rotation) -> RotatedToken | None:

--- a/cluster/rotators/forgejo_token_rotation/test_rotate.py
+++ b/cluster/rotators/forgejo_token_rotation/test_rotate.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest_bazel
 
+from cluster.rotators.forgejo_token_rotation import rotate
 from cluster.rotators.forgejo_token_rotation.rotate import (
     FULL_ACCOUNT_SCOPES,
     ForgejoCredentials,
@@ -10,6 +11,7 @@ from cluster.rotators.forgejo_token_rotation.rotate import (
     Rotation,
     TeaSecretOutput,
     build_secret_manifest,
+    encrypt_sops_file,
     mint_token,
     should_rotate,
     tea_config_yaml,
@@ -157,6 +159,19 @@ def test_secret_manifest_carries_config_and_raw_token():
     assert manifest["stringData"]["token"] == "token-value"
     assert manifest["stringData"]["username"] == "haku"
     assert "config.yml" in manifest["stringData"]
+
+
+def test_encrypt_sops_file_uses_prettier_compatible_yaml_indent(monkeypatch, tmp_path: Path):
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((list(args), kwargs))
+
+    monkeypatch.setattr(rotate.subprocess, "run", fake_run)
+    path = tmp_path / "secret.yaml"
+    encrypt_sops_file(path)
+
+    assert calls == [(["sops", "encrypt", "--indent", "2", "--in-place", str(path)], {"check": True})]
 
 
 def test_mint_token_omits_repositories_for_full_account_access():

--- a/secrets/codex-pod-forgejo-tea-token.yaml
+++ b/secrets/codex-pod-forgejo-tea-token.yaml
@@ -2,14 +2,14 @@ rotated_at_unencrypted: "2026-07-05T02:37:07Z"
 rotate_after_days_unencrypted: 30
 repository_access_unencrypted: all
 scopes_unencrypted:
-    - write:activitypub
-    - write:issue
-    - write:misc
-    - write:notification
-    - write:organization
-    - write:package
-    - write:repository
-    - write:user
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
 token_id_unencrypted: 6
 token_name_unencrypted: forgejo-tea-codex-pod-20260705023707386652
 token_last_eight_unencrypted: b99eab13
@@ -17,58 +17,58 @@ username: ENC[AES256_GCM,data:hCOfN+4BuTo8,iv:XUx3E7m51vB3uPv6vqfqg1PqyVQ8wpMCjg
 url: ENC[AES256_GCM,data:Xzl/oa8bm0bA4BwD0U2ZL1f50o0PuTPliTAo,iv:nAqSsAgnlgcjGUcbKEwJqJzc+K6Pw6xGIqbid1vkkDI=,tag:unPKQyzx3qGFXtv61MNYUg==,type:str]
 token: ENC[AES256_GCM,data:vt52g+zQfIVNhW9BiOOgmH4W/cRPhAaRcfguUNlMiPb0BlFrYUQVkA==,iv:+dyvhwYAWdt5c4r2mU5t3owF5FIggb1Twi4wzk+Z11I=,tag:g9Bfl6xa27b43m0s6OKIjg==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxdlQvdjh3OGNDbVBBQkd1
-            TmlpeUx2WGUwc08wM0JiRTI1ZDhjL29vQWtvCmtnYlJtT3diZGtla3lHMGdid1h4
-            TE5iZEQ1ZEp0QUh4Y2g5ZzRtSk1tZGcKLS0tIDhUU3BhbUI5eTZIL0UzU1hWU0kr
-            RnNXVjRyUkpXeG9nTHRKbzAxQ1N2QXMKhvIfW0jRdWoLw1AJa9mvY4Oylqb4rhDY
-            iLwL3F7iEb2bhmAQOofJORE/kN5F1LT/15yHkFtL2AjGkNdVGEqLQA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFSW5LTGFnTXhpZmpMTDV3
-            Q1JjaElJVUNKODNNaGZ0cE5uVWZuVHFXbG44Cnc0ZE00SnFWSEpzNE1scHl5czUy
-            VXNxZG5rdk9wbFA5VkdBQ1hOaHVUUkEKLS0tIGxuQ2dHZzJ6K00vZWdjTyszNWEy
-            TmMzNHlqNDdGVUFvU1pENDA3OUZkMmcKeiPOP7rTGMg6bGTm3kD4+MPSCEw50mvz
-            XpoykazsmDuT0GSkSPP90LNqYieJzGsqhQYyawJ5ZIiAvY42F4i3zA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVOXVhY002bjBNd29MZFhp
-            a1ZSS1k0NHdMdHovOW5vSWo0WStRcTE1Mnc4CjJLSmFjY2pYM0Fjd0NJTDhZRTlS
-            Rld0aGpyUmVWNVZwajRKWmJESEdHdW8KLS0tIG5rcTQ4Sk1sVlRpSDUrb0sxNDR2
-            cU1ieFR6K2FpRFRxNm12cGx6eGZQa00KKA2ntVC+U9FNNnBXRw4eqSO7Pd1bc9Aj
-            qfWQF46n4yP0E89WvyPRcqYtGHc1z1Jm2/vC9TeCWp+mGFSdfVdQ3w==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOOUtxcjFIdzNhMUxwUEtC
-            V1JmZGVqN2pxS1dhVldOb01hUlFXTzY1MTE0CmF3WExzUks4R2tPUUFuQWdGV0Nn
-            dWxnNE1tOWZNclNneTM0eDExOE9Jd1EKLS0tIHFJejlNV3YrZVpGQ2NSQXZpUGEy
-            YS9qc0NSbWF4UlpsOENGcVFnNnlzR0EKQHdXiNy7sUpavjpm8F32uPh+qVbV3Et8
-            fgyp4IRaFfNka6/R34Wjl8VzzIiDKTAFjVLQATXRFLyZAxHymAbxTA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3QnNSV3Z3WDhmeEp1ZW5J
-            U2hVcTFRdDJNOFZkejJEQ2tNaUczaXVEOEFRCldQU1d1ODRIUlNIY3ZNS004b0pQ
-            cEFGR2JEOUJ4ZHM5Tlh5QURkT290eEkKLS0tIEI4a2tURXpMRHBCL2NBYklHSWRj
-            TDE4VnMyK0hmNWhhY0JhalNwbkQwZTgK7kmklUIRcjOOvzQndwizBFro+qA5l+iM
-            vhQAbB5TMkWP5zOVdCISJJtbIxmB+pOn8V16QYn27anYosSvhCJPnA==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-05T02:37:09Z"
-    mac: ENC[AES256_GCM,data:Mj82IAVWl0vHiJ+X1PGQmD9ClXCBgPBzWaTdTalBpbMfRuevf61UXG0mbbddAv+0Up6+A8QDN1fguFSDTsS0DmofnXYIfZDmtMPhDd7IBeDQ4KgNgsvr0HWMocv0smZJVao6EMd4aCAVwjwHZAi1ik7mr2hMXkZIlrWpXljTdvk=,iv:z9q71zzC+IlQa2ikpY0J3/eJu1AtaI2Iu7gXggIC+Ck=,tag:CXVVQISWhA02uCZkhifu9g==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxdlQvdjh3OGNDbVBBQkd1
+        TmlpeUx2WGUwc08wM0JiRTI1ZDhjL29vQWtvCmtnYlJtT3diZGtla3lHMGdid1h4
+        TE5iZEQ1ZEp0QUh4Y2g5ZzRtSk1tZGcKLS0tIDhUU3BhbUI5eTZIL0UzU1hWU0kr
+        RnNXVjRyUkpXeG9nTHRKbzAxQ1N2QXMKhvIfW0jRdWoLw1AJa9mvY4Oylqb4rhDY
+        iLwL3F7iEb2bhmAQOofJORE/kN5F1LT/15yHkFtL2AjGkNdVGEqLQA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFSW5LTGFnTXhpZmpMTDV3
+        Q1JjaElJVUNKODNNaGZ0cE5uVWZuVHFXbG44Cnc0ZE00SnFWSEpzNE1scHl5czUy
+        VXNxZG5rdk9wbFA5VkdBQ1hOaHVUUkEKLS0tIGxuQ2dHZzJ6K00vZWdjTyszNWEy
+        TmMzNHlqNDdGVUFvU1pENDA3OUZkMmcKeiPOP7rTGMg6bGTm3kD4+MPSCEw50mvz
+        XpoykazsmDuT0GSkSPP90LNqYieJzGsqhQYyawJ5ZIiAvY42F4i3zA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVOXVhY002bjBNd29MZFhp
+        a1ZSS1k0NHdMdHovOW5vSWo0WStRcTE1Mnc4CjJLSmFjY2pYM0Fjd0NJTDhZRTlS
+        Rld0aGpyUmVWNVZwajRKWmJESEdHdW8KLS0tIG5rcTQ4Sk1sVlRpSDUrb0sxNDR2
+        cU1ieFR6K2FpRFRxNm12cGx6eGZQa00KKA2ntVC+U9FNNnBXRw4eqSO7Pd1bc9Aj
+        qfWQF46n4yP0E89WvyPRcqYtGHc1z1Jm2/vC9TeCWp+mGFSdfVdQ3w==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOOUtxcjFIdzNhMUxwUEtC
+        V1JmZGVqN2pxS1dhVldOb01hUlFXTzY1MTE0CmF3WExzUks4R2tPUUFuQWdGV0Nn
+        dWxnNE1tOWZNclNneTM0eDExOE9Jd1EKLS0tIHFJejlNV3YrZVpGQ2NSQXZpUGEy
+        YS9qc0NSbWF4UlpsOENGcVFnNnlzR0EKQHdXiNy7sUpavjpm8F32uPh+qVbV3Et8
+        fgyp4IRaFfNka6/R34Wjl8VzzIiDKTAFjVLQATXRFLyZAxHymAbxTA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3QnNSV3Z3WDhmeEp1ZW5J
+        U2hVcTFRdDJNOFZkejJEQ2tNaUczaXVEOEFRCldQU1d1ODRIUlNIY3ZNS004b0pQ
+        cEFGR2JEOUJ4ZHM5Tlh5QURkT290eEkKLS0tIEI4a2tURXpMRHBCL2NBYklHSWRj
+        TDE4VnMyK0hmNWhhY0JhalNwbkQwZTgK7kmklUIRcjOOvzQndwizBFro+qA5l+iM
+        vhQAbB5TMkWP5zOVdCISJJtbIxmB+pOn8V16QYn27anYosSvhCJPnA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-05T02:37:09Z"
+  mac: ENC[AES256_GCM,data:Mj82IAVWl0vHiJ+X1PGQmD9ClXCBgPBzWaTdTalBpbMfRuevf61UXG0mbbddAv+0Up6+A8QDN1fguFSDTsS0DmofnXYIfZDmtMPhDd7IBeDQ4KgNgsvr0HWMocv0smZJVao6EMd4aCAVwjwHZAi1ik7mr2hMXkZIlrWpXljTdvk=,iv:z9q71zzC+IlQa2ikpY0J3/eJu1AtaI2Iu7gXggIC+Ck=,tag:CXVVQISWhA02uCZkhifu9g==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4


### PR DESCRIPTION
Fixes the devel pre-commit failure where rotated SOPS YAML was generated with sops default indentation and then rewritten by prettier. Updates Forgejo, Attic, and Authentik rotators to call sops encrypt with --indent 2, and formats the current codex-pod Forgejo tea token secret output. Validation: pre-commit run --all-files --show-diff-on-failure -v; bbr test //cluster/rotators/forgejo_token_rotation:test_rotate //cluster/rotators/attic_jwt_rotation:test_rotate //cluster/rotators/authentik_jwt_rotation:test_rotate.