### PR TITLE
feat(wyrm2): sway gaming seat on the 5090 + DP audio + per-game gamescope

### DIFF
--- a/cluster/terraform/main/proxmox-vms.tf
+++ b/cluster/terraform/main/proxmox-vms.tf
@@ -43,17 +43,24 @@ resource "proxmox_virtual_environment_vm" "wyrm2" {
     floating  = 0 # Disable balloon (VFIO incompatible)
   }
 
-  # GPU passthrough
+  # GPU passthrough. hostpci0 → guest 01:00.0 (first PCI), hostpci1 → guest
+  # 02:00.0. The DISPLAY GPU must be guest 01:00.0 because DXVK renders on the
+  # first-PCI device and the two 5090s are identical (no per-app selector) — so
+  # the monitor's card has to be hostpci0 to avoid a cross-PCIe copy per frame.
+  # See debug/atlas/direct_display_bringup.md.
+  #
+  # Display 5090 (host 01:00, IOMMU group 14; DP cable to the FV43U): pass the
+  # WHOLE device (no function suffix) so the guest gets both the GPU (01:00.0)
+  # and its DP/HDMI audio function (01:00.1) — the monitor's audio path for the
+  # gaming seat. Applied imperatively via qm on atlas; this keeps TF in sync.
   hostpci {
     device = "hostpci0"
-    id     = "0000:01:00.0"
+    id     = "0000:01:00"
     pcie   = true
     rombar = true
   }
