### PR TITLE
docs(cluster): sync OVH tiering plan — etcd reshuffle done, rename remains

### DIFF
--- a/cluster/docs/plans/ovh_storage_tiering.md
+++ b/cluster/docs/plans/ovh_storage_tiering.md
@@ -1,19 +1,24 @@
-# Plan: etcd onto NVMe + data-disk mount rename (OVH storage tiering — Stage 2)
+# Plan: OVH data-disk mount rename (storage tiering — Stage 2 remainder)
 
-**Status: active — Stage 2 is the remaining work.** The tiering foundation is already in
-place: media-scoped StorageClasses (`local-path-ovh-{hdd,ssd}`, keyed to a
-`storage.allegedly.works/tier` node label), the SeaweedFS volume layer on `volumeTopology`
-(`hdd` 3× KS-5, `ssd` 2× KS-GAME; operator 1.0.30), **Forgejo git** on SSD, and both
-SSD-destined DBs — **`seaweedfs-filer-db`** and **`forgejo-db`** (all Case B moves) — cut
-over to the SSD tier. What's left is the one destructive piece the rest was sequenced
-around: moving **etcd onto NVMe** via a rolling
-Talos control-plane reshuffle, and renaming the OVH data-disk mounts off the legacy
-`/var/mnt/seaweedfs-data` path. Then an optional **Stage 3** (3rd NVMe box).
+**Status: active — the data-disk mount rename is the only remaining Stage 2 work.** The
+etcd-onto-NVMe control-plane reshuffle is **done**: the control plane is now
+`{103656, 104952, 104963}` (etcd on 2× KS-GAME NVMe + the KS-5 anchor `103656`), the leader
+sits on the anchor `103656`, and `102453`/`103711` are demoted to workers. The rest of the
+tiering foundation was already in place: media-scoped StorageClasses
+(`local-path-ovh-{hdd,ssd}`, keyed to a `storage.allegedly.works/tier` node label), the
+SeaweedFS volume layer on `volumeTopology` (`hdd` 3× KS-5, `ssd` 2× KS-GAME; operator 1.0.30),
+**Forgejo git** on SSD, and both SSD-destined DBs — **`seaweedfs-filer-db`** and **`forgejo-db`**
+— on the SSD tier.
+
+What's left is the destructive piece the reshuffle deliberately deferred: **renaming the OVH
+data-disk mounts off the legacy `/var/mnt/seaweedfs-data` path** to tier-named mounts, via a
+rolling one-node-at-a-time disk repartition. Then an optional **Stage 3** (3rd NVMe box).
 
 Reference material from the completed foundation work:
 <../lessons_learned/2026_07_04_seaweedfs_volumetopology_and_operator.md>,
 <../lessons_learned/2026_07_04_seaweedfs_stale_mount_cache_after_evacuation.md>,
-<../runbooks/seaweedfs_pvc_storageclass_migration.md> (reusable PVC storage-class migration).
+<../runbooks/seaweedfs_pvc_storageclass_migration.md> (reusable PVC storage-class migration),
+<../lessons_learned/2026_06_19_etcd_hdd_io_contention.md> (the etcd motivator, now resolved).
 
 ## Small independent cleanups
 
@@ -24,41 +29,40 @@ Reference material from the completed foundation work:
 ## Goal
 
 Split OVH node-local storage into media-scoped StorageClasses so fsync/latency-critical data
-(etcd, Forgejo git) sits on the KS-GAME NVMe, while bulk/append-heavy data (SeaweedFS blobs,
-most small Postgres DBs, logs, caches, VM disks) stays on the KS-5 HDDs. Motivated by slow
-Forgejo (SeaweedFS-over-FUSE on 7200rpm HDD) degrading the Haku dashboard, and by etcd HDD
-I/O contention (<../lessons_learned/2026_06_19_etcd_hdd_io_contention.md>). The storage side
-of this is done; **etcd on HDD is the last unaddressed motivator** — hence Stage 2.
+sits on the KS-GAME NVMe, while bulk/append-heavy data (SeaweedFS blobs, most small Postgres
+DBs, logs, caches, VM disks) stays on the KS-5 HDDs. The two original motivators are already
+addressed: slow Forgejo (SeaweedFS-over-FUSE on 7200rpm HDD) — Forgejo git is on SSD; and etcd
+HDD I/O contention — etcd is now on NVMe (control-plane reshuffle complete). The remaining
+rename is **naming/clarity**: the data disk is still a UserVolume named `seaweedfs-data` (a
+leftover from the SeaweedFS trial), with the general local-path-provisioner nested three levels
+down inside a mount named after one tenant. This pass renames the mount for the disk/tier.
 
-## Verified hardware + current usage (2026-07-03)
+## Verified hardware + current state (roles as of the completed reshuffle)
 
 Each OVH node has one XFS Talos UserVolume (`seaweedfs-data`) on its data disk, mounted at
 `/var/mnt/seaweedfs-data`, with the general local-path-provisioner nested at
-`.../local-path`. Whole-disk `df`:
+`.../local-path`. Whole-disk `df` (usage figures from 2026-07-03):
 
