### PR TITLE
oci-cache: authenticated HTTPS endpoint + puller cred for rules_oci pulls

### DIFF
--- a/cluster/k8s/haku-ci/config.yaml
+++ b/cluster/k8s/haku-ci/config.yaml
@@ -79,9 +79,14 @@ container:
     -e NODE_EXTRA_CA_CERTS=/egress-proxy-ca/ca-certificates.crt
     -v /egress-proxy-ca/ca-certificates.crt:/egress-proxy-ca/ca-certificates.crt:ro
     -v /egress-proxy-ca/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
-  # Allow the runner's own CA bind mounts above through act_runner's volume gate
-  # (a Haku-authored workflow still cannot mount arbitrary dind-host paths).
+    -e DOCKER_CONFIG=/etc/oci-auth
+    -v /etc/oci-auth/config.json:/etc/oci-auth/config.json:ro
+  # Allow the runner's own CA + oci-auth bind mounts above through act_runner's volume
+  # gate (a Haku-authored workflow still cannot mount arbitrary dind-host paths).
+  # DOCKER_CONFIG points Bazel rules_oci at the puller creds for oci-cache.allegedly.works
+  # so base-image pulls resolve through the authenticated cache, not Docker Hub.
   valid_volumes:
     - /egress-proxy-ca/ca-certificates.crt
+    - /etc/oci-auth/config.json
 cache:
   enabled: false

--- a/cluster/k8s/haku-ci/deployment.yaml
+++ b/cluster/k8s/haku-ci/deployment.yaml
@@ -84,21 +84,9 @@ spec:
               value: /egress-proxy-ca/ca-certificates.crt
             - name: NODE_EXTRA_CA_CERTS
               value: /egress-proxy-ca/ca-certificates.crt
-            # Bazel rules_oci reads $DOCKER_CONFIG/config.json at build time to
-            # authenticate base-image pulls. Point it at the mounted puller
-            # credential so rules_oci pulls through the authenticated oci-cache
-            # endpoint (oci-cache.allegedly.works) instead of Docker Hub direct.
-            - name: DOCKER_CONFIG
-              value: /etc/oci-auth
           volumeMounts:
             - name: config
               mountPath: /config
-              readOnly: true
-            # config.json (docker auth for oci-cache.allegedly.works) from the
-            # Reflector-mirrored puller-credential Secret; DOCKER_CONFIG above
-            # points rules_oci here.
-            - name: oci-auth
-              mountPath: /etc/oci-auth
               readOnly: true
             - name: token
               mountPath: /secrets
@@ -170,6 +158,14 @@ spec:
               mountPath: /var/lib/docker
             - name: egress-proxy-ca
               mountPath: /egress-proxy-ca
+              readOnly: true
+            # Puller docker-config (auth for oci-cache.allegedly.works) mounted on dind
+            # so config.yaml's container.options can -v it into each spawned job
+            # container — where Bazel rules_oci actually runs — mirroring the egress-CA
+            # bind. (The runner process itself never runs bazel, so a runner-container
+            # mount would not reach the build.)
+            - name: oci-auth
+              mountPath: /etc/oci-auth
               readOnly: true
           resources:
             requests:

--- a/cluster/k8s/haku-ci/deployment.yaml
+++ b/cluster/k8s/haku-ci/deployment.yaml
@@ -84,9 +84,21 @@ spec:
               value: /egress-proxy-ca/ca-certificates.crt
             - name: NODE_EXTRA_CA_CERTS
               value: /egress-proxy-ca/ca-certificates.crt
+            # Bazel rules_oci reads $DOCKER_CONFIG/config.json at build time to
+            # authenticate base-image pulls. Point it at the mounted puller
+            # credential so rules_oci pulls through the authenticated oci-cache
+            # endpoint (oci-cache.allegedly.works) instead of Docker Hub direct.
+            - name: DOCKER_CONFIG
+              value: /etc/oci-auth
           volumeMounts:
             - name: config
               mountPath: /config
+              readOnly: true
+            # config.json (docker auth for oci-cache.allegedly.works) from the
+            # Reflector-mirrored puller-credential Secret; DOCKER_CONFIG above
+            # points rules_oci here.
+            - name: oci-auth
+              mountPath: /etc/oci-auth
               readOnly: true
             - name: token
               mountPath: /secrets
@@ -186,3 +198,13 @@ spec:
         - name: egress-proxy-ca
           configMap:
             name: haku-egress-proxy-ca-cert
+        # Reflector mirrors oci-cache's puller-credential Secret into this
+        # namespace (same name). Only its config.json key (a docker config with
+        # the puller auth for oci-cache.allegedly.works) is projected, at
+        # $DOCKER_CONFIG/config.json for Bazel rules_oci.
+        - name: oci-auth
+          secret:
+            secretName: puller-credential
+            items:
+              - key: config.json
+                path: config.json

