### PR TITLE
cluster/tf: per-node data-disk mount rename mechanism (opt-in, no-op default)

### DIFF
--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -304,6 +304,16 @@ locals {
     if v.role == "controlplane"
   }
 
+  # Data-disk mount rename (OVH storage tiering — cluster/docs/plans/ovh_storage_tiering.md).
+  # Renaming a UserVolume repartitions/WIPES the disk, so roll it one node at a time: add a node
+  # here (empty set = no-op; every node keeps the legacy `seaweedfs-data` name) AND flip that
+  # node's nodePathMap entry in cluster/k8s/local-path-provisioner/helmrelease.yaml in the SAME
+  # commit, then `tofu apply -target=` for just that node under the plan's health gates
+  # (G-all + G-losable) — never a blanket bootstrap. A renamed node gets a tier-named UserVolume
+  # `local-path-ovh-${storage_tier}` mounted at `/var/mnt/local-path-ovh-${tier}`; its
+  # nodePathMap path becomes `/var/mnt/local-path-ovh-${tier}/local-path`. First node: 103711.
+  data_disk_mount_renamed_nodes = toset([])
+
   # Per-node user-volume patches. KS-5 nodes expose /dev/sdb; KS-GAME nodes
   # expose a second NVMe. Both are mounted at the same path so local-path-ovh
   # can use OVH-local capacity uniformly.
@@ -313,7 +323,7 @@ locals {
       yamlencode({
         apiVersion = "v1alpha1"
         kind       = "UserVolumeConfig"
-        name       = "seaweedfs-data"
+        name       = contains(local.data_disk_mount_renamed_nodes, k) ? "local-path-ovh-${v.storage_tier}" : "seaweedfs-data"
         volumeType = "disk"
         provisioning = {
           diskSelector = {


### PR DESCRIPTION
Builds the mechanism for the OVH data-disk mount rename (`/var/mnt/seaweedfs-data` → `local-path-ovh-{hdd,ssd}`), the last remaining Stage-2 work in `cluster/docs/plans/ovh_storage_tiering.md`.

## What it does

Makes the `UserVolumeConfig` name per-node instead of the shared `seaweedfs-data` literal:

```hcl
name = contains(local.data_disk_mount_renamed_nodes, k) ? "local-path-ovh-${v.storage_tier}" : "seaweedfs-data"
```

with an opt-in set `data_disk_mount_renamed_nodes` (mirrors the existing `kimsufi_eno1_peer_route_enabled_nodes` idiom).

## Safe to merge — no-op by default

The set is empty, so `contains()` is always false → `name` resolves to `"seaweedfs-data"` for every node, byte-identical to today. **`tofu plan` shows no diff.** Renaming a UserVolume repartitions/WIPES the disk, so nothing destructive happens until a node is deliberately opted in.

## Rolling the first node (103711) — the deliberate follow-up

Two hunks in one commit, then `tofu apply -target` for just that node under the health gates (G-all + G-losable, including the down→backup→restore of the three single-copy PVCs):

```hcl
# cluster/terraform/main/ovh-nodes.tf
data_disk_mount_renamed_nodes = toset(["ovh-ns103711"])
```

```yaml
# cluster/k8s/local-path-provisioner/helmrelease.yaml
      - node: ovh-ns103711
        paths:
-         - /var/mnt/seaweedfs-data/local-path
+         - /var/mnt/local-path-ovh-hdd/local-path
```

(`103711` is `storage_tier = hdd`, so it renders `local-path-ovh-hdd`, mounted at `/var/mnt/local-path-ovh-hdd`; the `nodePathMap` keeps the nested `/local-path` subdir.)

BAZEL_TEST_INVOCATIONS=none: TF mechanism, empty opt-in set = no apply-time change