### PR TITLE
cluster: finish etcd reshuffle wiring — mesh roles, etcd scrape, api DNS

### DIFF
--- a/cluster/k8s/monitoring/etcd/endpoints.yaml
+++ b/cluster/k8s/monitoring/etcd/endpoints.yaml
@@ -31,13 +31,13 @@ endpoints:
     nodeName: ovh-ns103656
     conditions:
       ready: true
-  - addresses: ["10.42.0.14"]
-    hostname: ovh-ns103711
-    nodeName: ovh-ns103711
+  - addresses: ["10.42.0.16"]
+    hostname: ovh-ns104952
+    nodeName: ovh-ns104952
     conditions:
       ready: true
-  - addresses: ["10.42.0.15"]
-    hostname: ovh-ns102453
-    nodeName: ovh-ns102453
+  - addresses: ["10.42.0.17"]
+    hostname: ovh-ns104963
+    nodeName: ovh-ns104963
     conditions:
       ready: true

--- a/nebula-mesh.json
+++ b/nebula-mesh.json
@@ -13,7 +13,7 @@
     "ovh-ns103711": {
       "nebula_ip": "10.42.0.14",
       "endpoint": "147.135.39.176:4242",
-      "role": "control-plane",
+      "role": "worker",
       "lighthouse": true,
       "relay": true,
       "managed_by": "tofu-ovh",
@@ -22,7 +22,7 @@
     "ovh-ns104952": {
       "nebula_ip": "10.42.0.16",
       "endpoint": "147.135.104.5:4242",
-      "role": "worker",
+      "role": "control-plane",
       "lighthouse": true,
       "relay": true,
       "managed_by": "tofu-ovh",
@@ -31,7 +31,7 @@
     "ovh-ns104963": {
       "nebula_ip": "10.42.0.17",
       "endpoint": "147.135.104.16:4242",
-      "role": "worker",
+      "role": "control-plane",
       "lighthouse": true,
       "relay": true,
       "managed_by": "tofu-ovh",
@@ -40,7 +40,7 @@
     "ovh-ns102453": {
       "nebula_ip": "10.42.0.15",
       "endpoint": "147.135.37.175:4242",
-      "role": "control-plane",
+      "role": "worker",
       "lighthouse": true,
       "relay": true,
       "managed_by": "tofu-ovh",

--- a/tf/gitops/dns-records/main.tf
+++ b/tf/gitops/dns-records/main.tf
@@ -29,15 +29,15 @@ locals {
     "147.135.104.16", # ovh-ns104963 (formerly talos-ks-game-worker-1)
   ]
 
-  # Kubernetes API endpoints — every control-plane node, not just the ones whose
-  # Cilium gateway is healthy. The apiserver listens on the host directly so it
-  # is independent of L2-announce state: `ovh-ns103711` (`.176`) is dropped from
-  # `public_gateway_ips` above for gateway-RST reasons but still serves the API
-  # on :6443.
+  # Kubernetes API endpoints — every control-plane node. The apiserver listens on
+  # the host directly on :6443, independent of Cilium gateway/L2-announce state.
+  # Post Stage-2 etcd reshuffle (cluster/docs/plans/ovh_storage_tiering.md) the
+  # control plane is 103656 (KS-5 anchor) + the two KS-GAME NVMe nodes; 102453 and
+  # 103711 were demoted to workers and no longer serve the API.
   kube_api_ips = [
-    "147.135.37.175", # ovh-ns102453 (formerly talos-kimsufi-cp-0)
-    "147.135.39.162", # ovh-ns103656 (formerly talos-kimsufi-worker-0)
-    "147.135.39.176", # ovh-ns103711 (formerly talos-kimsufi-worker-1)
+    "147.135.39.162", # ovh-ns103656
+    "147.135.104.5",  # ovh-ns104952
+    "147.135.104.16", # ovh-ns104963
   ]
 }
 


### PR DESCRIPTION
## Why (red devel)

`test_nebula_mesh` and `test_dns_records` are failing on devel. The Stage-2 control-plane reshuffle (#2904) flipped the Terraform node roles to CPs **{103656, 104952, 104963}** but left three downstream rosters pinned to the old CP set **{103656, 103711, 102453}**. These aren't just test nits — two are live operational bugs:

| Source | Was | Impact |
|--------|-----|--------|
| `nebula-mesh.json` roles | old CPs | metadata drift the validation test enforces |
| `cluster/k8s/monitoring/etcd/endpoints.yaml` | scraping 102453/103711 | **etcd metrics scraped from nodes that no longer run etcd** — the `ControlPlaneLeasePutLatency` alerts (our G-etcd tripwire) pointed at the wrong nodes |
| `tf/gitops/dns-records` `kube_api_ips` | 102453/103711 + 103656 | **`api.allegedly.works` resolved 2/3 A records to workers with no apiserver on :6443** |

## Fix

Align all three to the actual post-reshuffle control plane:
- mesh: 104952/104963 → `control-plane`, 102453/103711 → `worker` (lighthouse/relay/cert_groups untouched — they're per-node, not role-tied)
- etcd scrape endpoints → the two NVMe CPs + anchor
- `kube_api_ips` → new CP public IPs

All 12 `//cluster/validation:*` tests pass locally.

Unblocks devel and the cluster PRs behind it (#2909, #2911).

BAZEL_TEST_INVOCATIONS=none: config/roster alignment (validated by cluster/validation)