### PR TITLE
wyrm2: sway seat fonts + waybar volume applet

### DIFF
--- a/nix/home/hosts/wyrm2.nix
+++ b/nix/home/hosts/wyrm2.nix
@@ -82,7 +82,62 @@
       modifier = "Mod4";
       terminal = "foot";
       menu = "wofi --show drun";
+      # Replace the built-in swaybar with waybar (below): it carries the volume
+      # applet and a larger font for the 4K panel.
+      bars = [ ];
+      startup = [ { command = "waybar"; } ];
+      keybindings = lib.mkOptionDefault {
+        "XF86AudioRaiseVolume" = "exec wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SINK@ 5%+";
+        "XF86AudioLowerVolume" = "exec wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-";
+        "XF86AudioMute" = "exec wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
+      };
     };
+  };
+
+  # Terminal font, ~40% over foot's 8pt default, for the 4K gaming-seat panel.
+  programs.foot = {
+    enable = true;
+    settings.main.font = "monospace:size=11";
+  };
+
+  # Bottom bar for the sway seat: workspaces + clock + a clickable/scrollable
+  # volume applet (scroll to adjust, click opens pavucontrol) + tray. Larger
+  # font to match the 4K panel. Plain-text labels (no nerd-font glyphs) so it
+  # renders without an icon-font dependency.
+  programs.waybar = {
+    enable = true;
+    settings.mainBar = {
+      layer = "top";
+      position = "bottom";
+      height = 30;
+      modules-left = [
+        "sway/workspaces"
+        "sway/mode"
+      ];
+      modules-center = [ "clock" ];
+      modules-right = [
+        "pulseaudio"
+        "tray"
+      ];
+      pulseaudio = {
+        format = "Vol {volume}%";
+        format-muted = "Vol muted";
+        scroll-step = 5;
+        on-click = "pavucontrol";
+      };
+      clock.format = "{:%a %d %b  %H:%M}";
+      tray.spacing = 8;
+    };
+    style = ''
+      * {
+        font-family: monospace;
+        font-size: 15px;
+      }
+      #pulseaudio,
+      #clock {
+        padding: 0 10px;
+      }
+    '';
   };
 
   home.packages = [
@@ -93,6 +148,7 @@
     pkgs.inkscape
     pkgs.kicad
     pkgs.openscad
+    pkgs.pavucontrol # GUI mixer opened by the waybar volume applet
     pkgs.psmisc
     # TODO: Add a GUI system monitor with graphs (psensor not in nixpkgs;
     # candidates: gnomeExtensions.vitals, gnomeExtensions.astra-monitor)

--- a/nix/home/hosts/wyrm2.nix
+++ b/nix/home/hosts/wyrm2.nix
@@ -123,6 +123,9 @@
         format = "Vol {volume}%";
         format-muted = "Vol muted";
         scroll-step = 5;
+        # Cap scroll at 100% — HDMI sinks default to full scale and PipeWire
+        # allows >100% (10000% = deafening), so never let the applet exceed it.
+        max-volume = 100;
         on-click = "pavucontrol";
       };
       clock.format = "{:%a %d %b  %H:%M}";


### PR DESCRIPTION
Declarative UI polish for the wyrm2 gaming seat (follow-up to #2903).

## Changes
- **`programs.foot`** — terminal font size 11 (~+40% over foot's 8pt default) for the 4K panel. Replaces an ad-hoc `~/.config/foot/foot.ini` that shouldn't have been hand-written.
- **waybar** replaces the built-in swaybar: workspaces + clock + a **volume applet** (`Vol N%`, scroll to adjust, click opens `pavucontrol`) + tray, at a larger font. `max-volume = 100` so scrolling can't exceed 100% (HDMI sinks default to full scale; PipeWire allows 10000% = deafening — this bit us live).
- **`pavucontrol`** added; **XF86Audio** raise/lower/mute keybindings via `wpctl`.

## Verified live on wyrm2
Rebuilt + reloaded; waybar renders with the volume applet, foot picked up the larger font, volume clamped to a sane level.

BAZEL_TEST_INVOCATIONS=none: nix-only config change