### PR TITLE
cluster(seaweedfs): overcommit HDD volume-slot count (maxVolumeCounts=300)

### DIFF
--- a/cluster/k8s/seaweedfs/cluster/seaweed.yaml
+++ b/cluster/k8s/seaweedfs/cluster/seaweed.yaml
@@ -119,6 +119,19 @@ spec:
       storageClassName: local-path-ovh-hdd
       metricsPort: 9325
       extraArgs: ["-disk=hdd"]
+      # Go read-only before the disk fills rather than trusting the slot cap —
+      # the real safety bound once maxVolumeCounts overcommits (mirrors the ssd group).
+      minFreeSpacePercent: 10
+      # Overcommit the volume-slot count (same rationale as the ssd group). -max=0
+      # auto-derives disk_size / volumeSizeLimitMB → only 112/113 slots on the 1.8 TiB
+      # servers, which sat at 112/112 (full) while volumes were ~5% full (~0.85 GB of a
+      # 16 GB cap). Thin volumes make over-committing ~free; disk-full is bounded by
+      # minFreeSpacePercent, not the slot cap. 300 > the ~163 distinct HDD volumes, so a
+      # single survivor can hold the full 2-copy set while a peer is repartitioned during
+      # the data-disk mount rename (cluster/docs/plans/ovh_storage_tiering.md) — no
+      # forced single-copy window — and 300 > the 3.6 TB node's auto 232, so no server is
+      # capped below its previous count.
+      maxVolumeCounts: 300
       nodeSelector:
         storage.allegedly.works/tier: hdd
       tolerations:


### PR DESCRIPTION
## Problem

The SeaweedFS HDD volume group leaves `-max` auto (`disk_size / volumeSizeLimitMB`), so the 1.8 TiB servers get only ~112 slots. Preflight for the upcoming data-disk mount rename found `hdd-2` (103656) at **112/112 — full**, while each volume was ~5% full (~0.85 GB of the 16 GB cap) on a disk that's ~5% used. The "0 free slots" is a worst-case bookkeeping fiction, not disk pressure, and it blocks re-replication onto that server.

Distribution was also lopsided: `hdd-0`→103711 109/113, `hdd-1`→102453 (3.6 TB) 105/**232**, `hdd-2`→103656 **112/112**.

## Fix

Mirror what the SSD group already does (`maxVolumeCounts: 50` + `minFreeSpacePercent: 10`): overcommit the slot count on the HDD group and rely on `minFreeSpacePercent` as the real safety bound.

- `maxVolumeCounts: 300` — thin volumes make over-committing ~free.
- `minFreeSpacePercent: 10` — server goes read-only at 90% disk (a loud, recoverable stop), so disk-full is bounded by real space, not the slot cap.

## Why 300

- `> ~163` distinct HDD volumes → a **single survivor can hold the full 2-copy set** while a peer's data disk is repartitioned during the mount rename, so there's **no forced single-copy window** (the concern the preflight surfaced).
- `> 232` (the 3.6 TB node's auto cap) → no server is capped below its previous count.

Supersedes the earlier `volumeSizeLimit` 30→16 GB workaround that chased slot count via volume size; that can optionally be raised back later now that `maxVolumeCounts` controls slots directly.

## Context

Preflight for `cluster/docs/plans/ovh_storage_tiering.md` Stage-2 (data-disk mount rename). Unblocks the SeaweedFS slot pressure; a `volume.vacuum` pass was run separately (negligible reclaim at threshold 0.3 — per-volume garbage is <30%).

BAZEL_TEST_INVOCATIONS=none: cluster manifest change (validated by cluster pre-commit)