### PR TITLE
[codex] Format rotated SOPS YAML with Prettier

### DIFF
--- a/cluster/rotators/attic_jwt_rotation/BUILD.bazel
+++ b/cluster/rotators/attic_jwt_rotation/BUILD.bazel
@@ -8,6 +8,7 @@ py_library(
     name = "rotate",
     srcs = ["rotate.py"],
     deps = [
+        "//devinfra:prettier_cli",
         "@pypi//httpx",
         "@pypi//pydantic",
         "@pypi//pygit2",
@@ -74,6 +75,9 @@ oci_image(
         "@trixie_attic_rotation//:flat",
         ":sops_layer",
         ":kubectl_layer",
+        "//devinfra:node_bin_layer",
+        "//devinfra:prettier_cli_layer",
+        "//devinfra:prettier_bin_layer",
         ":layers",
     ],
 )

--- a/cluster/rotators/attic_jwt_rotation/rotate.py
+++ b/cluster/rotators/attic_jwt_rotation/rotate.py
@@ -33,6 +33,8 @@ import typer
 import yaml
 from pydantic import BaseModel, Field
 
+from devinfra.prettier_cli import prettier_format_yaml_in_place
+
 logger = logging.getLogger(__name__)
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
@@ -167,6 +169,7 @@ def rotate_one(token: Token, config: Config) -> bool:
     token.sops_file.parent.mkdir(parents=True, exist_ok=True)
     token.sops_file.write_text(yaml.safe_dump(stamps, sort_keys=False, width=2**31))
     encrypt_sops_file(token.sops_file)
+    prettier_format_yaml_in_place(token.sops_file)
     logger.info("%s: wrote token expiring %s", token.name, expires_iso)
     return True
 

--- a/cluster/rotators/attic_jwt_rotation/test_rotate.py
+++ b/cluster/rotators/attic_jwt_rotation/test_rotate.py
@@ -149,10 +149,13 @@ def test_rotate_one_mints_and_writes_when_absent(monkeypatch, tmp_path: Path):
     jwt = _make_jwt({"sub": "x", "exp": exp})
     token = Token(name="x", sops_file=sops_file, sub="x", validity="1 year", pull=["main"], push=[])
     fake = _FakeRun(jwt=jwt)
+    formatted: list[Path] = []
     monkeypatch.setattr(rotate.subprocess, "run", fake)
+    monkeypatch.setattr(rotate, "prettier_format_yaml_in_place", formatted.append)
     assert rotate_one(token, Config(tokens=[])) is True
     assert any("atticadm" in c for c in fake.calls)
     assert fake.calls[-1] == ["sops", "encrypt", "--indent", "2", "--in-place", str(sops_file)]
+    assert formatted == [sops_file]
     written = yaml.safe_load(sops_file.read_text())
     assert written["attic_token"] == jwt
     assert "expires_unencrypted" in written

--- a/cluster/rotators/authentik_jwt_rotation/BUILD.bazel
+++ b/cluster/rotators/authentik_jwt_rotation/BUILD.bazel
@@ -8,6 +8,7 @@ py_library(
     name = "rotate",
     srcs = ["rotate.py"],
     deps = [
+        "//devinfra:prettier_cli",
         "@pypi//httpx",
         "@pypi//pydantic",
         "@pypi//pyyaml",
@@ -57,6 +58,9 @@ oci_image(
     tars = [
         "@trixie_authentik_rotation//:flat",
         ":sops_layer",
+        "//devinfra:node_bin_layer",
+        "//devinfra:prettier_cli_layer",
+        "//devinfra:prettier_bin_layer",
         ":layers",
     ],
 )

--- a/cluster/rotators/authentik_jwt_rotation/rotate.py
+++ b/cluster/rotators/authentik_jwt_rotation/rotate.py
@@ -38,6 +38,8 @@ import typer
 import yaml
 from pydantic import BaseModel, Field
 
+from devinfra.prettier_cli import prettier_format_yaml_in_place
+
 logger = logging.getLogger(__name__)
 
 AUTH_BASE = "https://auth.allegedly.works"
@@ -314,6 +316,7 @@ def rotate_one(client: httpx.Client, rotation: Rotation, config: Config) -> bool
     rotation.sops_file.parent.mkdir(parents=True, exist_ok=True)
     rotation.sops_file.write_text(yaml.safe_dump(stamps, sort_keys=False, width=2**31))
     encrypt_sops_file(rotation.sops_file)
+    prettier_format_yaml_in_place(rotation.sops_file)
     logger.info("%s: wrote token expiring %s", rotation.name, expires_iso)
 
     if rotation.k8s_secret:
@@ -347,6 +350,7 @@ def write_k8s_secret(out: K8sSecretOutput, token: str, exp_epoch: int) -> None:
     out.path.parent.mkdir(parents=True, exist_ok=True)
     out.path.write_text(yaml.safe_dump(build_secret_manifest(out, token, exp_epoch), sort_keys=False, width=2**31))
     encrypt_sops_file(out.path)
+    prettier_format_yaml_in_place(out.path)
 
 
 def sparse_clone(config: Config, github_pat: str) -> None:

--- a/cluster/rotators/authentik_jwt_rotation/test_rotate.py
+++ b/cluster/rotators/authentik_jwt_rotation/test_rotate.py
@@ -49,6 +49,57 @@ class _RecordingClient:
         return _FakeResponse({"access_token": "minted.jwt"})
 
 
+def test_rotate_one_formats_raw_sops_file_after_encrypt(monkeypatch, tmp_path: Path):
+    sops_file = tmp_path / "secrets" / "haku-k8s-jwt.yaml"
+    credentials_dir = tmp_path / "creds"
+    credentials_dir.mkdir()
+    rotation = Rotation(
+        name="haku-k8s",
+        provider_slug="kubectl-sandbox-client-credentials",
+        scopes="openid profile email groups",
+        credentials_dir=credentials_dir,
+        sops_file=sops_file,
+        token_field="jwt",
+    )
+    token = _make_jwt({"iss": rotation.expected_issuer, "exp": 1_800_000_000, "groups": []})
+    calls: list[tuple[str, object]] = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(("run", list(args)))
+
+    def fake_format(path: Path) -> None:
+        calls.append(("format", path))
+
+    monkeypatch.setattr(rotate, "mint_jwt", lambda _client, _rotation: token)
+    monkeypatch.setattr(rotate.subprocess, "run", fake_run)
+    monkeypatch.setattr(rotate, "prettier_format_yaml_in_place", fake_format)
+
+    assert rotate.rotate_one(object(), rotation, Config(rotations=[])) is True
+    assert calls == [("run", ["sops", "encrypt", "--indent", "2", "--in-place", str(sops_file)]), ("format", sops_file)]
+
+
+def test_write_k8s_secret_formats_after_encrypt(monkeypatch, tmp_path: Path):
+    out = K8sSecretOutput(
+        path=tmp_path / "cluster/k8s/haku/cloud-agent-tf/haku-kube-token.sops.yaml",
+        name="haku-kube-token",
+        namespace="flux-system",
+    )
+    calls: list[tuple[str, object]] = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(("run", list(args)))
+
+    def fake_format(path: Path) -> None:
+        calls.append(("format", path))
+
+    monkeypatch.setattr(rotate.subprocess, "run", fake_run)
+    monkeypatch.setattr(rotate, "prettier_format_yaml_in_place", fake_format)
+
+    rotate.write_k8s_secret(out, token="the-jwt", exp_epoch=1_800_000_000)
+
+    assert calls == [("run", ["sops", "encrypt", "--indent", "2", "--in-place", str(out.path)]), ("format", out.path)]
+
+
 def test_jwt_payload_decodes_unpadded_base64url():
     claims = {"iss": "https://auth.allegedly.works/application/o/x/", "groups": ["some-group"], "exp": 123}
     assert jwt_payload(_make_jwt(claims)) == claims

--- a/cluster/rotators/forgejo_token_rotation/BUILD.bazel
+++ b/cluster/rotators/forgejo_token_rotation/BUILD.bazel
@@ -8,6 +8,7 @@ py_library(
     name = "rotate",
     srcs = ["rotate.py"],
     deps = [
+        "//devinfra:prettier_cli",
         "@pypi//httpx",
         "@pypi//pydantic",
         "@pypi//pyyaml",
@@ -55,6 +56,9 @@ oci_image(
     tars = [
         "@trixie_authentik_rotation//:flat",
         ":sops_layer",
+        "//devinfra:node_bin_layer",
+        "//devinfra:prettier_cli_layer",
+        "//devinfra:prettier_bin_layer",
         ":layers",
     ],
 )

--- a/cluster/rotators/forgejo_token_rotation/rotate.py
+++ b/cluster/rotators/forgejo_token_rotation/rotate.py
@@ -25,6 +25,8 @@ import typer
 import yaml
 from pydantic import BaseModel, Field
 
+from devinfra.prettier_cli import prettier_format_yaml_in_place
+
 logger = logging.getLogger(__name__)
 
 FULL_ACCOUNT_SCOPES = [
@@ -280,6 +282,7 @@ def write_raw_token_sops_file(
     rotation.sops_file.parent.mkdir(parents=True, exist_ok=True)
     rotation.sops_file.write_text(yaml.safe_dump(stamps, sort_keys=False, width=2**31))
     encrypt_sops_file(rotation.sops_file)
+    prettier_format_yaml_in_place(rotation.sops_file)
 
 
 def build_secret_manifest(
@@ -316,6 +319,7 @@ def write_tea_secret(rotation: Rotation, creds: ForgejoCredentials, token_data: 
         )
     )
     encrypt_sops_file(rotation.tea_secret.path)
+    prettier_format_yaml_in_place(rotation.tea_secret.path)
 
 
 def rotate_one(client: httpx.Client, rotation: Rotation) -> RotatedToken | None:

--- a/cluster/rotators/forgejo_token_rotation/test_rotate.py
+++ b/cluster/rotators/forgejo_token_rotation/test_rotate.py
@@ -51,6 +51,59 @@ class _RecordingClient:
         )
 
 
+def test_write_raw_token_sops_file_formats_after_encrypt(monkeypatch, tmp_path: Path):
+    sops_file = tmp_path / "secrets" / "haku.yaml"
+    rotation = Rotation(name="haku", credentials_dir=Path("/creds"), sops_file=sops_file)
+    creds = ForgejoCredentials("haku", "secret", "http://forgejo-http.forgejo:3000", "https://git.allegedly.works")
+    calls: list[tuple[str, object]] = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(("run", list(args)))
+
+    def fake_format(path: Path) -> None:
+        calls.append(("format", path))
+
+    monkeypatch.setattr(rotate.subprocess, "run", fake_run)
+    monkeypatch.setattr(rotate, "prettier_format_yaml_in_place", fake_format)
+
+    rotate.write_raw_token_sops_file(
+        rotation,
+        creds,
+        {"id": 12, "name": "forgejo-tea-haku-20260701", "sha1": "token-value", "token_last_eight": "en-value"},
+        now=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+
+    assert calls == [("run", ["sops", "encrypt", "--indent", "2", "--in-place", str(sops_file)]), ("format", sops_file)]
+
+
+def test_write_tea_secret_formats_after_encrypt(monkeypatch, tmp_path: Path):
+    out = TeaSecretOutput(
+        path=tmp_path / "cluster/k8s/haku/agent-worker/haku-forgejo-tea.sops.yaml", name="tea", namespace="haku"
+    )
+    rotation = Rotation(
+        name="haku", credentials_dir=Path("/creds"), sops_file=tmp_path / "secrets/haku.yaml", tea_secret=out
+    )
+    creds = ForgejoCredentials("haku", "secret", "http://forgejo-http.forgejo:3000", "https://git.allegedly.works")
+    calls: list[tuple[str, object]] = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(("run", list(args)))
+
+    def fake_format(path: Path) -> None:
+        calls.append(("format", path))
+
+    monkeypatch.setattr(rotate.subprocess, "run", fake_run)
+    monkeypatch.setattr(rotate, "prettier_format_yaml_in_place", fake_format)
+
+    rotate.write_tea_secret(
+        rotation,
+        creds,
+        {"id": 12, "name": "forgejo-tea-haku-20260701", "sha1": "token-value", "token_last_eight": "en-value"},
+    )
+
+    assert calls == [("run", ["sops", "encrypt", "--indent", "2", "--in-place", str(out.path)]), ("format", out.path)]
+
+
 def test_default_scopes_are_full_non_admin_write_set():
     r = Rotation(name="haku", credentials_dir=Path("/creds"), sops_file=Path("secrets/haku.yaml"))
     assert r.scopes == FULL_ACCOUNT_SCOPES

--- a/devinfra/BUILD.bazel
+++ b/devinfra/BUILD.bazel
@@ -3,6 +3,7 @@
 load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@npm_ducktape//:prettier/package_json.bzl", prettier_bin = "bin")
 load("@pypi//:requirements.bzl", "all_whl_requirements")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
 load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
 load("//devinfra:filter_wheels.bzl", "filter_system_packages")
@@ -83,4 +84,32 @@ py_library(
     data = [":prettier_bin"],
     visibility = ["//visibility:public"],
     deps = ["//util/bazel:runfiles"],
+)
+
+py_library(
+    name = "prettier_cli",
+    srcs = ["prettier_cli.py"],
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "prettier_cli_layer",
+    srcs = ["//:node_modules/prettier"],
+    mode = "0755",
+    package_dir = "/usr/local/lib",
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "prettier_bin_layer",
+    symlinks = {"/usr/local/bin/prettier": "../lib/prettier/bin/prettier.cjs"},
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "node_bin_layer",
+    srcs = ["@nodejs_linux_amd64//:bin/node"],
+    mode = "0755",
+    package_dir = "/usr/local/bin",
+    visibility = ["//visibility:public"],
 )

--- a/devinfra/prettier_cli.py
+++ b/devinfra/prettier_cli.py
@@ -1,0 +1,23 @@
+"""Prettier helpers for runtime containers with prettier on PATH."""
+
+import subprocess
+from pathlib import Path
+
+
+def prettier_format_yaml_in_place(path: Path) -> None:
+    """Run prettier on YAML with the repo's YAML-relevant formatting options."""
+    subprocess.run(
+        [
+            "prettier",
+            "--write",
+            "--parser",
+            "yaml",
+            "--print-width",
+            "120",
+            "--tab-width",
+            "2",
+            "--no-use-tabs",
+            str(path),
+        ],
+        check=True,
+    )


### PR DESCRIPTION
## Summary

- Run the repo-pinned Prettier CLI after rotators write and encrypt SOPS YAML.
- Package Node plus the npm Prettier package into the affected rotator OCI images so `prettier` is available on `PATH` at runtime.
- Add focused tests that the rotators format SOPS outputs after encryption.

## Root Cause

The rotators generated YAML through PyYAML and SOPS but did not invoke the repo formatter in the runtime container, so rotated SOPS files could fail the repository's Prettier formatting check.

## Validation

- `bbr test //cluster/rotators/forgejo_token_rotation:test_rotate //cluster/rotators/attic_jwt_rotation:test_rotate //cluster/rotators/authentik_jwt_rotation:test_rotate`
- `bbr build //cluster/rotators/forgejo_token_rotation:image //cluster/rotators/attic_jwt_rotation:image //cluster/rotators/authentik_jwt_rotation:image`
- normal commit hooks passed, including buildifier, ruff, and ducktape pre-commit hooks