-  # Display 5090 (host 03:00, IOMMU group 16): pass the WHOLE device (no function
-  # suffix) so the guest gets both the GPU (02:00.0) and its DP/HDMI audio
-  # function (02:00.1) — the monitor's audio path for the gaming seat. Applied
-  # imperatively via qm on atlas; this keeps the TF source in sync.
+  # Compute 5090 (host 03:00): headless, no monitor. Whole device passed (its
+  # audio function 02:00.1 rides along harmlessly).
   hostpci {
     device = "hostpci1"
     id     = "0000:03:00"

--- a/cluster/terraform/main/proxmox-vms.tf
+++ b/cluster/terraform/main/proxmox-vms.tf
@@ -50,9 +50,13 @@ resource "proxmox_virtual_environment_vm" "wyrm2" {
     pcie   = true
     rombar = true
   }
+  # Display 5090 (host 03:00, IOMMU group 16): pass the WHOLE device (no function
+  # suffix) so the guest gets both the GPU (02:00.0) and its DP/HDMI audio
+  # function (02:00.1) — the monitor's audio path for the gaming seat. Applied
+  # imperatively via qm on atlas; this keeps the TF source in sync.
   hostpci {
     device = "hostpci1"
-    id     = "0000:03:00.0"
+    id     = "0000:03:00"
     pcie   = true
     rombar = true
   }

--- a/debug/atlas/direct_display_bringup.md
+++ b/debug/atlas/direct_display_bringup.md
@@ -283,11 +283,74 @@ back returns nothing). Useful convars probed live: `composite_force`,
 corruption (see #5). Session env to reach it:
 `XDG_RUNTIME_DIR=/run/user/1001 WAYLAND_DISPLAY=gamescope-0 gamescopectl <convar> <val>`.
 
+## 2026-07-04 (later): pivot to a sway seat + SSD library + monitor audio
+
+Dropped the gamescope Big-Picture **kiosk** session in favor of a real WM on the
+game seat — one you can debug from and launch games from normally. Also moved the
+Steam library to SSD and got monitor audio working. **Current state: sway on the
+5090 works, Steam + Proton run, monitor speakers work; the one open item is
+per-game lag.**
+
+### Architecture change: gamescope kiosk → sway
+
+- seat-game runs a **sway** session (NixOS `programs.sway`; config via HM
+  `wayland.windowManager.sway` with `package = null`) as agentydragon — non-GNOME,
+  so no D-Bus clash with the seat0 SPICE GNOME session. Games get direct scan-out
+  via **per-title gamescope** (`gamescope -f -- %command%`), not a kiosk session.
+- NVIDIA/wlroots gotchas that cost time:
+  - `--unsupported-gpu` is mandatory (sway refuses NVIDIA otherwise); set via
+    `programs.sway.extraOptions`.
+  - **Do NOT set `WLR_DRM_DEVICES` to a `/dev/dri/by-path/pci-…` node.** That env
+    is a _colon-separated list_, so the PCI address's colons split it into garbage
+    → "Found 0 GPUs, cannot create backend" → sway exits and _wedges the greeter_
+    (it grabbed DRM, died, mutter couldn't reclaim). Unneeded anyway: the seat
+    assignment already hands seat-game only card2 (the 5090).
+  - `WLR_NO_HARDWARE_CURSORS=1`.
+  - Same GDM 60 s silent-death trap as gamescope — a failed session Exec logs
+    nothing. The **"Sway (debug)"** session (logs `sway -d` to
+    `/tmp/sway-session.log`) is what cracked the WLR_DRM_DEVICES bug. Keep the
+    debug-session-with-file-logging pattern for anything GDM launches.
+- Driving the seat headlessly over SSH works well: `swaymsg -t get_tree` for
+  windows, `grim -` for screenshots (pipe to a local file and view), `swaymsg
+seat - cursor` for input. Env: `XDG_RUNTIME_DIR=/run/user/1001
+WAYLAND_DISPLAY=wayland-1 SWAYSOCK=/run/user/1001/sway-ipc.1001.<pid>.sock`.
+
+### Steam library on SSD (/games)
+
+- Library was on `/mnt/tankshare` (tank-hdd virtiofs); Proton prefix creation
+  (thousands of small files) crawled for minutes. Repurposed the decommissioned
+  Longhorn disk (vdb, local-zfs SSD) into a **500 GB `/games`** library — grew
+  100→500 GB imperatively via `qm` on atlas, reusing the `virtio1` slot so
+  `/dev/vdb` doesn't rename.
+- **Stellaris** (native Linux) dies on `libselinux.so.1` in the SLR sandbox →
+  force Proton. First Proton launch then failed with `FileNotFoundError: …/
+tracked_files` — a **half-migrated prefix** (moving the game copied `pfx/` but
+  not `version`/`tracked_files`). Fix: `rm -rf compatdata/281990` and relaunch to
+  rebuild the prefix fresh (fast on SSD).
+
+### Monitor audio (DP passthrough)
+
+- The seat had **no audio path**: only the SPICE virtual sink (routes to the SPICE
+  console, muted). The display 5090's DP audio function wasn't passed through.
+- Fix: pass the **whole** display-GPU device. Host `03:00.0` had only its GPU
+  function passed; `03:00.1` (audio, same IOMMU group 16, already `vfio-pci`) was
+  not. Changed `hostpci1` from `0000:03:00.0` → `0000:03:00` (qm on atlas + TF).
+  Guest now sees `02:00.1` → ALSA "HDA NVidia" → PipeWire sink "GB202 … (HDMI)";
+  `wpctl set-default <sink>` routes audio to the FV43U's built-in speakers.
+  **Confirmed working.**
+- Gotcha: after a _forced_ VM stop, `qm start` failed once with `/dev/vfio/14:
+Device or resource busy` (compute-GPU IOMMU group not yet released) — just retry
+  `qm start` after a few seconds.
+
 ## Open questions
 
-- **Harden the session-teardown leak** (item 3) so re-logins stop colliding:
-  logind `KillUserProcesses` scoped to the seat-game session, or a session-exit
-  hook that reaps gamescope/Steam. Currently manual.
+- **Per-game lag** (open): Stellaris under Proton is an XWayland window in sway →
+  presentation-bound (~12% GPU, laggy despite the 5090). Fix not yet applied: add
+  `gamescope -f -- %command%` to the game's Steam launch options for direct
+  scan-out + frame pacing.
+- **Harden the session-teardown leak** so re-logins stop colliding: logind
+  `KillUserProcesses` scoped to the seat-game session, or a session-exit hook that
+  reaps the compositor/Steam. Currently manual (also bit the sway seat).
 - Is the spare USB A→B cable actually good? (First-port "cable is bad"
   errors vs. port flakiness — untested since the mux never engaged.)
 - Does the FV43U KVM binding survive monitor power cycles?

--- a/debug/atlas/direct_display_bringup.md
+++ b/debug/atlas/direct_display_bringup.md
@@ -372,6 +372,33 @@ Operation not permitted`. Set `programs.gamescope.enable = true; capSysNice = fa
 - Also: sway defaulted DP-4 to **4K@60** though the FV43U exposes a **4K@144** mode
   (`swaymsg -t get_outputs`) — worth pinning 144 in the sway output config.
 
+### Wind-down status (2026-07-04, end of session)
+
+**Working + verified:** sway on the display 5090 (seat-game); `/games` 500 GB SSD
+Steam library; monitor DP audio; Stellaris launches and runs under Proton.
+
+**The one thing left to verify — per-game gamescope for the lag:** the raw
+gamescope fix (`programs.gamescope.enable = true; capSysNice = false`) is
+**built and live on wyrm2** — `command -v gamescope` is the unwrapped binary, the
+`/run/wrappers/bin/gamescope` capSysNice wrapper is gone. What remains is purely
+the Steam-side step: set the launch option **in the Steam UI** (not over SSH —
+Steam Cloud reverts `localconfig.vdf` edits) to
+`gamescope -f --prefer-vk-device 10de:2b85 -- %command%`, launch fresh, and
+confirm `nvidia-smi --query-compute-apps` shows `stellaris.exe` on `02:00.0`
+(display GPU) instead of `01:00.0` (compute) — that kills the cross-GPU copy.
+Gotcha: `steam://rungameid` no-ops if the game is already running; stop it first.
+
+**Branches (all unmerged at wind-down):**
+
+- **#2891** `wyrm2-games-disk` — the `/games` SSD disk (nix + TF). Open PR.
+- **`wyrm2-sway-seat`** — stacked on #2891; carries the sway session, the audio
+  passthrough, grim, the raw-gamescope fix, and these notes. **No PR opened yet.**
+
+**Still to do (cleanup, not blocking):** strip the now-unused gamescope kiosk bits
+(`programs.steam.gamescopeSession`, the "Steam (debug)" + "Sway (debug)" sessions,
+`gdm.debug`); pin DP-4 to 4K@144 in the sway config; harden the session-teardown
+leak.
+
 ## Open questions
 
 - **Per-game lag** (root-caused, fix in progress): cross-GPU copy — see above.

--- a/debug/atlas/direct_display_bringup.md
+++ b/debug/atlas/direct_display_bringup.md
@@ -342,12 +342,41 @@ tracked_files` — a **half-migrated prefix** (moving the game copied `pfx/` but
 Device or resource busy` (compute-GPU IOMMU group not yet released) — just retry
   `qm start` after a few seconds.
 
+### Per-game lag = cross-GPU copy (root-caused)
+
+Stellaris felt like ~15 FPS on a 5090. Cause is **not** presentation overhead and
+**not** GPU power — it's the **two-identical-5090** topology:
+
+```text
+stellaris.exe  → GPU0 (01:00.0)  6.6 GiB   ← the COMPUTE 5090 (DXVK rendered here)
+sway/Xwayland/display → GPU1 (02:00.0)      ← the DISPLAY 5090 (monitor is on DP-4)
+```
+
+DXVK picks the first Vulkan device (GPU0, the compute card), but the monitor is
+on GPU1, so **every frame is copied GPU0→GPU1 over PCIe** — that copy is the
+bottleneck. Diagnose with `nvidia-smi --query-compute-apps=pid,process_name,gpu_bus_id,used_memory`
+(the game's `gpu_bus_id` should match the display GPU) and `nvidia-smi pmon`.
+
+Two identical GPUs give no clean per-app PCI selector (DXVK's `DXVK_FILTER_DEVICE_NAME`
+can't tell them apart; NVIDIA Vulkan has none either). The standard fix is
+**gamescope with `--prefer-vk-device`**, which pins render+display to one GPU:
+
+- Launch option: `gamescope -f --prefer-vk-device 10de:2b85 -- %command%`
+  (`--prefer-vk-device` mandatory — without it gamescope grabs the virtio GPU:
+  `radv/amdgpu: failed to initialize device` / `vdrm_device_connect failed`).
+- Needs a **raw** gamescope: the capSysNice-wrapped `/run/wrappers/bin/gamescope`
+  dies in Steam's `no_new_privs` sandbox with `failed to inherit capabilities:
+Operation not permitted`. Set `programs.gamescope.enable = true; capSysNice = false;`.
+- The option must be set in the **Steam UI** — Steam Cloud reverts `localconfig.vdf`
+  edits made over SSH.
+- Also: sway defaulted DP-4 to **4K@60** though the FV43U exposes a **4K@144** mode
+  (`swaymsg -t get_outputs`) — worth pinning 144 in the sway output config.
+
 ## Open questions
 
-- **Per-game lag** (open): Stellaris under Proton is an XWayland window in sway →
-  presentation-bound (~12% GPU, laggy despite the 5090). Fix not yet applied: add
-  `gamescope -f -- %command%` to the game's Steam launch options for direct
-  scan-out + frame pacing.
+- **Per-game lag** (root-caused, fix in progress): cross-GPU copy — see above.
+  Fix = raw gamescope (`capSysNice=false`) + `--prefer-vk-device 10de:2b85` launch
+  option to pin the game to the display GPU. Also bump DP-4 to 4K@144 in sway.
 - **Harden the session-teardown leak** so re-logins stop colliding: logind
   `KillUserProcesses` scoped to the seat-game session, or a session-exit hook that
   reaps the compositor/Steam. Currently manual (also bit the sway seat).

--- a/debug/atlas/direct_display_bringup.md
+++ b/debug/atlas/direct_display_bringup.md
@@ -399,11 +399,55 @@ Gotcha: `steam://rungameid` no-ops if the game is already running; stop it first
 `gdm.debug`); pin DP-4 to 4K@144 in the sway config; harden the session-teardown
 leak.
 
+### 2026-07-05 — gamescope abandoned; display moved to 01:00.0 instead
+
+Tried the gamescope launch option (`gamescope -f --prefer-vk-device 10de:2b85 --
+%command%`) live — **it did not help.** Confirmed why: `--prefer-vk-device` only
+takes `vendorID:deviceID`, and the two 5090s are identical (`10de:2b85`), so it
+cannot disambiguate them — it just grabs whichever Vulkan device enumerates first
+(the compute card, `01:00.0`), leaving the cross-PCIe copy in place. gamescope
+3.16.24 has **no PCI-bus selector**, and NVIDIA's proprietary Vulkan honors no
+per-app PCI device filter (Mesa's `MESA_VK_DEVICE_SELECT` layer isn't present /
+doesn't apply to the NVIDIA ICD). So there is **no software way to pin the game to
+a specific one of two identical GPUs** on this stack.
+
+**The actual fix (simpler, no gamescope): move the monitor to the GPU the game
+already renders on.** DXVK/Vulkan always picks the first-PCI device (`01:00.0`) and
+we can't change that — so instead make `01:00.0` the _display_ GPU. Then
+render==display==`01:00.0`, zero cross-PCIe copy, no compositor tricks.
+
+Steps taken (commit on `wyrm2-sway-seat`):
+
+- **Physical:** replug the FV43U DP cable from the `02:00.0` 5090 to the `01:00.0`
+  5090 (passthrough mapping unchanged; only which card the cable is in).
+- **Config swap** in `nix/nixos/hosts/wyrm2/default.nix`: `seat-game` udev pin
+  `02:00.0`→`01:00.0`; `mutter-device-ignore` `01:00.0`→`02:00.0` (now hide the
+  headless compute card, which is `02:00.0`); the "Steam/Sway (debug)"
+  `WLR_DRM_DEVICES` node `02:00.0`→`01:00.0`.
+- **Deploy:** `nixos-rebuild boot` + reboot (udev seat TAGs persist in the db, so a
+  live `switch` won't fully re-home the seat — reboot required).
+
+Post-reboot verification (all ✅): monitor connected on `card0-DP-1` (`01:00.0`);
+`udevadm info` shows `ID_SEAT=seat-game` on `card0`/`01:00.0` and gone from
+`02:00.0`; `loginctl seat-status seat-game` masters `card0`/`01:00.0`; greeter up
+on seat-game. (Transient gotcha: right after boot, `loginctl seat-status` briefly
+showed the _old_ card2 master — re-read a few seconds later for the settled view;
+`udevadm info` is authoritative immediately.)
+
+**Still to verify:** log into sway, launch Stellaris **plain (no gamescope launch
+option — remove it)**, confirm `nvidia-smi --query-compute-apps=pid,process_name,gpu_bus_id`
+shows `stellaris.exe` on `01:00.0` = the display GPU, with 5090-class FPS.
+
+**Now-vestigial:** the raw-gamescope block + `programs.steam.gamescopeSession`
+kiosk (and its `--prefer-vk-device` comment at ~L215, now describing the old
+ordering) are dead for the lag fix — fold into the deferred gamescope cleanup.
+
 ## Open questions
 
-- **Per-game lag** (root-caused, fix in progress): cross-GPU copy — see above.
-  Fix = raw gamescope (`capSysNice=false`) + `--prefer-vk-device 10de:2b85` launch
-  option to pin the game to the display GPU. Also bump DP-4 to 4K@144 in sway.
+- **Per-game lag** (root-caused, fix deployed 2026-07-05): cross-GPU copy — solved
+  by making `01:00.0` the display GPU (cable replug + seat/mutter/WLR pin swap) so
+  render==display. gamescope is _not_ the fix (can't pin one of two identical
+  GPUs). Final in-game FPS check still pending. Also bump DP-4 to 4K@144 in sway.
 - **Harden the session-teardown leak** so re-logins stop colliding: logind
   `KillUserProcesses` scoped to the seat-game session, or a session-exit hook that
   reaps the compositor/Steam. Currently manual (also bit the sway seat).

--- a/nix/home/hosts/wyrm2.nix
+++ b/nix/home/hosts/wyrm2.nix
@@ -71,6 +71,20 @@
     fi
   '';
 
+  # Sway config for the game seat (seat-game / 5090). The wrapped sway (with
+  # --unsupported-gpu for NVIDIA) and its greeter session come from the NixOS
+  # programs.sway module; package = null means "config only, reuse that sway".
+  # foot/wofi are installed system-wide via programs.sway.extraPackages.
+  wayland.windowManager.sway = {
+    enable = true;
+    package = null;
+    config = {
+      modifier = "Mod4";
+      terminal = "foot";
+      menu = "wofi --show drun";
+    };
+  };
+
   home.packages = [
     # TODO: Add syncthing tray (syncthing-gtk not in nixpkgs).
     # Options: gnomeExtensions.syncthing-indicator, gnomeExtensions.syncthing-toggle, qsyncthingtray

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -226,11 +226,20 @@ in
       "--force-composition"
     ];
   };
-  # Let gamescope renice itself for smoother frame pacing (the session UI felt
-  # laggy without it). The module installs the cap_sys_nice-wrapped gamescope at
-  # /run/wrappers/bin/gamescope; the steam-gamescope session script picks it up
-  # from PATH, and the steam module auto-adds the setuid bwrap wrapper this needs.
-  programs.gamescope.capSysNice = true;
+  # Expose a RAW gamescope in PATH for per-game use. On this 2-identical-5090 VM
+  # the game (DXVK) renders on the compute 5090 while the monitor is on the other
+  # 5090, so every frame is copied cross-PCIe → ~15 FPS. gamescope pins render +
+  # display to one GPU: Steam launch option
+  # `gamescope -f --prefer-vk-device 10de:2b85 -- %command%` (the device pin is
+  # mandatory or gamescope grabs the virtio GPU and dies).
+  # capSysNice is OFF on purpose: its setcap wrapper can't gain CAP_SYS_NICE in
+  # Steam's no_new_privs game-launch sandbox — gamescope dies with "failed to
+  # inherit capabilities". The unwrapped binary just runs (no realtime priority,
+  # which that sandbox denies anyway).
+  programs.gamescope = {
+    enable = true;
+    capSysNice = false;
+  };
   # Attempt at the native Steam Linux Runtime `libselinux.so.1` failure (Stellaris
   # dies: "mkdir: libselinux.so.1: cannot open shared object file"). Adds it to
   # the Steam FHS env. Only helps if the failing binary runs in the outer FHS,

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -263,7 +263,7 @@ in
           # Restrict wlroots/gamescope DRM discovery to the display 5090:
           # gamescope naively opens the first card node (card0 = the compute
           # GPU, owned by seat0) and dies when logind refuses it.
-          export WLR_DRM_DEVICES=/dev/dri/by-path/pci-0000:02:00.0-card
+          export WLR_DRM_DEVICES=/dev/dri/by-path/pci-0000:01:00.0-card
           exec steam-gamescope
         ''}
         Type=Application
@@ -315,24 +315,30 @@ in
   # keyboard/mouse.
   # Rules 2+3: multiseat for the direct-display gaming plan — see
   # debug/atlas/direct_display_bringup.md.
-  # - The display 5090 (guest 02:00.0 = hostpci1; DP cable to the FV43U)
+  # - The display 5090 (guest 01:00.0 = hostpci0; DP cable to the FV43U)
   #   belongs to logind seat "seat-game": GDM spawns a separate greeter
   #   there, independent of the seat0 SPICE desktop. Do NOT
   #   mutter-device-ignore this card — the seat-game greeter must use it.
-  # - The other 5090 (01:00.0, headless compute) stays on seat0 but is
+  #   Why 01:00.0 and not 02:00.0: DXVK/Vulkan renders on the first-PCI GPU
+  #   (01:00.0) by default, and the two 5090s are identical (same
+  #   vendor:device 10de:2b85) so no selector can pin the game to a specific
+  #   one. Putting the monitor on 01:00.0 makes render==display==01:00.0 →
+  #   no cross-PCIe copy per frame (that copy was the ~15 FPS lag). See
+  #   debug/atlas/direct_display_bringup.md.
+  # - The other 5090 (02:00.0, headless compute) stays on seat0 but is
   #   hidden from mutter: multi-GPU mutter with NVIDIA cards crash-looped
   #   (SIGSEGV) as primary and rendered black as copy target (2026-07-02).
   # Gotcha: udev TAGS persist in the udev db — removing/changing these
   # rules needs a VM reboot to fully take effect.
   services.udev.extraRules = ''
     KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", TAG+="uaccess"
-    SUBSYSTEM=="drm", KERNEL=="card[0-9]*", KERNELS=="0000:01:00.0", TAG+="mutter-device-ignore"
+    SUBSYSTEM=="drm", KERNEL=="card[0-9]*", KERNELS=="0000:02:00.0", TAG+="mutter-device-ignore"
   '';
   # seat-game device assignments must run at priority 72 — BEFORE systemd's
   # 73-seat-late.rules finalizes seat bookkeeping (extraRules lands in
   # 99-local.rules, which is too late: libinput saw ID_SEAT there but logind
   # denied TakeDevice to the seat-game greeter). Same slot loginctl-attach
-  # uses. Devices: the display 5090 (guest 02:00.0), and the TEX Shura
+  # uses. Devices: the display 5090 (guest 01:00.0), and the TEX Shura
   # (04d9:0532), which arrives via QEMU port-path passthrough ONLY when the
   # monitor's KVM routes its hub to USB-B — in this guest it is unambiguously
   # the seat-game keyboard. See debug/atlas/direct_display_bringup.md.
@@ -341,7 +347,7 @@ in
       name = "seat-game-udev-rules";
       destination = "/lib/udev/rules.d/72-seat-game.rules";
       text = ''
-        SUBSYSTEM=="drm", KERNEL=="card[0-9]*", KERNELS=="0000:02:00.0", ENV{ID_SEAT}="seat-game"
+        SUBSYSTEM=="drm", KERNEL=="card[0-9]*", KERNELS=="0000:01:00.0", ENV{ID_SEAT}="seat-game"
         # No KERNEL=="event*" filter: logind resolves an evdev node's seat via
         # its PARENT input-class device, so inputNN needs ID_SEAT too (event-
         # only assignment = libinput claims it but logind denies TakeDevice).

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -191,15 +191,12 @@ in
       swaylock
     ];
   };
-  # wlroots (sway) on seat-game must be restricted to the display 5090 (guest
-  # 02:00.0 = card2); otherwise it also probes the seat0-owned compute-5090 /
-  # virtio card nodes and dies on logind's TakeDevice denial (the same trap
-  # gamescope hit — but sway respects WLR_DRM_DEVICES). Global is safe: only
-  # wlroots reads these, and the seat0 GNOME desktop uses mutter.
-  environment.sessionVariables = {
-    WLR_NO_HARDWARE_CURSORS = "1";
-    WLR_DRM_DEVICES = "/dev/dri/by-path/pci-0000:02:00.0-card";
-  };
+  # NVIDIA: wlroots can't do hardware cursors on this path. GPU selection is left
+  # to the seat assignment — seat-game owns only card2 (the display 5090), so
+  # libseat hands sway the right device. (Don't set WLR_DRM_DEVICES to the
+  # by-path node: it's a colon-separated list, and the PCI address's colons make
+  # wlroots split it into garbage — "Found 0 GPUs".)
+  environment.sessionVariables.WLR_NO_HARDWARE_CURSORS = "1";
 
   # Steam — games run on the RTX 5090s (direct display via seat-game, or
   # streamed to atlas via Sunshine/Moonlight).
@@ -279,7 +276,6 @@ in
           id
           echo "seat=$XDG_SEAT vt=$XDG_VTNR session=$XDG_SESSION_ID"
           ls -l /dev/dri/by-path/
-          export WLR_DRM_DEVICES=/dev/dri/by-path/pci-0000:02:00.0-card
           export WLR_NO_HARDWARE_CURSORS=1
           exec sway -d
         ''}

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -6,7 +6,6 @@
   pkgs,
   lib,
   username,
