### PR TITLE
fix: satisfy debundle clippy lints

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -157,8 +157,8 @@ fn source_match_binding_names(value: &serde_yaml::Value) -> BTreeSet<String> {
         .filter_map(|binding| match binding {
             serde_yaml::Value::String(local) => Some(local.to_string()),
             serde_yaml::Value::Mapping(mapping) => mapping
-                .get(&serde_yaml::Value::String("name".to_string()))
-                .or_else(|| mapping.get(&serde_yaml::Value::String("local".to_string())))
+                .get(serde_yaml::Value::String("name".to_string()))
+                .or_else(|| mapping.get(serde_yaml::Value::String("local".to_string())))
                 .and_then(serde_yaml::Value::as_str)
                 .map(str::to_string),
             _ => None,

--- a/devinfra/js/debundle/spec_tree.rs
+++ b/devinfra/js/debundle/spec_tree.rs
@@ -253,11 +253,10 @@ fn is_trivial_binding_patch(member: &Member) -> bool {
         return false;
     };
     let binding_name = &binding.name;
-    let name_is_noop = member
+    member
         .name
         .as_ref()
-        .is_none_or(|export_name| export_name == binding_name);
-    name_is_noop
+        .is_none_or(|export_name| export_name == binding_name)
 }
 
 fn vendor_map(

--- a/devinfra/js/debundle/stage_one/mod.rs
+++ b/devinfra/js/debundle/stage_one/mod.rs
@@ -122,6 +122,7 @@ where
 /// resolution uses that same structural layer before semantic member
 /// annotations can be projected to concrete bindings; this entry point lets
 /// materialization keep one source-text walk and one final owner graph.
+#[allow(clippy::too_many_arguments)]
 pub fn compute_chunk_analysis_from_structural<F>(
     chunk_id: &str,
     module: &Module,


### PR DESCRIPTION
Fixes the remaining devel CI Bazel failure after the rotator pre-commit issue was resolved. The failing devel BuildBuddy invocation reported clippy errors in spec_tree.rs, stage_one/mod.rs, and selector_minimizer_expectation_test.rs. Validation: pre-commit run --files devinfra/js/debundle/spec_tree.rs devinfra/js/debundle/stage_one/mod.rs devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs; bbr test //devinfra/js/debundle/... (BuildBuddy wrapper 6b00a057-efc2-4f16-aca0-73aaf5ea29d0, inner 21a47879-7168-4e94-b3ca-dc9901215d13).