### PR TITLE
[codex] fix oci-cache auth split for haku-ci mirror

### DIFF
--- a/cluster/k8s/haku-ci/README.md
+++ b/cluster/k8s/haku-ci/README.md
@@ -49,10 +49,11 @@ kubectl -n haku-ci exec deploy/haku-runner -c dind -- \
   docker -H tcp://127.0.0.1:2375 pull --platform=linux/amd64 catthehacker/ubuntu:act-latest
 ```
 
-If this regresses, check the job log first. The Docker Hub symptom before the 2026-07-05 fix
-was dockerd timing out against `https://registry-1.docker.io/v2/` after the mirror rejected a
-Docker schema2 child manifest; the owning fix is `oci-cache`'s Zot `http.compat:
-["docker2s2"]` setting.
+If this regresses, check the job log first. Two known failure signatures from 2026-07-05:
+`no basic auth credentials` against the `oci-cache` mirror means Zot auth is on the internal
+listener instead of only the public proxy; Docker Hub timeouts after a mirror rejection mean
+dockerd fell back to direct `https://registry-1.docker.io/v2/`. Schema2 child-manifest
+rejections are handled by `oci-cache`'s Zot `http.compat: ["docker2s2"]` setting.
 
 ## What's here
 

--- a/cluster/k8s/oci-cache/README.md
+++ b/cluster/k8s/oci-cache/README.md
@@ -7,15 +7,16 @@ allowlisting every registry CDN.
 
 ## Architecture
 
-| Concern            | Choice                                                                                                                                                                                                                                                                                                 |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Registry           | Zot (`ghcr.io/project-zot/zot-linux-amd64`, full image — needs the `sync` extension)                                                                                                                                                                                                                   |
-| Durable content    | SeaweedFS S3 `registry-cache` bucket (`seaweedfs/registry-cache-bucket/`) — manifests + blobs                                                                                                                                                                                                          |
-| Dedupe index       | `oci-cache-valkey` `RedisReplication` (Zot `cacheDriver: redis`, `remoteCache`)                                                                                                                                                                                                                        |
-| Local state        | none durable — only ephemeral upload staging on `emptyDir`, so the pod reschedules freely                                                                                                                                                                                                              |
-| Placement          | unpinned (soft-prefers OVH region to sit near SeaweedFS); Valkey on `seaweedfs-ovh` (HDD, networked)                                                                                                                                                                                                   |
-| S3 credentials     | `s3-identity-registry-cache` Secret (seaweedfs ns), Reflector-mirrored into `oci-cache`, injected as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`                                                                                                                                                       |
-| Exposure (phase 1) | ClusterIP, plain HTTP on `oci-cache.oci-cache.svc:80` (→ container 5000) — no public route, no auth. (Port 80 is for conventional addressing; a port-restricted egress policy must still allow the **backend** port 5000 — Cilium enforces egress on the translated targetPort, not the Service port.) |
+| Concern           | Choice                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Registry          | Zot (`ghcr.io/project-zot/zot-linux-amd64`, full image — needs the `sync` extension)                                                                                                                                                                                                                                                                                                                                        |
+| Durable content   | SeaweedFS S3 `registry-cache` bucket (`seaweedfs/registry-cache-bucket/`) — manifests + blobs                                                                                                                                                                                                                                                                                                                               |
+| Dedupe index      | `oci-cache-valkey` `RedisReplication` (Zot `cacheDriver: redis`, `remoteCache`)                                                                                                                                                                                                                                                                                                                                             |
+| Local state       | none durable — only ephemeral upload staging on `emptyDir`, so the pod reschedules freely                                                                                                                                                                                                                                                                                                                                   |
+| Placement         | unpinned (soft-prefers OVH region to sit near SeaweedFS); Valkey on `seaweedfs-ovh` (HDD, networked)                                                                                                                                                                                                                                                                                                                        |
+| S3 credentials    | `s3-identity-registry-cache` Secret (seaweedfs ns), Reflector-mirrored into `oci-cache`, injected as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`                                                                                                                                                                                                                                                                            |
+| Internal exposure | ClusterIP, plain HTTP on `oci-cache.oci-cache.svc:80` (→ Zot container 5000), no auth. This is intentional: dockerd's Docker Hub `--registry-mirror` probe does not attach Docker-config credentials for the mirror host. (Port 80 is for conventional addressing; a port-restricted egress policy must still allow the **backend** port 5000 — Cilium enforces egress on the translated targetPort, not the Service port.) |
+| Public exposure   | `https://oci-cache.allegedly.works` routes to the nginx `public-auth-proxy` sidecar on Service port 8080. The sidecar enforces the `puller-credential` htpasswd and then proxies to the unauthenticated in-pod Zot listener.                                                                                                                                                                                                |
 
 Upstreams are addressed **by path prefix** (Zot `sync` `stripPrefix`); the endpoint
 is plain HTTP on port 80, so clients need an `http://` endpoint / insecure-registry config:
