### PR TITLE
cluster: Stage 2 control-plane reshuffle — etcd onto NVMe

### DIFF
--- a/cluster/docs/plans/ovh_storage_tiering.md
+++ b/cluster/docs/plans/ovh_storage_tiering.md
@@ -277,9 +277,13 @@ servers). Mounts self-describing; bulk on HDD.
 **system disk** (`/dev/sda`), not the big data disk, so an HDD control-plane is equivalent
 whichever KS-5 node holds it — while the largest data disk (`102453`, 3.6 TB) is left as a
 **worker** so it can attract the most local-path/bulk pods without control-plane resource/I-O
-contention. `103656` is chosen because it is the current etcd leader, so it doubles as the
-migration anchor (below) with no opening `move-leader` needed. This means the TF
-primary/bootstrap control-plane must move `102453` → `103656`: `primary_controlplane_ip` and
+contention. `103656` is chosen as the anchor (the KS-5 node that stays control-plane through
+the whole reshuffle and holds the final HDD etcd seat). **Note (verified 2026-07-05): the
+current etcd leader is `102453`, NOT `103656`** — so an **opening `talosctl etcd move-leader`
+(`102453` → `103656`) IS required** before the reshuffle (an earlier draft wrongly said none
+was needed). `102453` is slated for demotion, and no membership step may touch the leader, so
+leadership must move onto the anchor first. This also means the TF primary/bootstrap
+control-plane must move `102453` → `103656`: `primary_controlplane_ip` and
 the `talos_machine_bootstrap`/kubeconfig endpoints (`infrastructure.tf`) point at `102453`
 today, and `102453` sits in its own `kimsufi_cp_servers` map — reassign both to `103656` and
 demote `102453` into the worker set. (Bootstrap already ran; guard the endpoint change so it
@@ -338,10 +342,11 @@ data disk to `local-path-ovh-{hdd,ssd}`. Rules: **one etcd membership change at 
 wipe (R) is independent of etcd (which lives on the install disk).
 
 Anchor = `103656` (the KS-5 node that stays control-plane throughout and holds the final HDD
-etcd seat). It is the current leader, so no opening `move-leader` is needed — just confirm
-leadership is on `103656` and keep it there; no membership step ever touches the leader. Do the
-TF primary/bootstrap reassignment (`102453` → `103656`, see Final state) before promoting any
-KS-GAME node.
+etcd seat). The current leader is `102453` (verified 2026-07-05), so the reshuffle **opens with
+`talosctl etcd move-leader <102453-member-id> --to <103656>`** to put leadership on the anchor;
+confirm leadership is on `103656` and keep it there, since no membership step may touch the
+leader. Then do the TF primary/bootstrap reassignment (`102453` → `103656`, see Final state)
+before promoting any KS-GAME node.
 
 **G-losable** (before wiping each node `N`): list the local-path volumes pinned to `N` and
 confirm the only non-replicated ones are the pre-accepted disposable disks (rename rule 3):
@@ -365,6 +370,11 @@ re-pinned `local-path-ovh` (`tier=hdd`) `allowedTopologies` lands it on a KS-5 n
 
 Per-node order — each fenced by **G-all** + **G-losable** before and after:
 
+0. **Opening moves (non-destructive).** `talosctl etcd move-leader 102453 → 103656` so the
+   anchor holds leadership; verify G-etcd leader = `103656`. Then apply the TF
+   primary/bootstrap reassignment (`primary_controlplane_ip → 103656` + the
+   `talos_machine_bootstrap`/`talos_cluster_kubeconfig` `ignore_changes` guards) — its plan
+   must show `talos_machine_bootstrap` unchanged.
 1. **`ovh-ns104952` → SSD control-plane.** Verify re-clone sources (**G-cnpg**), cordon+drain.
    Wipe+rename NVMe#2 → `local-path-ovh-ssd` (R). Promote to control-plane → joins etcd
    (learner → voter). **Post:** **G-etcd** shows 4 healthy members incl. `104952`;

