### PR TITLE
wayback: scale wayback-archive-db to 2 instances (HA, Stage 2 prep)

### DIFF
--- a/cluster/k8s/wayback-cache/db/postgres-cluster.yaml
+++ b/cluster/k8s/wayback-cache/db/postgres-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: wayback-archive-db
   namespace: wayback-cache
 spec:
-  instances: 1
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie
 
   # CNPG 1.27+ kills isolated primaries by default (liveness probe).
@@ -14,9 +14,14 @@ spec:
       isolationCheck:
         enabled: false
 
+  # OVH-HA profile (cnpg_conventions R2): two instances on separate OVH kimsufi nodes.
+  # Scaled 1 → 2 ahead of the Stage 2 CP reshuffle so it has a re-clone source and rides
+  # Case A eviction instead of being destroyed with its node
+  # (cluster/docs/plans/ovh_storage_tiering.md).
   affinity:
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
+    topologyKey: kubernetes.io/hostname
 
   storage:
     storageClass: local-path-ovh


### PR DESCRIPTION
`wayback-archive-db` was the only single-instance OVH CNPG cluster. During the Stage 2
KS-GAME control-plane reshuffle its node drains, and with only one instance it has no
re-clone source — it would be destroyed. Scale to 2 (OVH-HA profile) so it gains a
streaming replica and rides Case A eviction like every other 2-instance cluster.

Also adds the missing `topologyKey: kubernetes.io/hostname` so the two instances land on
separate kimsufi nodes (real HA). The new instance provisions on `local-path-ovh` (=
`hdd` tier), landing on a KS-5 node — fine, `wayback-archive-db` is HDD-destined.

Non-disruptive: CNPG clones the new replica from the running primary.
Server-side dry-run accepted; pre-commit incl. kubeconform passed.