@@ -60,15 +61,15 @@ everything else ages out and `gc` reclaims its blobs from S3. Tune `pulledWithin
 SeaweedFS bucket-lifecycle rule under Zot — deleting blobs out from under the registry
 corrupts manifests.
 
-## Phase 2 (not yet wired)
+## Node-level pull-through (not yet wired)
 
-The public, authenticated endpoint and node-level pull-through are deliberately deferred
-— nothing here depends on them, and Talos machine-config changes reboot nodes.
+The public authenticated endpoint is wired, but node-level pull-through is deliberately
+deferred because Talos machine-config changes reboot nodes.
 
-1. **Authenticated public endpoint** at `oci-cache.allegedly.works`. The gateway already
-   terminates `*.allegedly.works`, so this is an `HTTPRoute` to the `oci-cache` Service
-   plus Zot htpasswd auth. Generate the credential from the devshell and add it as a SOPS
-   Secret mounted at `/etc/zot/htpasswd`, with `http.auth.htpasswd.path` in `config.json`:
+1. **Public credential rotation**. Generate the credential from the devshell and update
+   `app/puller-credential.sops.yaml`; `htpasswd` is mounted into the nginx public-auth
+   sidecar, while `config.json` is reflected into haku-ci for clients that explicitly pull
+   from `oci-cache.allegedly.works`:
 
    ```bash
    htpasswd -nbBC 10 puller "$(openssl rand -base64 30)"   # -> puller:$2y$10$...
@@ -128,3 +129,8 @@ This path was last checked with haku-state's push-triggered `validate-state` wor
 the `docker2s2` fix. A manual `workflow_dispatch` proves the job can pass, but it does not
 replace a failed push status on the commit Forgejo shows in the branch badge; use a real
 push-triggered run when clearing red default-branch CI.
+
+If the dind log says `no basic auth credentials` for
+`http://oci-cache.oci-cache.svc.cluster.local/v2/...`, Zot auth has leaked back onto the
+internal listener. Keep auth on the public nginx sidecar only; dockerd cannot authenticate
+its automatic Docker Hub registry-mirror probe against an htpasswd-protected mirror.

