### PR TITLE
haku-ci: drop the oci-auth DOCKER_CONFIG injection (fixes docker login)

### DIFF
--- a/cluster/k8s/haku-ci/config.yaml
+++ b/cluster/k8s/haku-ci/config.yaml
@@ -79,14 +79,25 @@ container:
     -e NODE_EXTRA_CA_CERTS=/egress-proxy-ca/ca-certificates.crt
     -v /egress-proxy-ca/ca-certificates.crt:/egress-proxy-ca/ca-certificates.crt:ro
     -v /egress-proxy-ca/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
-    -e DOCKER_CONFIG=/etc/oci-auth
-    -v /etc/oci-auth/config.json:/etc/oci-auth/config.json:ro
-  # Allow the runner's own CA + oci-auth bind mounts above through act_runner's volume
-  # gate (a Haku-authored workflow still cannot mount arbitrary dind-host paths).
-  # DOCKER_CONFIG points Bazel rules_oci at the puller creds for oci-cache.allegedly.works
-  # so base-image pulls resolve through the authenticated cache, not Docker Hub.
+  # NO oci-cache credential is injected. The oci-cache Zot registry is a public
+  # pull-through cache — anonymous by design; only its *public* HTTPRoute is fronted
+  # by a basic-auth sidecar. In-cluster consumers reach Zot's internal Service
+  # (oci-cache.oci-cache.svc.cluster.local, covered by the .svc.cluster.local NO_PROXY
+  # suffix above, and by the dind --registry-mirror in deployment.yaml) with no
+  # credential — so dind base-image pulls need no DOCKER_CONFIG.
+  # COUPLING: Bazel rules_oci does NOT go through the dind mirror (it has its own
+  # puller), so haku-state's MODULE.bazel oci.pull refs must point at the internal
+  # Service (insecure/HTTP), not oci-cache.allegedly.works — otherwise, with this cred
+  # gone, an explicit public-host ref 401s. Land that MODULE.bazel switch alongside this.
+  #
+  # (Was: -e DOCKER_CONFIG=/etc/oci-auth + a read-only config.json bind mount, to hand
+  # rules_oci the public-door puller creds. That made DOCKER_CONFIG a read-only mount,
+  # which broke `docker login` in every other job — `rename … device or resource busy`.
+  # Removed 2026-07-05; see cluster/docs/harbor_pullthrough.md.)
+  #
+  # Allow the runner's own CA bind mount above through act_runner's volume gate
+  # (a Haku-authored workflow still cannot mount arbitrary dind-host paths).
   valid_volumes:
     - /egress-proxy-ca/ca-certificates.crt
-    - /etc/oci-auth/config.json
 cache:
   enabled: false

--- a/cluster/k8s/haku-ci/deployment.yaml
+++ b/cluster/k8s/haku-ci/deployment.yaml
@@ -159,14 +159,6 @@ spec:
             - name: egress-proxy-ca
               mountPath: /egress-proxy-ca
               readOnly: true
-            # Puller docker-config (auth for oci-cache.allegedly.works) mounted on dind
-            # so config.yaml's container.options can -v it into each spawned job
-            # container — where Bazel rules_oci actually runs — mirroring the egress-CA
-            # bind. (The runner process itself never runs bazel, so a runner-container
-            # mount would not reach the build.)
-            - name: oci-auth
-              mountPath: /etc/oci-auth
-              readOnly: true
           resources:
             requests:
               cpu: 200m
@@ -194,13 +186,3 @@ spec:
         - name: egress-proxy-ca
           configMap:
             name: haku-egress-proxy-ca-cert
-        # Reflector mirrors oci-cache's puller-credential Secret into this
-        # namespace (same name). Only its config.json key (a docker config with
-        # the puller auth for oci-cache.allegedly.works) is projected, at
-        # $DOCKER_CONFIG/config.json for Bazel rules_oci.
-        - name: oci-auth
-          secret:
-            secretName: puller-credential
-            items:
-              - key: config.json
-                path: config.json


### PR DESCRIPTION
## What

The haku-ci runner injected `-e DOCKER_CONFIG=/etc/oci-auth` into every job container, with `config.json` bind-mounted **read-only** — to hand Bazel `rules_oci` the puller cred for the **public** `oci-cache.allegedly.works` host. Side effect: `DOCKER_CONFIG` became a read-only single-file mount, so `docker login` in every *other* job (notably build-ui's Forgejo registry push) died with `rename … device or resource busy` **before any push**. Result: no haku-ui image has shipped since 2026-07-04 16:43 — the Now-tab + geolocation work is built and green but stuck behind this.

This drops the injection: the `-e DOCKER_CONFIG` / `-v …/config.json:ro` from `config.yaml`'s `container.options`, its `valid_volumes` entry, the dind `/etc/oci-auth` mount, and the `puller-credential` reflection volume in `deployment.yaml`.

## Why it's safe (no credential needed in-cluster)

oci-cache Zot is **anonymous on its internal Service** — the public HTTPRoute's basic-auth is a separate `public-auth` sidecar (Service ports: `http 80→zot`, `public-auth 8080→sidecar`). And `devel` already routes dind's Docker Hub base-image pulls through it (`--registry-mirror=http://oci-cache.oci-cache.svc.cluster.local` + `--insecure-registry`), with the netpol already allowing egress to the Zot backend port 5000. So dind base-image pulls keep working with no cred, and build-ui's `docker login` now writes the default writable `~/.docker/config.json`.

## ⚠️ Coupled change required in the same rollout

`rules_oci` uses **its own puller**, not the dind registry-mirror — so it does **not** benefit from the mirror. haku-state's `MODULE.bazel` `oci.pull` still targets the public host:

```python
image = "oci-cache.allegedly.works/library/debian",   # → must become the internal Service
```

Once this cred is gone, that explicit public-host ref **401s**. The companion change (on haku-state `wip/bazelify`) is to point it at the internal Service over insecure/HTTP, e.g. `oci-cache.oci-cache.svc.cluster.local/library/debian` with `rules_oci` insecure-registry config. Since `bazel-ci` runs only on `wip/bazelify` (not the main line), this PR is safe to merge first, but that switch must land before `wip/bazelify` next integrates `devel`.

## Follow-ups (not in this PR)

- `cluster/k8s/oci-cache`: the `puller-credential` Secret's Reflector mirror into `haku-ci` is now unused and can be dropped.
- `cluster/docs/harbor_pullthrough.md` is stale (describes Harbor; oci-cache is Zot now) — separate doc pass.

## Not fixed by this PR

The image *still* won't ship until a **separate Forgejo registry-auth regression** is resolved: since ~Jul 4-5, `docker push` fails (`denied`) — the account password now gets a zero-scope registry token, and the registry auth flaps intermittently (direct API blob/manifest pushes succeed, the CI image push is denied). That's a Forgejo/SeaweedFS server-side issue tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LD4L7Z4fZ3yEqTmUMzn8NG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LD4L7Z4fZ3yEqTmUMzn8NG)_