--- a/cluster/terraform/main/infrastructure.tf
+++ b/cluster/terraform/main/infrastructure.tf
@@ -23,7 +23,11 @@ locals {
   proxmox_gateway = "10.2.0.1"
 
   # Stable Talos endpoint used for post-bootstrap client configuration reads.
-  primary_controlplane_ip     = data.ovh_dedicated_server.kimsufi_cp["ovh-ns102453"].ip
+  # Stage 2 (OVH storage tiering): moved 102453 -> 103656, the KS-5 node that stays
+  # control-plane throughout the reshuffle, so 102453 can later be demoted to a worker
+  # without breaking this reference. The bootstrap/kubeconfig resources below
+  # ignore_changes on this so the repoint does NOT re-trigger a cluster bootstrap.
+  primary_controlplane_ip     = data.ovh_dedicated_server.kimsufi["ovh-ns103656"].ip
   kubeconfig_cluster_endpoint = "https://api.${var.cluster_domain}:6443"
 
   # Total expected node count (for health checks)
@@ -293,6 +297,14 @@ resource "talos_machine_bootstrap" "cluster" {
     talos_machine_configuration_apply.kimsufi,
     talos_machine_configuration_apply.kimsufi_cp,
   ]
+
+  # The cluster is already bootstrapped. Re-pointing primary_controlplane_ip
+  # (Stage 2 CP reshuffle) must NOT force this resource to re-run bootstrap against a
+  # new node — that would fail on an already-bootstrapped cluster. Bootstrap is a
+  # one-time event; ignore endpoint/node drift.
+  lifecycle {
+    ignore_changes = [endpoint, node]
+  }
 }
 
 # Generate kubeconfig
@@ -302,6 +314,12 @@ resource "talos_cluster_kubeconfig" "cluster" {
   node                 = local.primary_controlplane_ip
 
   depends_on = [talos_machine_bootstrap.cluster]
+
+  # As talos_machine_bootstrap: the kubeconfig is already generated; a primary-IP
+  # repoint should not churn it. Any live CP endpoint serves the same kubeconfig.
+  lifecycle {
+    ignore_changes = [endpoint, node]
+  }
 }
 
 # Generate talosconfig