-  inputs,
   ...
 }:
 let
@@ -152,33 +151,15 @@ in
     }
   ];
 
-  # gamescope 3.16.17 (nixpkgs 25.11) SIGABRTs on startup when a seat input
-  # event races wlserver_init's lock — upstream ValveSoftware/gamescope#1746,
-  # fixed in 3.16.24 by PR #2023 ("Lock wlserver while initializing wayland").
-  # Pull the fixed build from unstable until 25.11 catches up. Overriding the
-  # package-set attr covers the gamescopeSession, the capSysNice wrapper, and
-  # Steam in one place. CLEANUP: drop once nixpkgs 25.11 ships gamescope ≥3.16.24.
-  nixpkgs.overlays = [
-    (_: _: {
-      inherit
-        (import inputs.nixpkgs-unstable {
-          inherit (pkgs.stdenv.hostPlatform) system;
-          config.allowUnfree = true;
-        })
-        gamescope
-        ;
-    })
-  ];
-
   # Sway session for the game seat (seat-game, on the display 5090). A real WM to
   # game + debug from, run as agentydragon — non-GNOME, so it doesn't clash with
   # the seat0 SPICE GNOME session on the shared user bus (GNOME's fixed D-Bus
   # names are the reason a second GNOME can't run for one user; sway has none).