-| Node           | Box     | Role today    | Data disk      | Size    | Used    | Free    |
-| -------------- | ------- | ------------- | -------------- | ------- | ------- | ------- |
-| `ovh-ns102453` | KS-5    | control-plane | `/dev/sdb` HDD | 3.6 TiB | 205 GiB | 3.4 TiB |
-| `ovh-ns103656` | KS-5    | control-plane | `/dev/sdb` HDD | 1.8 TiB | 192 GiB | 1.6 TiB |
-| `ovh-ns103711` | KS-5    | control-plane | `/dev/sdb` HDD | 1.9 TiB | 77 GiB  | 1.8 TiB |
-| `ovh-ns104952` | KS-GAME | worker        | NVMe#2 SSD     | 419 GiB | 68 GiB  | 351 GiB |
-| `ovh-ns104963` | KS-GAME | worker        | NVMe#2 SSD     | 419 GiB | 59 GiB  | 360 GiB |
+| Node           | Box     | Role today                | etcd disk      | Data disk      | Size    | Used    | Free    |
+| -------------- | ------- | ------------------------- | -------------- | -------------- | ------- | ------- | ------- |
+| `ovh-ns103656` | KS-5    | control-plane (anchor)    | `/dev/sda` HDD | `/dev/sdb` HDD | 1.8 TiB | 192 GiB | 1.6 TiB |
+| `ovh-ns104952` | KS-GAME | control-plane             | NVMe#1 SSD     | NVMe#2 SSD     | 419 GiB | 68 GiB  | 351 GiB |
+| `ovh-ns104963` | KS-GAME | control-plane             | NVMe#1 SSD     | NVMe#2 SSD     | 419 GiB | 59 GiB  | 360 GiB |
+| `ovh-ns102453` | KS-5    | worker (3.6 TB HDD, bulk) | —              | `/dev/sdb` HDD | 3.6 TiB | 205 GiB | 3.4 TiB |
+| `ovh-ns103711` | KS-5    | worker                    | —              | `/dev/sdb` HDD | 1.9 TiB | 77 GiB  | 1.8 TiB |
 
 **Gotchas the earlier draft got wrong:**
 
 - **KS-5 disks are not uniform.** `102453` is a ~4 TB disk; the other two are ~2 TB.
 - **The etcd disk is separate** from the data disk above: etcd rides each control-plane's
