### PR TITLE
[codex] raise ESO concurrency and alert on backlog

### DIFF
--- a/cluster/k8s/external-secrets/operator/external-secrets.yaml
+++ b/cluster/k8s/external-secrets/operator/external-secrets.yaml
@@ -38,14 +38,21 @@ spec:
 
     # Controller configuration
     replicaCount: 1
+    concurrent: 8
 
     resources:
       limits:
-        cpu: 100m
+        cpu: 500m
         memory: 128Mi
       requests:
-        cpu: 10m
+        cpu: 100m
         memory: 64Mi
+
+    serviceMonitor:
+      enabled: true
+      namespace: monitoring
+      additionalLabels:
+        release: kube-prometheus-stack
 
     # Service account used by the Kubernetes-provider ClusterSecretStores to read
     # secrets from authentik / openclaw-gateway / openclaw-sandbox / openhands.

--- a/cluster/k8s/monitoring/rules/external-secrets-prometheus-rule.yaml
+++ b/cluster/k8s/monitoring/rules/external-secrets-prometheus-rule.yaml
@@ -1,0 +1,62 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: external-secrets-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: external-secrets
+      rules:
+        - alert: ExternalSecretNotReady
+          expr: externalsecret_status_condition{condition="Ready",status="False"} == 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "ExternalSecret {{ $labels.namespace }}/{{ $labels.name }} is not Ready"
+            description: >
+              ExternalSecret {{ $labels.namespace }}/{{ $labels.name }} has reported
+              Ready=False for more than 10 minutes. For Kubernetes-provider mirrors,
+              this usually means the source Secret/key is missing or unreadable.
+        - alert: ClusterExternalSecretNotReady
+          expr: clusterexternalsecret_status_condition{condition="Ready",status="False"} == 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "ClusterExternalSecret {{ $labels.name }} is not Ready"
+            description: >
+              ClusterExternalSecret {{ $labels.name }} has reported Ready=False for
+              more than 10 minutes. Check failed namespaces and generated
+              ExternalSecret children.
+        - alert: ExternalSecretsControllerBacklogged
+          expr: |
+            sum by (controller) (
+              workqueue_depth{controller=~"externalsecret|clusterexternalsecret|secretstore|clustersecretstore"}
+            ) > 0
+            and on (controller)
+            controller_runtime_active_workers{controller=~"externalsecret|clusterexternalsecret|secretstore|clustersecretstore"}
+              >= controller_runtime_max_concurrent_reconciles{controller=~"externalsecret|clusterexternalsecret|secretstore|clustersecretstore"}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "External Secrets {{ $labels.controller }} controller is saturated with queued work"
+            description: >
+              External Secrets {{ $labels.controller }} has queued work while all
+              workers are busy for more than 15 minutes. Short-refresh mirrors may
+              stop propagating source Secret updates even while Ready=True remains
+              stale.
+        - alert: ExternalSecretsControllerLongRunningWorker
+          expr: workqueue_longest_running_processor_seconds{controller=~"externalsecret|clusterexternalsecret|secretstore|clustersecretstore"} > 120
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "External Secrets {{ $labels.controller }} worker has been running for {{ $value | humanizeDuration }}"
+            description: >
+              A single External Secrets {{ $labels.controller }} worker has been
+              processing one item for more than two minutes. With low concurrency,
+              this can starve unrelated mirrors and leave target Secrets stale.

--- a/cluster/k8s/monitoring/rules/kustomization.yaml
+++ b/cluster/k8s/monitoring/rules/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - control-plane-io-prometheus-rule.yaml
+  - external-secrets-prometheus-rule.yaml
   - flux-prometheus-rule.yaml
   - mcp-auth-prometheus-rule.yaml


### PR DESCRIPTION
## Summary
- raise External Secrets controller concurrency from 1 to 8 and give it more CPU headroom
- enable ESO ServiceMonitor scraping
- add alerts for ExternalSecret/ClusterExternalSecret failures, saturated ESO workqueues, and long-running ESO workers

## Root cause
Airlock Google/Gmail token source Secrets were fresh, but mirrored target Secrets were stale because ESO was saturated. Controller metrics showed single-worker reconcile queues with long-running work and nonzero depth; after a live test bump to concurrent=8, mirrors converged and the queues drained.

## Validation
- `kubectl kustomize cluster/k8s/monitoring/rules`
- `kubectl kustomize cluster/k8s/external-secrets/operator`
- `kubectl apply --dry-run=server -f cluster/k8s/monitoring/rules/external-secrets-prometheus-rule.yaml`
- `kubectl apply --dry-run=server -k cluster/k8s/external-secrets/operator`
- commit hooks: pre-commit, prettier, ducktape pre-commit, ducktape pytest-main-check, ducktape enforce-bazel-tests, kubeconform (cluster)
- live check: ESO max concurrent 8, queue depths 0, Airlock Google/Gmail mirrors match source expiries