-  # Games get direct scan-out via per-title gamescope (Steam launch option
-  # `gamescope -f -- %command%`), not a gamescope kiosk session.
+  # Games run directly in this session (the display GPU is also the render GPU —
+  # see the programs.steam note below); no gamescope.
   # NVIDIA: --unsupported-gpu is mandatory; hardware cursors off (wlroots can't
-  # do them on this NVIDIA path). On seat-game logind hands sway only the 5090,
-  # so no manual WLR_DRM_DEVICES pinning is needed (unlike gamescope).
+  # do them on this NVIDIA path). On seat-game logind hands sway only the display
+  # 5090, so no manual WLR_DRM_DEVICES pinning is needed.
   programs.sway = {
     enable = true;
     wrapperFeatures.gtk = true;
@@ -194,7 +175,7 @@ in
     ];
   };
   # NVIDIA: wlroots can't do hardware cursors on this path. GPU selection is left
-  # to the seat assignment — seat-game owns only card2 (the display 5090), so
+  # to the seat assignment — seat-game owns only the display 5090 (01:00.0), so
   # libseat hands sway the right device. (Don't set WLR_DRM_DEVICES to the
   # by-path node: it's a colon-separated list, and the PCI address's colons make
   # wlroots split it into garbage — "Found 0 GPUs".)