--- a/cluster/k8s/oci-cache/app/config.json
+++ b/cluster/k8s/oci-cache/app/config.json
@@ -41,12 +41,7 @@
   "http": {
     "address": "0.0.0.0",
     "port": "5000",
-    "compat": ["docker2s2"],
-    "auth": {
-      "htpasswd": {
-        "path": "/etc/zot/htpasswd"
-      }
-    }
+    "compat": ["docker2s2"]
   },
   "log": {
     "level": "info"

--- a/cluster/k8s/oci-cache/app/deployment.yaml
+++ b/cluster/k8s/oci-cache/app/deployment.yaml
@@ -12,9 +12,9 @@ metadata:
       (/docker-hub, /ghcr, /quay, /k8s, /gcr). Durable content in the
       SeaweedFS registry-cache bucket (S3); dedupe index in the oci-cache-valkey
       RedisReplication. No PVC — the only local state is ephemeral upload
-      staging on emptyDir, so the pod reschedules freely. ClusterIP-only for
-      now; the authenticated public endpoint + Talos containerd mirrors are a
-      later phase (see README).
+      staging on emptyDir, so the pod reschedules freely. The in-cluster
+      Service is intentionally unauthenticated for Docker registry-mirror
+      compatibility; the public endpoint is authenticated by the nginx sidecar.
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
@@ -69,10 +69,8 @@ spec:
             limits:
               memory: 512Mi
               cpu: "1"
-          # TCP probes, not httpGet /v2/: with htpasswd auth enabled an
-          # unauthenticated GET /v2/ returns 401, which a plain httpGet probe
-          # (no credentials to send) would score as a failure and crashloop the
-          # pod. A TCP check confirms Zot is listening without exercising auth.
+          # TCP probe only confirms Zot is listening. Pull-through behavior is
+          # covered by the README smoke tests.
           readinessProbe:
             tcpSocket:
               port: http
@@ -85,24 +83,64 @@ spec:
             periodSeconds: 20
           securityContext:
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+        # Public basic-auth wrapper. Zot itself must stay unauthenticated on the
+        # in-cluster Service because dockerd's Docker Hub registry-mirror probe
+        # does not send client Docker-config credentials for the mirror host.
+        - name: public-auth-proxy
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          ports:
+            - name: public-auth
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: public-auth-config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+            - name: public-auth
+              mountPath: /etc/nginx/auth
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          readinessProbe:
+            tcpSocket:
+              port: public-auth
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: public-auth
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
+            capabilities:
+              drop: ["ALL"]
       volumes:
-        # Projected so config.json (ConfigMap) and htpasswd (puller-credential
-        # Secret) both land in /etc/zot — Zot's config references
-        # /etc/zot/htpasswd. Only the Secret's htpasswd key is projected (not its
-        # config.json client key, which is for the runner, not Zot).
         - name: config
-          projected:
-            sources:
-              - configMap:
-                  name: oci-cache-zot-config
-              - secret:
-                  name: puller-credential
-                  items:
-                    - key: htpasswd
-                      path: htpasswd
+          configMap:
+            name: oci-cache-zot-config
+        - name: public-auth-config
+          configMap:
+            name: oci-cache-public-auth-proxy
+        - name: public-auth
+          secret:
+            secretName: puller-credential
+            items:
+              - key: htpasswd
+                path: htpasswd
         - name: cache
           emptyDir:
             sizeLimit: 5Gi

--- a/cluster/k8s/oci-cache/app/httproute.yaml
+++ b/cluster/k8s/oci-cache/app/httproute.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     description: >-
       Authenticated public endpoint for the Zot pull-through cache. The
-      cluster-gateway already terminates TLS for *.allegedly.works, so this is
-      just a route to the oci-cache Service (:80 -> container :5000); Zot's
-      htpasswd auth (see config.json + the puller-credential Secret) gates it.
+      cluster-gateway terminates TLS for *.allegedly.works; this route targets
+      the nginx sidecar on Service port 8080, which enforces the
+      puller-credential htpasswd before proxying to Zot.
 spec:
   parentRefs:
     - name: cluster-gateway
@@ -18,4 +18,4 @@ spec:
   rules:
     - backendRefs:
         - name: oci-cache
-          port: 80
+          port: 8080

--- a/cluster/k8s/oci-cache/app/kustomization.yaml
+++ b/cluster/k8s/oci-cache/app/kustomization.yaml
@@ -11,6 +11,9 @@ configMapGenerator:
   - name: oci-cache-zot-config
     files:
       - config.json
+  - name: oci-cache-public-auth-proxy
+    files:
+      - public-auth-proxy.conf
 generatorOptions:
   # Stable name; the Deployment's reloader annotation restarts Zot on change.
   disableNameSuffixHash: true

--- a/cluster/k8s/oci-cache/app/public-auth-proxy.conf
+++ b/cluster/k8s/oci-cache/app/public-auth-proxy.conf
@@ -1,0 +1,23 @@
+server {
+    listen 8080;
+    server_name _;
+
+    client_max_body_size 0;
+
+    auth_basic "oci-cache";
+    auth_basic_user_file /etc/nginx/auth/htpasswd;
+
+    location / {
+        proxy_pass http://127.0.0.1:5000;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 900s;
+        proxy_send_timeout 900s;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Docker-Distribution-Api-Version registry/2.0;
+    }
+}

--- a/cluster/k8s/oci-cache/app/puller-credential.sops.yaml
+++ b/cluster/k8s/oci-cache/app/puller-credential.sops.yaml
@@ -4,7 +4,7 @@ metadata:
     name: puller-credential
     namespace: oci-cache
     annotations:
-        description: Puller credential for the authenticated oci-cache endpoint (oci-cache.allegedly.works). `htpasswd` is mounted into Zot at /etc/zot/htpasswd (bcrypt line for user `puller`); `config.json` is a docker config (base64 of `puller:<password>`) that Reflector mirrors into haku-ci, where the runner exposes it as DOCKER_CONFIG so Bazel rules_oci authenticates when pulling base images through the cache.
+        description: Puller credential for the authenticated oci-cache endpoint (oci-cache.allegedly.works). `htpasswd` is mounted into the public nginx auth proxy (bcrypt line for user `puller`); `config.json` is a docker config (base64 of `puller:<password>`) that Reflector mirrors into haku-ci, where the runner exposes it as DOCKER_CONFIG so Bazel rules_oci authenticates when pulling base images through the cache.
         reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
         reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: haku-ci
         reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"

--- a/cluster/k8s/oci-cache/app/service.yaml
+++ b/cluster/k8s/oci-cache/app/service.yaml
@@ -19,3 +19,10 @@ spec:
       port: 80
       targetPort: http
       protocol: TCP
+    # Authenticated public entrypoint. The HTTPRoute for
+    # oci-cache.allegedly.works targets this port; in-cluster Docker mirrors
+    # must use the unauthenticated `http` port above.
+    - name: public-auth
+      port: 8080
+      targetPort: public-auth
+      protocol: TCP


### PR DESCRIPTION
## Summary

- keep Zot unauthenticated on the in-cluster `oci-cache` Service so dockerd `--registry-mirror` can use it
- move public `oci-cache.allegedly.works` basic auth to an nginx sidecar that uses the existing `puller-credential` htpasswd
- document the failure signature in `oci-cache` and `haku-ci` docs

## Root Cause

Docker Engine sends the Docker Hub pull to its configured registry mirror, but it does not attach the job container Docker config credentials for the mirror host. Once Zot global htpasswd auth was enabled, haku-ci dind got `no basic auth credentials`, abandoned the mirror, and then timed out against direct Docker Hub.

## Live Verification

- applied the non-secret manifests live without touching the SOPS Secret
- `oci-cache` pod rolled out as `2/2 Running`
- internal `http://oci-cache/v2/` returns `200` without auth
- public `https://oci-cache.allegedly.works/v2/` returns `401` without auth and `200` with the puller credential
- haku-ci dind successfully pulled `catthehacker/ubuntu:act-latest` through the mirror, digest `sha256:8a141fe91b8afc03c793085c8fcc6bba93f5dd9ce6fde7680f4651fd7f3aa827`
- dispatched haku-state `validate-state` task 479 succeeded on `73449ef`

## Checks

- `jq . cluster/k8s/oci-cache/app/config.json`
- `git diff --check`
- `kubectl kustomize cluster/k8s/oci-cache/app`
- commit hooks: prettier, markdownlint, kubeconform, ducktape hooks
