### PR TITLE
ci(ansible-lint): mock community.general.flatpak{,_remote} modules

### DIFF
--- a/.ansible-lint.yaml
+++ b/.ansible-lint.yaml
@@ -33,6 +33,8 @@ mock_modules:
   - community.general.zfs
   - community.general.dconf
   - community.general.ufw
+  - community.general.flatpak
+  - community.general.flatpak_remote
   - community.docker.docker_container
   - community.docker.docker_compose_v2
   - ansible.posix.mount

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -8,10 +8,12 @@ on:
     branches: [main, devel]
     paths:
       - "ansible/**"
+      - ".ansible-lint.yaml"
       - ".github/workflows/ansible-lint.yml"
   pull_request:
     paths:
       - "ansible/**"
+      - ".ansible-lint.yaml"
       - ".github/workflows/ansible-lint.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Problem

The `ansible-lint` (full mode) workflow has been **red on devel** since the wyrm2/atlas moonlight commit (`6d27403a7`). It fails with a fatal, unskippable `syntax-check` error:

```
couldn't resolve module/action 'community.general.flatpak_remote'
ansible/atlas.yaml:113:7
```

## Root cause

That commit added `community.general.flatpak_remote` and `community.general.flatpak` tasks to `atlas.yaml` but didn't register them in the ansible-lint `mock_modules` list. This repo mocks **all** `community.general`/`community.docker` modules (`snap`, `zfs`, `dconf`, `ufw`, ...) because its ansible-lint setup doesn't reliably resolve the bundled collection — an unmocked module trips the fatal syntax-check rule.

## Fix

Add the two new flatpak modules to `mock_modules`, following the existing pattern.

## Verification

Reproduced the exact CI failure locally (ansible-core 2.21.1 / community.general 13.1.0 / ansible-lint 26.6.0), then confirmed the fix:

```
Passed: 0 failure(s), 4 warning(s) ... Rating: 5/5 star
```

The 4 remaining warnings are the same non-fatal `args[module]` warnings the already-mocked `snap`/`zfs` modules produce (empty mock param schema) — they do not fail CI.

BAZEL_TEST_INVOCATIONS=none: config-only change to ansible-lint mock list