@@ -202,76 +183,19 @@ in
 
   # Steam — games run on the RTX 5090s (direct display via seat-game, or
   # streamed to atlas via Sunshine/Moonlight).
+  # Games run directly in the sway session on seat-game (the display GPU is
+  # 01:00.0 = the same GPU DXVK renders on, so no gamescope GPU-pinning is
+  # needed — see debug/atlas/direct_display_bringup.md). No gamescope kiosk
+  # session: on this 2-identical-5090 box gamescope can't disambiguate the
+  # GPUs and its greeter session crashed opening the wrong (seat0-owned) card.
   programs.steam.enable = true;
-  # "Steam (gamescope)" session in the greeter — the intended session for
-  # seat-game: gamescope owns the display 5090's KMS directly (no desktop
-  # compositor between game and monitor).
-  programs.steam.gamescopeSession = {
-    enable = true;
-    # Device-selection quirk exploitation (gamescope 3.16.17,
-    # src/rendervulkan.cpp): gamescope picks the FIRST Vulkan device unless
-    # --prefer-vk-device matches, in which case the LAST matching device
-    # wins. Both 5090s match 10de:2b85, Vulkan enumerates in PCI order
-    # (01:00.0 compute, 02:00.0 display) → this selects 02:00.0, the
-    # display GPU, whose primary DRM node gamescope then opens for KMS
-    # (it derives the node from the Vulkan device; WLR_DRM_DEVICES is
-    # ignored). Without this it opens the seat0-owned compute card and
-    # dies on logind's TakeDevice denial.
-    args = [
-      "--prefer-vk-device"
-      "10de:2b85"
-      # NVIDIA direct scan-out produced flicker, corruption, and wrong
-      # colors (verified live 2026-07-03: `gamescopectl composite_force 1`
-      # fixed all three; gamescope-internal screenshots were always clean).
-      "--force-composition"
-    ];
-  };
-  # Expose a RAW gamescope in PATH for per-game use. On this 2-identical-5090 VM
-  # the game (DXVK) renders on the compute 5090 while the monitor is on the other
-  # 5090, so every frame is copied cross-PCIe → ~15 FPS. gamescope pins render +
-  # display to one GPU: Steam launch option
-  # `gamescope -f --prefer-vk-device 10de:2b85 -- %command%` (the device pin is
-  # mandatory or gamescope grabs the virtio GPU and dies).
-  # capSysNice is OFF on purpose: its setcap wrapper can't gain CAP_SYS_NICE in
-  # Steam's no_new_privs game-launch sandbox — gamescope dies with "failed to
-  # inherit capabilities". The unwrapped binary just runs (no realtime priority,
-  # which that sandbox denies anyway).
-  programs.gamescope = {
-    enable = true;
-    capSysNice = false;
-  };
   # Attempt at the native Steam Linux Runtime `libselinux.so.1` failure (Stellaris
   # dies: "mkdir: libselinux.so.1: cannot open shared object file"). Adds it to
   # the Steam FHS env. Only helps if the failing binary runs in the outer FHS,
   # not deep inside the pressure-vessel container — if a game still fails in the
   # SLR sandbox, force Proton on it instead.
   programs.steam.extraPackages = [ pkgs.libselinux ];