--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -45,10 +45,13 @@ locals {
       storage_tier    = "hdd"
     }
     "ovh-ns104952" = {
-      service_name    = var.kimsufi_service_name_ks_game_0
-      hostname        = "ovh-ns104952"
-      nebula_ip       = "10.42.0.16"
-      role            = "worker"
+      service_name = var.kimsufi_service_name_ks_game_0
+      hostname     = "ovh-ns104952"
+      nebula_ip    = "10.42.0.16"
+      # Stage 2 (OVH storage tiering): promoted worker -> control-plane to move etcd
+      # onto NVMe. storage_tier stays "ssd" (keyed to hardware, not role).
+      role            = "controlplane"
+      apply_mode      = "staged_if_needing_reboot"
       install_disk    = "/dev/disk/by-id/nvme-INTEL_SSDPE2MX450G7_BTPF8256006P450RGN"
       data_disk_match = "disk.serial == 'BTPF8304019P450RGN'"
       zone            = "hil-ovh"

--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -34,10 +34,13 @@ locals {
       storage_tier = "hdd"
     }
     "ovh-ns103711" = {
-      service_name    = var.kimsufi_service_name_1
-      hostname        = "ovh-ns103711"
-      nebula_ip       = "10.42.0.14"
-      role            = "controlplane"
+      service_name = var.kimsufi_service_name_1
+      hostname     = "ovh-ns103711"
+      nebula_ip    = "10.42.0.14"
+      # Stage 2 (OVH storage tiering): demoted control-plane -> worker (etcd moves onto
+      # NVMe). Data disk (/dev/sdb, seaweedfs-data) is preserved by the config-only
+      # demotion; the mount rename to local-path-ovh-hdd is a separate partition pass.
+      role            = "worker"
       apply_mode      = "staged_if_needing_reboot"
       install_disk    = "/dev/sda"
       data_disk_match = "disk.dev_path == '/dev/sdb'"
@@ -58,14 +61,32 @@ locals {
       storage_tier    = "ssd"
     }
     "ovh-ns104963" = {
-      service_name    = var.kimsufi_service_name_ks_game_1
-      hostname        = "ovh-ns104963"
-      nebula_ip       = "10.42.0.17"
-      role            = "worker"
+      service_name = var.kimsufi_service_name_ks_game_1
+      hostname     = "ovh-ns104963"
+      nebula_ip    = "10.42.0.17"
+      # Stage 2 (OVH storage tiering): promoted worker -> control-plane (etcd onto NVMe),
+      # data-preserving. storage_tier stays "ssd".
+      role            = "controlplane"
+      apply_mode      = "staged_if_needing_reboot"
       install_disk    = "/dev/disk/by-id/nvme-INTEL_SSDPE2MX450G7_BTPF8256002V450RGN"
       data_disk_match = "disk.serial == 'BTPF8256009U450RGN'"
       zone            = "hil-ovh"
       storage_tier    = "ssd"
+    }
+    "ovh-ns102453" = {
+      service_name = var.kimsufi_service_name_cp0
+      hostname     = "ovh-ns102453"
+      nebula_ip    = "10.42.0.15"
+      # Stage 2 (OVH storage tiering): demoted control-plane -> worker (etcd onto NVMe).
+      # Moved from the former kimsufi_cp_servers (bootstrap-CP) map into kimsufi_servers so
+      # the role-aware config path applies a worker machine config. This node's data disk
+      # (/dev/sdb) is the biggest KS-5 disk — it becomes the primary HDD-bulk worker.
+      role            = "worker"
+      apply_mode      = "staged_if_needing_reboot"
+      install_disk    = "/dev/sda"
+      data_disk_match = "disk.dev_path == '/dev/sdb'"
+      zone            = "hil-ovh"
+      storage_tier    = "hdd"
     }
   }
   # Filter out unpurchased servers (empty service name)
@@ -73,18 +94,11 @@ locals {
     for k, v in local.kimsufi_servers : k => v if v.service_name != ""
   }
 
-  kimsufi_cp_servers = {
-    "ovh-ns102453" = {
-      service_name    = var.kimsufi_service_name_cp0
-      hostname        = "ovh-ns102453"
-      nebula_ip       = "10.42.0.15"
-      role            = "controlplane"
-      install_disk    = "/dev/sda"
-      data_disk_match = "disk.dev_path == '/dev/sdb'"
-      zone            = "hil-ovh"
-      storage_tier    = "hdd"
-    }
-  }
+  # Stage 2: emptied — the bootstrap CP (102453) was demoted into kimsufi_servers as a
+  # worker, and primary_controlplane_ip was repointed to 103656. Kept as an empty map so
+  # the kimsufi_cp_* resource shells (which for_each over active_kimsufi_cp_servers) reduce
+  # to zero instances rather than being deleted from the config.
+  kimsufi_cp_servers = {}
   active_kimsufi_cp_servers = {
     for k, v in local.kimsufi_cp_servers : k => v if v.service_name != ""
   }


### PR DESCRIPTION
## What

Moves etcd fsync onto the KS-GAME NVMe nodes via a rolling control-plane reshuffle
(OVH storage tiering, Stage 2). **Already applied to the live cluster** — this PR brings
the committed config in line with the applied state.

| Node | Change | Disk |
|------|--------|------|
| `ovh-ns104952` | worker → **control-plane** | NVMe |
| `ovh-ns104963` | worker → **control-plane** | NVMe |
| `ovh-ns103711` | control-plane → **worker** | HDD |
| `ovh-ns102453` | control-plane → **worker** | HDD |
| `ovh-ns103656` | control-plane (anchor, unchanged) | HDD |

**Final etcd = `{103656, 104952, 104963}`, leader `103656`** — quorum now formed by the two
NVMe nodes (the latency win; watch `ControlPlaneLeasePutLatency*` drop).

## How it was applied (all data-preserving)

- Promotions/demotions via **config-apply + reboot** — Talos accepts the `machine.type`
  change and the data disks (`/dev/sdb`, `seaweedfs-data`) were **never wiped**. Local-path
  PVCs (CNPG replicas, SeaweedFS volumes, grocy, etc.) survived every reboot.
- etcd handoffs via `etcd remove-member` (demotions) and learner→voter join (promotions),
  one member at a time, gated on health between each.
- `infrastructure.tf`: `primary_controlplane_ip` repointed `102453 → 103656` + `lifecycle
  { ignore_changes = [endpoint, node] }` on `talos_machine_bootstrap`/`talos_cluster_kubeconfig`
  so the repoint does **not** re-bootstrap.
- `102453` was moved out of the `kimsufi_cp_servers` bootstrap map into `kimsufi_servers`;
  applied via **`tofu state mv`** of its 7 resources so **no reprovision/`dd`** was triggered.

## Verified post-migration

Roles + taints correct (2 new workers have no CP taint), etcd 3-member healthy on NVMe,
SeaweedFS clean (no under-replication), all CNPG healthy, Forgejo write path healthy.

## Not in this PR (follow-up)

- **Partition/mount renames** (`seaweedfs-data` → `local-path-ovh-{hdd,ssd}`) — cosmetic;
  needs data-disk wipes (grocy backup+restore, SeaweedFS re-replication, flux `nodePathMap`).
- The pending `ks_game_nebula_mitigation` for the two new workers + the stale `pve_cp0` state reap.