--- a/cluster/k8s/oci-cache/app/config.json
+++ b/cluster/k8s/oci-cache/app/config.json
@@ -41,7 +41,12 @@
   "http": {
     "address": "0.0.0.0",
     "port": "5000",
-    "compat": ["docker2s2"]
+    "compat": ["docker2s2"],
+    "auth": {
+      "htpasswd": {
+        "path": "/etc/zot/htpasswd"
+      }
+    }
   },
   "log": {
     "level": "info"

--- a/cluster/k8s/oci-cache/app/deployment.yaml
+++ b/cluster/k8s/oci-cache/app/deployment.yaml
@@ -69,15 +69,17 @@ spec:
             limits:
               memory: 512Mi
               cpu: "1"
+          # TCP probes, not httpGet /v2/: with htpasswd auth enabled an
+          # unauthenticated GET /v2/ returns 401, which a plain httpGet probe
+          # (no credentials to send) would score as a failure and crashloop the
+          # pod. A TCP check confirms Zot is listening without exercising auth.
           readinessProbe:
-            httpGet:
-              path: /v2/
+            tcpSocket:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            httpGet:
-              path: /v2/
+            tcpSocket:
               port: http
             initialDelaySeconds: 20
             periodSeconds: 20
@@ -87,9 +89,20 @@ spec:
             capabilities:
               drop: ["ALL"]
       volumes:
+        # Projected so config.json (ConfigMap) and htpasswd (puller-credential
+        # Secret) both land in /etc/zot — Zot's config references
+        # /etc/zot/htpasswd. Only the Secret's htpasswd key is projected (not its
+        # config.json client key, which is for the runner, not Zot).
         - name: config
-          configMap:
-            name: oci-cache-zot-config
+          projected:
+            sources:
+              - configMap:
+                  name: oci-cache-zot-config
+              - secret:
+                  name: puller-credential
+                  items:
+                    - key: htpasswd
+                      path: htpasswd
         - name: cache
           emptyDir:
             sizeLimit: 5Gi

--- a/cluster/k8s/oci-cache/app/flux-kustomization.yaml
+++ b/cluster/k8s/oci-cache/app/flux-kustomization.yaml
@@ -13,6 +13,10 @@ spec:
   path: ./cluster/k8s/oci-cache/app
   prune: true
   wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age-cluster-secrets
   healthChecks:
     - apiVersion: apps/v1
       kind: Deployment

--- a/cluster/k8s/oci-cache/app/httproute.yaml
+++ b/cluster/k8s/oci-cache/app/httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oci-cache
+  namespace: oci-cache
+  annotations:
+    description: >-
+      Authenticated public endpoint for the Zot pull-through cache. The
+      cluster-gateway already terminates TLS for *.allegedly.works, so this is
+      just a route to the oci-cache Service (:80 -> container :5000); Zot's
+      htpasswd auth (see config.json + the puller-credential Secret) gates it.
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "oci-cache.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: oci-cache
+          port: 80

--- a/cluster/k8s/oci-cache/app/kustomization.yaml
+++ b/cluster/k8s/oci-cache/app/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - valkey-instance.yaml
   - deployment.yaml
   - service.yaml
+  - httproute.yaml
+  - puller-credential.sops.yaml
 configMapGenerator:
   - name: oci-cache-zot-config
     files:

--- a/cluster/k8s/oci-cache/app/puller-credential.sops.yaml
+++ b/cluster/k8s/oci-cache/app/puller-credential.sops.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: puller-credential
+    namespace: oci-cache
+    annotations:
+        description: Puller credential for the authenticated oci-cache endpoint (oci-cache.allegedly.works). `htpasswd` is mounted into Zot at /etc/zot/htpasswd (bcrypt line for user `puller`); `config.json` is a docker config (base64 of `puller:<password>`) that Reflector mirrors into haku-ci, where the runner exposes it as DOCKER_CONFIG so Bazel rules_oci authenticates when pulling base images through the cache.
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: haku-ci
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: haku-ci
+type: Opaque
+stringData:
+    htpasswd: ENC[AES256_GCM,data:6/pSi6KjL+yXqj7iBEfaKodL6TniK7Xm9TMJMQq0SrskF7d9EVarbpAU+zS5mZju8kxKB4fPLgvadEE4RPGcGrVWTg==,iv:AEI5w0dqHPKv5hziC9fPkj7Nd+4qONKmwDOKB4yUi74=,tag:pYvPGI0JF/EjCSSZ5Wb5Vw==,type:str]
+    config.json: ENC[AES256_GCM,data:ST1r7kUw9LwkxV/emzMNZO7YG0HiKym6cDepvYfURhyjwJbGp5ijLSdlfc5Ua7WUs+/x3RVjX13j9B9q3jLa+R7T8WuunOEfRBvLUsZklckUMopkDi7NvQRouHOg24nf4h9dMViB7Q==,iv:yAa8T78MuprDkduY5VvmOp9DK5gEelzUWdDz4TrHmMc=,tag:9E/3H+fuPdxsiBAVvXdSrA==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxMC9DRmNHdzE2SVF1OWxB
+            cU5pZkptdDUzQzNwQVVYTUxXdXR0MkgrV2tNCm5jVVVBcW5VZXc0bUVEcDFpaUdQ
+            amhIRTBRbm5RdFBIZWxESWJtQVJSczAKLS0tIFdSTlJvT3c5ZWQ3ZGlXeXZmOS9B
+            Zi8wTXAvWmFtZXFvbkorVkRnL05kbmsKPPKGVJgODX53M7SoYUDpRz7oapu01Dxr
+            wz9qK2ncJtjtOKNGHCfmrbNTe1IQ4STRwrKGz/ogl6Bav0Sbje9GSg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0UktiQUlWM2JNbTh1UGIw
+            M1BUbldFeS9Wdi95N3I0N2J4R2lpaGIwd1NNCjRaQ0xnZ08wa2Y0cGxJS1JpSGxk
+            dVE1NjBYVUVQOHdZYk9lankxQmZWZjgKLS0tIFdUS1hqYjRKeVhJaXhNc3JCWXJU
+            UWhzM1p0bklkaWZvUXRYVXg2elZJVjgKDmMdut1vOQ/+IrZBYfbChTW4/KJA3NXH
+            kXsu8tRqguHjj5OSaZ9ujUj6JRmO3PfJQeElPojtpYk8zsAVpdCuzQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-05T04:57:16Z"
+    mac: ENC[AES256_GCM,data:0Md8W7gxRHOzXj2iTurG1rnJ7kzrOJocX/UAlob7wkM9+AVITN0lwUBBwX7jez5tuR6gpx8FlVAG4J2VwnD5a26E/ykK76hZl7DQG1rKmpRctD0b0SvKC98BXhHMQiceReNZt3JTWvUADd7cnu12jVw2bmW5Fu9UEM48ygO7bks=,iv:7u+Qvam6pLoajMiXKV57DnwRiXbBC/sXPz6jnl+0X9w=,tag:gevXsEdKq3qMSWGSq+zz6g==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1


### PR DESCRIPTION
## What

Wires the deferred **Phase 2 authenticated public endpoint** for the Zot pull-through
cache (`oci-cache.README.md` § Phase 2), so Bazel `rules_oci` base-image pulls in the
haku-state CI can resolve through the cache over HTTPS instead of hitting Docker Hub
directly (whose FQDNs were dropped from the `haku-egress-proxy` allowlist in #2865).

## Changes

- **`oci-cache/app/httproute.yaml`** (new) — `HTTPRoute` for `oci-cache.allegedly.works`
  → `oci-cache` Service via `cluster-gateway` (which already terminates
  `*.allegedly.works` TLS).
- **`oci-cache/app/puller-credential.sops.yaml`** (new) — SOPS-encrypted Secret with two
  keys: `htpasswd` (a `puller:` bcrypt line consumed by Zot) and `config.json` (a docker
  config carrying the puller auth for clients). Reflector-mirrored into `haku-ci`.
  Recipients: admin + cluster-secrets (Flux), so Flux can decrypt.
- **`oci-cache/app/config.json`** — enable `http.auth.htpasswd` pointing at
  `/etc/zot/htpasswd`.
- **`oci-cache/app/deployment.yaml`** — project `config.json` + `htpasswd` into
  `/etc/zot`; switch liveness/readiness probes `httpGet` → `tcpSocket` (auth makes
  `GET /v2/` return 401, which would fail an HTTP probe).
- **`haku-ci/deployment.yaml` + `haku-ci/config.yaml`** — mount the mirrored puller
  docker-config on the **dind** sidecar and inject it into each spawned **job container**
  via `container.options` (`-e DOCKER_CONFIG=/etc/oci-auth` + `-v` the `config.json`, plus
  `valid_volumes`), mirroring how the egress-proxy CA reaches jobs. Bazel `rules_oci` runs
  inside the job container, not the runner process, so a runner-container mount would never
  reach the build.

## Review caveats

- **Probes changed to `tcpSocket`** because htpasswd auth returns 401 on `GET /v2/`; a
  TCP-connect probe is the right liveness signal for an auth-gated registry.
- **Runner-auth path is only verifiable by a real CI run** — the `DOCKER_CONFIG`
  reaching the Bazel job container can't be confirmed locally; it needs this PR merged +
  Flux reconciled + a `wip/bazelify` push.
- **Gateway TLS reference** (`cluster-gateway` terminating `oci-cache.allegedly.works`)
  is not locally verifiable; it relies on the existing `*.allegedly.works` wildcard.

## Follow-up (gated on this merging + Flux reconciling)

Re-point the haku-state `MODULE.bazel` `oci.pull` debian `image` to
`oci-cache.allegedly.works/library/debian` (HTTPS) and confirm bazel-ci is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189a1fUCQnvrMwEx5fedtYd

---
_Generated by [Claude Code](https://claude.ai/code/session_0189a1fUCQnvrMwEx5fedtYd)_