-  # Debug variant: same payload but with stdout/stderr + xtrace captured to
-  # /tmp/steam-session.log — the stock session dies silently under GDM
-  # (~60s, zero journal output). Remove once the session works.
   services.displayManager.sessionPackages = [
-    (
-      (pkgs.writeTextDir "share/wayland-sessions/steam-debug.desktop" ''
-        [Desktop Entry]
-        Name=Steam (debug)
-        Comment=steam-gamescope with logging to /tmp/steam-session.log
-        Exec=${pkgs.writeShellScript "steam-gamescope-debug" ''
-          exec > /tmp/steam-session.log 2>&1
-          set -x
-          date
-          id
-          # Restrict wlroots/gamescope DRM discovery to the display 5090:
-          # gamescope naively opens the first card node (card0 = the compute
-          # GPU, owned by seat0) and dies when logind refuses it.
-          export WLR_DRM_DEVICES=/dev/dri/by-path/pci-0000:01:00.0-card
-          exec steam-gamescope
-        ''}
-        Type=Application
-      '').overrideAttrs
-      (_: {
-        passthru.providedSessions = [ "steam-debug" ];
-      })
-    )
     # Debug variant of sway: logs sway -d output to /tmp/sway-session.log, since
     # a failed session Exec dies silently under GDM (~60s, zero journal output).
     # Remove once sway on the seat is confirmed working.

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -189,6 +189,8 @@ in
       wl-clipboard
       swayidle
       swaylock
+      grim # screenshots (wlroots)
+      slurp # region select for grim
     ];
   };
   # NVIDIA: wlroots can't do hardware cursors on this path. GPU selection is left

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -170,6 +170,29 @@ in
     })
   ];
 