-  **install disk** (`/dev/sda` on KS-5, NVMe#1 on KS-GAME), not `/var/mnt/seaweedfs-data`.
+  **install disk** (`/dev/sda` on KS-5, NVMe#1 on KS-GAME), not `/var/mnt/seaweedfs-data`. This
+  is why the mount rename (a data-disk repartition) is independent of etcd.
 - **SSD headroom is generous, not tight** (~350 GiB free on each KS-GAME node). What fills
-  the NVMe today is **movable bulk**, not hot DBs — per-PVC `du`:
+  the NVMe is **movable bulk**, not hot DBs — per-PVC `du`:
   - `104952`: `seaweedfs-volume-0` 40 GiB (SeaweedFS bulk, re-replicates), `gecko/gecko-root`
     1.9 GiB (VM, disposable); every actual Postgres DB there is <5 GiB and mostly <1 GiB.
   - `104963`: `agent-box/agent-box-root` 47 GiB (VM, disposable); everything else <0.7 GiB.
   - The combined small-CNPG footprint across both SSD nodes is only a few GiB.
-
-So the SSD is currently occupied by exactly the things this plan moves **off** it (one
-SeaweedFS bulk volume server + two VM root disks). Almost nothing on the NVMe today actually
-needs NVMe.
 
 **Reclaimable garbage:** several `Released`/orphaned local-path dirs still consume disk
 (duplicate `seaweedfs-volume-*` dirs, stale CNPG instance ordinals such as
@@ -75,10 +79,10 @@ deliberately:
 **SSD tier:**
 
 - **etcd** — the whole reason for the control-plane reshuffle. It is **not a PVC**, so no
-  StorageClass can place it: "etcd on SSD" means keeping the control plane on the KS-GAME
-  NVMe boxes (Stage 2). This is a hard requirement.
+  StorageClass places it: "etcd on SSD" means the control plane runs on the KS-GAME NVMe boxes,
+  which is now the case.
 - **Forgejo git** (SeaweedFS `ssd` volume group + `forgejo-git` RWX PVC), **`seaweedfs-filer-db`**,
-  and **`forgejo-db`** — all already on SSD (Case B complete).
+  and **`forgejo-db`** — all on SSD.
 
 **HDD tier (default — includes "most of the tiny Postgreses"):** all other CNPG DBs
 (`authentik`, `langfuse`, `atuin`, `airlock`, `litellm`, `props`, `paperless`, `plaid`,
@@ -87,31 +91,29 @@ deliberately:
 volume servers, Loki/Mimir/Tempo WAL+cache, Valkey caches, and VM root disks (`agent-box`,
 `gecko`, `codex`).
 
-## Tier enforcement (built — Stage 2 relies on it)
+## Tier enforcement (built — the rename relies on it)
 
 The `storage.allegedly.works/tier` node label (<../../terraform/main/ovh-nodes.tf>, a
 per-node `storage_tier` field) is keyed to the node's **actual data-disk hardware, not its
-role** — so it stays correct when a KS-GAME node is re-designated control-plane in Stage 2.
-Three StorageClasses (<../../k8s/local-path-provisioner/>) share one provisioner +
-nodePathMap and differ only by `allowedTopologies`, which ANDs
-`topology.kubernetes.io/zone=hil-ovh` (never lands on a non-OVH SSD node like wyrm2) with the
-tier label: `-hdd` → `tier=hdd`, `-ssd` → `tier=ssd`, and `local-path-ovh` → deprecated alias
-re-pinned to `-hdd`. Under `WaitForFirstConsumer` a mis-scheduled `-ssd` PVC stays **Pending
-(loud)** rather than silently landing on HDD.
-
-Two facts that matter for the Stage 2 reshuffle:
+role** — so it stayed correct when the KS-GAME nodes were promoted to control-plane. Three
+StorageClasses (<../../k8s/local-path-provisioner/>) share one provisioner + nodePathMap and
+differ only by `allowedTopologies`, which ANDs `topology.kubernetes.io/zone=hil-ovh` (never
+lands on a non-OVH SSD node like wyrm2) with the tier label: `-hdd` → `tier=hdd`, `-ssd` →
+`tier=ssd`, and `local-path-ovh` → deprecated alias re-pinned to `-hdd`. Under
+`WaitForFirstConsumer` a mis-scheduled `-ssd` PVC stays **Pending (loud)** rather than silently
+landing on HDD.
 
 - **No control-plane taint trap.** OVH control planes run `allowSchedulingOnControlPlanes =
-true` and carry no CP taint, so when the KS-GAME nodes are promoted they stay schedulable;
-  neither the SSD volume group nor SSD-pinned CNPG pods need a CP toleration.
+true` and carry no CP taint, so the promoted KS-GAME nodes stayed schedulable; neither the SSD
+  volume group nor SSD-pinned CNPG pods need a CP toleration.
 - **Guardrail:** `-disk` tags are unverified, so an alert fires if a SeaweedFS `ssd`
   volume-server pod is not on a `tier=ssd` node.
 
-The mount rename (below) is naming/clarity, **not** an enforcement layer: local-path's
-`nodePathMap` is keyed by node, not StorageClass, so a mis-scheduled pod would still provision
-at whatever path that node has.
+The mount rename is naming/clarity, **not** an enforcement layer: local-path's `nodePathMap` is
+keyed by node, not StorageClass, so a mis-scheduled pod would still provision at whatever path
+that node has.
 
-## SeaweedFS re-replication is manual (Stage 2 depends on this)
+## SeaweedFS re-replication is manual (the rename depends on this)
 
 SeaweedFS does **not** auto-re-replicate: neither the operator (the `Seaweed` CRD exposes no
 repair/heal field) nor the master self-heals under-replicated volumes. Restoring replica
@@ -127,14 +129,14 @@ printf 'lock\nvolume.fix.replication -apply\nunlock\n' | kubectl -n seaweedfs ex
 `volume.fix.replication -apply` fixes **one** missing replica per volume per run and needs a
 target server with a **free volume slot** (see the slot model below). So an _unplanned_
 volume-server/node loss leaves volumes at 1 copy until a human runs this. Every volume-server
-wipe in Stage 2 is therefore gated on **G-swfs** before (a source copy exists) and after
+wipe in the rename is therefore gated on **G-swfs** before (a source copy exists) and after
 (re-replication back to 2 completed via this command).
 
 The **`SeaweedFSReplicaPlacementMismatch`** alert
 (<../../k8s/seaweedfs/monitoring/prometheusrule.yaml>) surfaces under-replication so it
 doesn't lurk — it fires on `sum(SeaweedFS_master_replica_placement_mismatch) > 0`. Keep it
 **alert-only**, not auto-remediation, so node failures surface rather than being masked; if a
-scheduled `-apply` autoheal is ever added it must be **suspended during Stage 2** so
+scheduled `-apply` autoheal is ever added it must be **suspended during the rename** so
 re-replication stays deliberate and gated at G-swfs checkpoints.
 
 **Slot model** (why re-replication can stall): a volume server's capacity is a **volume-slot
@@ -142,7 +144,7 @@ count** (`-max=0` → disk size ÷ `volumeSizeLimitMB`, 16 GB here), not raw spa
 419 GB NVMe yields only ~24 slots. Re-replication needs a server with a **free slot**, so a
 slot-full server (`volume-0` at 24/24) cannot receive replicas even with disk free.
 
-**GOTCHA — refresh FUSE clients before deleting a volume server (Stage 2 retires and
+**GOTCHA — refresh FUSE clients before deleting a volume server (the rename retires and
 re-provisions volume-server nodes, so it must follow this).** `weed mount` clients cache
 volume locations and only re-resolve off an **alive** server's "volume not found"; a
 **deleted** server (DNS `no such host`) leaves the cache stale → I/O errors / SIGBUS on
@@ -166,17 +168,30 @@ tenant, three levels down. It's a leftover from the SeaweedFS trial.
 - KS-GAME: UserVolume `local-path-ovh-ssd` → `/var/mnt/local-path-ovh-ssd`
   (`diskSelector` on the NVMe serial)
 
+### Prerequisite — the per-node rename mechanism is not coded yet
+
+The current TF gives every node the **same** UserVolume `name = "seaweedfs-data"`
+(<../../terraform/main/ovh-nodes.tf>), and the `nodePathMap`
+(<../../k8s/local-path-provisioner/helmrelease.yaml>) points **all five** OVH nodes at
+`/var/mnt/seaweedfs-data/local-path`. Before any node can be renamed, both surfaces must be made
+**per-node**:
+
+1. Talos side: derive the UserVolume name from the node's `storage_tier`
+   (`local-path-ovh-${tier}`), gated by an **opt-in node set** (the `kimsufi_*_enabled_nodes`
+   idiom already in `ovh-nodes.tf`) so an empty set is a no-op and nodes flip one at a time.
+2. local-path side: change that node's `nodePathMap` entry to the new path in the same commit.
+
 ### Two change surfaces move together per node (gotcha)
 
-The rename touches **both** (a) the Talos `UserVolumeConfig` name in
-<../../terraform/main/ovh-nodes.tf> (renaming a UserVolume **repartitions/wipes** the disk)
-and (b) the local-path-provisioner `nodePathMap` in
-<../../k8s/local-path-provisioner/helmrelease.yaml> (Flux). If (a) renames a node's mount to
-`/var/mnt/local-path-ovh-hdd` but (b) still points that node at
-`/var/mnt/seaweedfs-data/local-path`, new PVCs land on the **root filesystem**. The
-`nodePathMap` is a single ConfigMap but has per-node entries, so per-node rollout is possible
-— but the "opt-in node set" idiom (rule 2) covers only the Talos side; each node's
-`nodePathMap` entry must be flipped in lockstep with its wipe.
+The rename touches **both** (a) the Talos `UserVolumeConfig` name in `ovh-nodes.tf` (renaming a
+UserVolume **repartitions/wipes** the disk) and (b) the local-path-provisioner `nodePathMap` in
+`helmrelease.yaml` (Flux). If (a) renames a node's mount to `/var/mnt/local-path-ovh-hdd` but
+(b) still points that node at `/var/mnt/seaweedfs-data/local-path`, new PVCs land on the **root
+filesystem**. The `nodePathMap` is a single ConfigMap but has per-node entries, so per-node
+rollout is possible — each node's `nodePathMap` entry must be flipped in lockstep with its wipe.
+The non-atomicity between the TF apply and the Flux reconcile is covered by the node being
+**cordoned+drained** during its wipe: nothing provisions a PVC on it until both surfaces are on
+the new path and it is uncordoned.
 
 ### Why the wipe is OK
 
@@ -190,10 +205,10 @@ SeaweedFS S3; Valkey is cache. So a **rolling, one-node-at-a-time wipe** is safe
    instances on the two KS-GAME nodes; wiping both loses them. Wipe one, wait for CNPG
    re-clone + SeaweedFS re-replication onto the survivor, then the next.
 2. **Do NOT apply via a blanket `bazel run //cluster:bootstrap`** — it hits all OVH nodes
-   together. Gate the rename per node with an opt-in node set (same idiom as
-   `kimsufi_eno1_peer_route_enabled_nodes` in `ovh-nodes.tf`): an empty set is a no-op; you
-   roll by adding one node at a time. Flip that node's `nodePathMap` entry (surface b) in the
-   same step.
+   together. Gate the rename per node with the opt-in node set (rule 1 of the mechanism above):
+   an empty set is a no-op; you roll by adding one node at a time. Flip that node's
+   `nodePathMap` entry (surface b) in the same step, and apply the Talos side with
+   `tofu apply -target=` for just that node.
 3. **Warn before wiping any single-copy disk.** These local-path PVCs are not replicated.
    They are pre-accepted as **disposable**, but the per-node preflight (**G-losable**) must
    **list them and halt for explicit acknowledgment**, and must **halt on any single-copy
@@ -207,47 +222,43 @@ SeaweedFS S3; Valkey is cache. So a **rolling, one-node-at-a-time wipe** is safe
 
 **CNPG `storage.storageClass` is effectively immutable** — the operator will not migrate
 existing PVCs, and the proven path (the repo's `cnpg_region_switch` skill / RUNBOOK) is a
-**clone-and-cutover**, not an in-place edit. So the two cases are handled very differently.
+**clone-and-cutover**, not an in-place edit. The two cases are handled differently.
 
 **Verified inventory (2026-07-03):** all HDD-destined OVH CNPG clusters are on
 `local-path-ovh` (the two SSD-migrated DBs, `seaweedfs-filer-db-ssd` and `forgejo-db-ssd`, are
 on `local-path-ovh-ssd` and stay put). Instance counts: mostly 2-instance, `study-casino-db` ×
 3, `wayback-archive-db` × **1**. Three HDD-destined clusters have _both_ instances on the two
-KS-GAME nodes (`airlock`, `atuin`, `langfuse`) — these ride Case A eviction during Stage 2.
+KS-GAME nodes (`airlock`, `atuin`, `langfuse`) — these ride Case A eviction when their KS-GAME
+node is drained for the data-disk rename.
 
 ### Case A — HDD-destined (nearly all): no class change, ride node-eviction
 
 `local-path-ovh` re-pins to `= -hdd`, so these keep their existing PVC/SC name — **no
-migration, no app repoint**. They only need to leave the KS-GAME nodes, which happens for free
-when those nodes drain in Stage 2: CNPG deletes the unschedulable PVC + pod and re-clones from
-the surviving instance via `pg_basebackup`, and the re-pinned SC's `tier=hdd`
-`allowedTopologies` **forces** the new PVC onto a KS-5 node. Gate: **G-cnpg** before (≥1
-healthy instance elsewhere as the re-clone source) and after (re-cloned instance `streaming`,
-caught up). Strictly one KS-GAME node at a time — the three both-on-KS-GAME clusters pass
-through a single-healthy-instance window, so never drain the second KS-GAME node until the
-first's re-clone is streaming.
+migration, no app repoint**. When a node holding an instance is cordoned+drained for its
+data-disk wipe, CNPG deletes the unschedulable PVC + pod and re-clones from the surviving
+instance via `pg_basebackup`, and the re-pinned SC's `tier=hdd` `allowedTopologies` **forces**
+the new PVC onto a KS-5 node. Gate: **G-cnpg** before (≥1 healthy instance elsewhere as the
+re-clone source) and after (re-cloned instance `streaming`, caught up). Strictly one KS-GAME
+node at a time — the three both-on-KS-GAME clusters pass through a single-healthy-instance
+window, so never drain the second KS-GAME node until the first's re-clone is streaming.
 
-### Case B — SSD-destined (`seaweedfs-filer-db`, `forgejo-db`): clone-and-cutover — done
+### Case B — SSD-destined (`seaweedfs-filer-db`, `forgejo-db`): done
 
-Both SSD-destined DBs are migrated (a real class change `local-path-ovh` →
-`local-path-ovh-ssd`, done via the **`cnpg_region_switch`** clone-and-cutover: streaming
-replica → promote → repoint app → delete source → declare app user via `initdb.owner`). They
-now sit on `local-path-ovh-ssd`, so the Stage 2 drains leave them in place rather than
-relocating them. No Case B work remains; the procedure lives in the runbook if another DB
-ever needs it.
+Both SSD-destined DBs already sit on `local-path-ovh-ssd` (migrated via the
+**`cnpg_region_switch`** clone-and-cutover), so the data-disk rename leaves them in place. The
+procedure lives in the runbook if another DB ever needs it.
 
 ### Pre-execution prep
 
 - **`wayback-archive-db`: scale 1 → 2 instances first** (make it HA like the others) so it
-  gains a re-clone source and rides Case A during the Stage-2 KS-GAME drain, instead of being
-  destroyed with its only node. Do this before Stage 2.
+  gains a re-clone source and rides Case A during its node's data-disk wipe, instead of being
+  destroyed with its only node. Do this before wiping its node.
 - Confirm every 2-instance cluster is `G-cnpg`-green before the roll; `study-casino-db` (3
-  instances across 4 to-be-wiped nodes) always keeps ≥1 healthy instance if steps stay
-  one-at-a-time.
+  instances) always keeps ≥1 healthy instance if steps stay one-at-a-time.
 
 See <../cnpg_conventions.md> and <../../skills/cnpg_region_switch/RUNBOOK.md>.
 
-## Execution plan
+## Execution plan — data-disk mount rename (rolling, node-by-node)
 
 ### Application discipline (every Terraform-applying step)
 
@@ -255,70 +266,18 @@ See <../cnpg_conventions.md> and <../../skills/cnpg_region_switch/RUNBOOK.md>.
 nodes at once. Each TF-applying step is: `tofu plan` against `cluster/terraform/main/` →
 **read the full diff** → apply only the intended addresses with **`tofu apply
 -target=<addr>`** (the same `-target` mechanism `bootstrap.py` uses) → re-plan to confirm the
-residual diff is empty or only what's expected. One concern at a time. Stage 2 per-node ops
-are targeted single-node applies, gated additionally by the opt-in node set (rule 2) so the
-plan surfaces only that node — reviewed before apply.
-
-### Final state (no new hardware — end of Stage 2)
-
-| Node           | Box     | Role                                     | etcd disk      | Data disk → mount                          | Holds                                                         |
-| -------------- | ------- | ---------------------------------------- | -------------- | ------------------------------------------ | ------------------------------------------------------------- |
-| `ovh-ns104952` | KS-GAME | **control-plane**                        | NVMe#1 **SSD** | NVMe#2 → `/var/mnt/local-path-ovh-ssd`     | SSD tier: SeaweedFS `ssd` vol (git), `forgejo-db`, `filer-db` |
-| `ovh-ns104963` | KS-GAME | **control-plane**                        | NVMe#1 **SSD** | NVMe#2 → `/var/mnt/local-path-ovh-ssd`     | SSD tier (peer copy)                                          |
-| `ovh-ns103656` | KS-5    | control-plane (3rd, HDD; primary/anchor) | `/dev/sda` HDD | `/dev/sdb` → `/var/mnt/local-path-ovh-hdd` | HDD bulk: SeaweedFS bulk vol + cold DBs/PVs                   |
-| `ovh-ns102453` | KS-5    | **worker** (3.6 TB HDD)                  | —              | `/dev/sdb` → `/var/mnt/local-path-ovh-hdd` | HDD bulk — biggest disk → most local-path/bulk pods           |
-| `ovh-ns103711` | KS-5    | **worker**                               | —              | `/dev/sdb` → `/var/mnt/local-path-ovh-hdd` | HDD bulk                                                      |
-
-etcd quorum = 2 NVMe + 1 HDD (commits gated by the two-NVMe majority; the HDD member lags
-harmlessly and occasionally leads — accepted). Forgejo git on `seaweedfs-ovh-ssd` (NVMe volume
-servers). Mounts self-describing; bulk on HDD.
-
-**The 3rd (HDD) control-plane is `103656`, not the big-disk `102453`.** etcd rides each CP's
-**system disk** (`/dev/sda`), not the big data disk, so an HDD control-plane is equivalent
-whichever KS-5 node holds it — while the largest data disk (`102453`, 3.6 TB) is left as a
-**worker** so it can attract the most local-path/bulk pods without control-plane resource/I-O
-contention. `103656` is chosen as the anchor (the KS-5 node that stays control-plane through
-the whole reshuffle and holds the final HDD etcd seat). **Note (verified 2026-07-05): the
-current etcd leader is `102453`, NOT `103656`** — so an **opening `talosctl etcd move-leader`
-(`102453` → `103656`) IS required** before the reshuffle (an earlier draft wrongly said none
-was needed). `102453` is slated for demotion, and no membership step may touch the leader, so
-leadership must move onto the anchor first. This also means the TF primary/bootstrap
-control-plane must move `102453` → `103656`: `primary_controlplane_ip` and
-the `talos_machine_bootstrap`/kubeconfig endpoints (`infrastructure.tf`) point at `102453`
-today, and `102453` sits in its own `kimsufi_cp_servers` map — reassign both to `103656` and
-demote `102453` into the worker set. (Bootstrap already ran; guard the endpoint change so it
-does not retrigger.)
-
-**etcd's neighbors on the KS-GAME NVMe#1 (accepted co-location).** On Talos the install disk's
-EPHEMERAL partition (`/var`) is one XFS filesystem, so etcd (`/var/lib/etcd`) shares that disk
-_and_ filesystem with containerd's image + snapshot store (`/var/lib/containerd`), disk-backed
-emptyDirs (`/var/lib/kubelet/...`; memory-medium emptyDirs are tmpfs, so they don't count),
-and pod/system logs (`/var/log`). etcd therefore contends with containerd and emptyDir I/O —
-but this is accepted:
-
-- On NVMe the contention is a different order of magnitude from the HDD problem we're fixing
-  (seek-bound p99 124–240 ms → sub-ms NVMe fsync even under concurrent I/O), so the move off
-  HDD already captures ~all the win.
-- A 2-NVMe box cannot fully isolate etcd's device queue — etcd always shares a physical device
-  with something (OS/containerd on NVMe#1, or the SSD blob store + DBs on NVMe#2). Keeping
-  etcd on **NVMe#1 is the better side**: NVMe#2's heaviest tenant is the SeaweedFS ssd volume
-  server (sustained blob writes), so NVMe#1 keeps etcd away from that, leaving only
-  containerd's bursty pulls + emptyDirs as neighbors, which NVMe absorbs.
-- Residual risk: these CPs are schedulable (`allowSchedulingOnControlPlanes=true`), so a
-  scratch-/image-heavy pod could land on a KS-GAME CP and pound NVMe#1. Mitigate by steering
-  heavy/emptyDir-heavy workloads onto the **HDD workers** — which is already the reason the
-  biggest-disk node (`102453`) is a worker. A dedicated `/var/lib/etcd` UserVolume carved from
-  NVMe#2 (filesystem isolation, not device isolation) is available if a benchmark ever shows
-  fsync contention, but it trades blob-store contention for containerd contention and is not
-  worth it up front.
+residual diff is empty or only what's expected. One node at a time, gated additionally by the
+opt-in node set (rule 2) so the plan surfaces only that node — reviewed before apply.
 
 ### Health gates (each destructive step is fenced by these)
 
-**G-all** = all of the below green; must hold before starting a stage and after each node op.
+**G-all** = all of the below green; must hold before wiping a node and after each node op.
 
 - **G-etcd** — `talosctl … etcd status` / `service etcd`: every member `HEALTH OK`, same DB
   revision/raft index, no alarms, no leader churn; `ControlPlaneLeasePutLatency*` not firing.
-  Change **one** etcd member at a time, only when the rest are green.
+  The rename touches only the data disk, not etcd, but keep etcd green as a tripwire: the two
+  control-plane data-disk wipes (`103656`, `104952`, `104963`) drain a CP node, and a wobbly
+  quorum during a drain is a stop signal.
 - **G-nodes** — `kubectl get nodes`: all `Ready` except the one intentionally cordoned.
 - **G-swfs** — from a master pod (commands on stdin — no `-c` flag), a dry-run
   `printf 'volume.fix.replication\n' | weed shell` returns **empty** (nothing
@@ -329,24 +288,10 @@ but this is accepted:
   instances `streaming`, lag ≈ 0. Gate every node wipe on: every CNPG cluster with an instance
   on that node has **≥1 healthy instance elsewhere** (re-clone source); after: the re-cloned
   instance is `streaming` and caught up.
-- **G-flux** — `flux get kustomizations` / `helmreleases` all `Ready`.
+- **G-flux** — `flux get kustomizations` / `helmreleases` all `Ready` (allowing for the
+  known-suspended services).
 - **G-public** — Gatus green + blackbox: `git.allegedly.works`, `auth.allegedly.works`
   reachable; a test `git clone` succeeds.
-
-### Stage 2 — mount rename + etcd onto NVMe (rolling, node-by-node)
-
-Two rolls interleaved per node: **(E)** move the etcd quorum from
-{`102453`, `103656`, `103711`} to {`103656`, `104952`, `104963`}, and **(R)** wipe+rename each
-data disk to `local-path-ovh-{hdd,ssd}`. Rules: **one etcd membership change at a time** with
-**G-etcd** green between each; **never wipe both KS-GAME at once** (**G-cnpg**); the data-disk
-wipe (R) is independent of etcd (which lives on the install disk).
-
-Anchor = `103656` (the KS-5 node that stays control-plane throughout and holds the final HDD
-etcd seat). The current leader is `102453` (verified 2026-07-05), so the reshuffle **opens with
-`talosctl etcd move-leader <102453-member-id> --to <103656>`** to put leadership on the anchor;
-confirm leadership is on `103656` and keep it there, since no membership step may touch the
-leader. Then do the TF primary/bootstrap reassignment (`102453` → `103656`, see Final state)
-before promoting any KS-GAME node.
 
 **G-losable** (before wiping each node `N`): list the local-path volumes pinned to `N` and
 confirm the only non-replicated ones are the pre-accepted disposable disks (rename rule 3):
@@ -364,39 +309,39 @@ kubectl get pv -o json | jq -r --arg n "$node" '
 Everything CNPG re-clones and every SeaweedFS volume re-replicates; Loki/Mimir/Tempo are
 S3-backed and Valkey is cache. Anything left that is **not** on the disposable list **halts the
 roll**. Otherwise print the disposable disks about to be destroyed and get an explicit ack.
-HDD-destined DBs (Case A above) need no pre-step — draining forces the re-clone, and the
-re-pinned `local-path-ovh` (`tier=hdd`) `allowedTopologies` lands it on a KS-5 node. Ensure
-`wayback-archive-db` is already 2-instance before draining its KS-GAME node.
+HDD-destined DBs (Case A) need no pre-step — draining forces the re-clone, and the re-pinned
+`local-path-ovh` (`tier=hdd`) `allowedTopologies` lands it on a KS-5 node. Ensure
+`wayback-archive-db` is already 2-instance before draining its node.
 
-Per-node order — each fenced by **G-all** + **G-losable** before and after:
+### Per-node roll
 
-0. **Opening moves (non-destructive).** `talosctl etcd move-leader 102453 → 103656` so the
-   anchor holds leadership; verify G-etcd leader = `103656`. Then apply the TF
-   primary/bootstrap reassignment (`primary_controlplane_ip → 103656` + the
-   `talos_machine_bootstrap`/`talos_cluster_kubeconfig` `ignore_changes` guards) — its plan
-   must show `talos_machine_bootstrap` unchanged.
-1. **`ovh-ns104952` → SSD control-plane.** Verify re-clone sources (**G-cnpg**), cordon+drain.
-   Wipe+rename NVMe#2 → `local-path-ovh-ssd` (R). Promote to control-plane → joins etcd
-   (learner → voter). **Post:** **G-etcd** shows 4 healthy members incl. `104952`;
-   **G-swfs**/**G-cnpg** re-replicated.
-2. **`ovh-ns103711` → worker.** One membership change: remove from etcd, reprovision as worker;
-   wipe+rename `/dev/sdb` → `local-path-ovh-hdd` (R). **Post:** **G-etcd** back to 3 {`102453`,
-   `103656`, `104952`}.
-3. **`ovh-ns104963` → SSD control-plane.** As step 1. **Post:** **G-etcd** 4 members incl.
-   `104963`.
-4. **`ovh-ns102453` → worker (big 3.6 TB HDD).** Membership change: remove from etcd,
-   reprovision as worker; drain its `/dev/sdb` local-path PVs, wipe+rename → `local-path-ovh-hdd`
-   (R). **Post:** **G-etcd** = target {`103656`, `104952`, `104963`}.
-5. **`ovh-ns103656` — data disk only.** Stays control-plane (anchor); do **not** touch its etcd
-   / `/dev/sda`. Drain its `/dev/sdb` local-path PVs, wipe+rename → `local-path-ovh-hdd` (R).
-   **Post:** **G-swfs**/**G-cnpg** green.
-6. **Finalize.** All SSD-destined DBs are already on `local-path-ovh-ssd` (Case B done), so no
-   DB moves are needed here — every other DB stays on HDD. Re-check Nebula lighthouse placement
-   now that `102453`/`103711` are workers (lighthouse role is per-node, not tied to k8s
-   control-plane role).
+Each node's data disk is wiped+renamed to `local-path-ovh-{hdd,ssd}` (surface a) with its
+`nodePathMap` entry flipped in lockstep (surface b), fenced by **G-all** + **G-losable** before
+and after. etcd is untouched (it lives on the install disk), so there is no membership change —
+but draining a control-plane node still moves its pods, so keep G-etcd green throughout.
 
-**Exit:** matches the Final-state table; watch `ControlPlaneLeasePutLatency*` drop as etcd
-fsync moves onto NVMe.
+Suggested order (least-risk first):
+
+1. **`ovh-ns103711` (KS-5 worker, HDD).** Cleanest first node: pure worker, no etcd, HDD tier.
+   Verify re-clone sources (**G-cnpg**) + SeaweedFS 2-copy (**G-swfs**), cordon+drain,
+   wipe+rename `/dev/sdb` → `local-path-ovh-hdd`. Proves the mechanism end-to-end on the
+   lowest-stakes node.
+2. **`ovh-ns102453` (KS-5 worker, 3.6 TB HDD, most bulk).** As step 1; more to drain +
+   re-replicate, so budget time for **G-swfs** to return to 2 copies.
+3. **`ovh-ns104952` (KS-GAME control-plane, NVMe#2 → SSD).** Never together with `104963`
+   (both hold KS-GAME CNPG instances). Wipe+rename NVMe#2 → `local-path-ovh-ssd`. etcd stays on
+   NVMe#1, untouched. **Post:** **G-etcd** still 3 healthy members; **G-swfs**/**G-cnpg**
+   re-replicated.
+4. **`ovh-ns104963` (KS-GAME control-plane, NVMe#2 → SSD).** Only after step 3's re-clones are
+   `streaming`. As step 3.
+5. **`ovh-ns103656` (KS-5 control-plane anchor, HDD).** Do **not** touch its etcd / `/dev/sda`.
+   Drain its `/dev/sdb` local-path PVs, wipe+rename → `local-path-ovh-hdd`.
+6. **Finalize.** All SSD-destined DBs are already on `local-path-ovh-ssd` — every other DB stays
+   on HDD, no DB moves here. Re-check Nebula lighthouse placement now that `102453`/`103711`
+   are workers (lighthouse role is per-node, not tied to k8s control-plane role).
+
+**Exit:** every OVH data disk mounted at `/var/mnt/local-path-ovh-{hdd,ssd}`, `nodePathMap`
+pointing there, and the `seaweedfs-data` UserVolume name retired.
 
 ### Stage 3 — third SSD node (optional, future)
 


### PR DESCRIPTION
The OVH storage-tiering Stage-2 plan described the etcd control-plane reshuffle as pending — including a "move-leader 102453 → 103656 opening move" — but that whole roll is **already complete and healthy on the live cluster**.

## Live-verified state (2026-07-05)

- Control plane: `{103656, 104952, 104963}`; `102453`/`103711` demoted to workers.
- etcd: 3-member quorum, 2 NVMe (`104952`, `104963`) + anchor `103656`; **leader on the anchor `103656`**; all members same raft index/term, no alarms, no learners.
- Applying #2904 executed the entire (E) roll. Data disks were explicitly preserved.

## What the rewrite does

Per the repo convention that plans are forward-looking (no "DONE" todos), the etcd reshuffle becomes completed foundation and the plan now covers only the remaining Stage-2 work — the **data-disk mount rename** (`/var/mnt/seaweedfs-data` → `local-path-ovh-{hdd,ssd}`):

- Flags that the **per-node rename mechanism isn't coded yet**: the UserVolume name is still a shared `seaweedfs-data` literal (`ovh-nodes.tf:316`) and all five `nodePathMap` entries still point at the old path. Both surfaces must be made per-node + opt-in-gated before any node can be renamed.
- Reduces the execution plan to the **rename-only** roll (etcd untouched — it lives on the install disk), with a least-risk suggested order: `103711` → `102453` → `104952` → `104963` → `103656`.
- Updates the hardware table roles to post-reshuffle reality.
- Keeps the still-needed reference (SeaweedFS manual re-replication, stale-mount gotcha, CNPG Case A, health gates, `G-losable`).

Docs-only.

BAZEL_TEST_INVOCATIONS=none: docs-only plan sync