+  # Sway session for the game seat (seat-game, on the display 5090). A real WM to
+  # game + debug from, run as agentydragon — non-GNOME, so it doesn't clash with
+  # the seat0 SPICE GNOME session on the shared user bus (GNOME's fixed D-Bus
+  # names are the reason a second GNOME can't run for one user; sway has none).
+  # Games get direct scan-out via per-title gamescope (Steam launch option
+  # `gamescope -f -- %command%`), not a gamescope kiosk session.
+  # NVIDIA: --unsupported-gpu is mandatory; hardware cursors off (wlroots can't
+  # do them on this NVIDIA path). On seat-game logind hands sway only the 5090,
+  # so no manual WLR_DRM_DEVICES pinning is needed (unlike gamescope).
+  programs.sway = {
+    enable = true;
+    wrapperFeatures.gtk = true;
+    extraOptions = [ "--unsupported-gpu" ];
+    extraPackages = with pkgs; [
+      foot
+      wofi
+      wl-clipboard
+      swayidle
+      swaylock
+    ];
+  };
+  environment.sessionVariables.WLR_NO_HARDWARE_CURSORS = "1";
+
   # Steam — games run on the RTX 5090s (direct display via seat-game, or
   # streamed to atlas via Sunshine/Moonlight).
   programs.steam.enable = true;

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -191,7 +191,15 @@ in
       swaylock
     ];
   };
-  environment.sessionVariables.WLR_NO_HARDWARE_CURSORS = "1";
+  # wlroots (sway) on seat-game must be restricted to the display 5090 (guest
+  # 02:00.0 = card2); otherwise it also probes the seat0-owned compute-5090 /
+  # virtio card nodes and dies on logind's TakeDevice denial (the same trap
+  # gamescope hit — but sway respects WLR_DRM_DEVICES). Global is safe: only
+  # wlroots reads these, and the seat0 GNOME desktop uses mutter.
+  environment.sessionVariables = {
+    WLR_NO_HARDWARE_CURSORS = "1";
+    WLR_DRM_DEVICES = "/dev/dri/by-path/pci-0000:02:00.0-card";
+  };
 
   # Steam — games run on the RTX 5090s (direct display via seat-game, or
   # streamed to atlas via Sunshine/Moonlight).
@@ -254,6 +262,31 @@ in
       '').overrideAttrs
       (_: {
         passthru.providedSessions = [ "steam-debug" ];
+      })
+    )
+    # Debug variant of sway: logs sway -d output to /tmp/sway-session.log, since
+    # a failed session Exec dies silently under GDM (~60s, zero journal output).
+    # Remove once sway on the seat is confirmed working.
+    (
+      (pkgs.writeTextDir "share/wayland-sessions/sway-debug.desktop" ''
+        [Desktop Entry]
+        Name=Sway (debug)
+        Comment=sway -d with logging to /tmp/sway-session.log
+        Exec=${pkgs.writeShellScript "sway-debug" ''
+          exec > /tmp/sway-session.log 2>&1
+          set -x
+          date
+          id
+          echo "seat=$XDG_SEAT vt=$XDG_VTNR session=$XDG_SESSION_ID"
+          ls -l /dev/dri/by-path/
+          export WLR_DRM_DEVICES=/dev/dri/by-path/pci-0000:02:00.0-card
+          export WLR_NO_HARDWARE_CURSORS=1
+          exec sway -d
+        ''}
+        Type=Application
+      '').overrideAttrs
+      (_: {
+        passthru.providedSessions = [ "sway-debug" ];
       })
     )
   ];


### PR DESCRIPTION
Pivots the wyrm2 gaming seat from a gamescope Big-Picture **kiosk** to a real **sway** WM on the display 5090 (seat-game, as agentydragon) — one you can debug from and launch games from normally. Full running notes: `debug/atlas/direct_display_bringup.md`.

## What's in here
- **Sway session** on the display 5090 (`programs.sway` + HM `wayland.windowManager.sway`, `package = null`). NVIDIA glue: `--unsupported-gpu`, `WLR_NO_HARDWARE_CURSORS=1`; GPU selection left to the seat assignment (no `WLR_DRM_DEVICES` — its colon-list splits the `by-path` PCI node into garbage and wedges the greeter). `foot`/`wofi`/`grim`/`slurp` for a usable + screenshottable seat.
- **DP audio passthrough** — pass the whole display-GPU device (`hostpci1: 0000:03:00.0` → `0000:03:00`) so the guest gets the audio function `02:00.1` → monitor speakers. (nix reference + TF; applied via `qm` on atlas.)
- **Raw gamescope for per-game GPU pinning** (`programs.gamescope.enable = true; capSysNice = false`) — the 2-identical-5090 topology makes DXVK render on the compute 5090 while the monitor's on the other → cross-PCIe copy → ~15 FPS. gamescope `--prefer-vk-device` pins both to the display GPU; the capSysNice setcap wrapper dies in Steam's `no_new_privs` sandbox, so we need the unwrapped binary.
- **Docs** — the whole bring-up: sway pivot + WLR gotcha, SSD library + Stellaris Proton/prefix fixes, DP audio, cross-GPU lag root-cause, and a wind-down status.

## Stacking / status
- **Stacked on #2891** (`wyrm2-games-disk`, the `/games` SSD library). Until #2891 merges this diff includes that commit; rebases clean after.
- **Pending verify:** the gamescope GPU-pin needs the Steam-UI launch option `gamescope -f --prefer-vk-device 10de:2b85 -- %command%` set + a fresh launch (Steam Cloud reverts SSH edits). Raw gamescope is already live on wyrm2.

## Follow-ups (not here)
Strip the now-unused gamescope kiosk bits (`programs.steam.gamescopeSession`, the "Steam (debug)"/"Sway (debug)" sessions, `gdm.debug`); pin DP-4 to 4K@144 in the sway config; harden the session-teardown leak.