### PR TITLE
cluster: roll ovh-ns103711 data-disk mount rename (seaweedfs-data → local-path-ovh-hdd)

### DIFF
--- a/cluster/k8s/local-path-provisioner/helmrelease.yaml
+++ b/cluster/k8s/local-path-provisioner/helmrelease.yaml
@@ -52,7 +52,7 @@ spec:
           - /var/mnt/seaweedfs-data/local-path
       - node: ovh-ns103711
         paths:
-          - /var/mnt/seaweedfs-data/local-path
+          - /var/mnt/local-path-ovh-hdd/local-path
       - node: ovh-ns102453
         paths:
           - /var/mnt/seaweedfs-data/local-path

--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -312,7 +312,9 @@ locals {
   # (G-all + G-losable) — never a blanket bootstrap. A renamed node gets a tier-named UserVolume
   # `local-path-ovh-${storage_tier}` mounted at `/var/mnt/local-path-ovh-${tier}`; its
   # nodePathMap path becomes `/var/mnt/local-path-ovh-${tier}/local-path`. First node: 103711.
-  data_disk_mount_renamed_nodes = toset([])
+  data_disk_mount_renamed_nodes = toset([
+    "ovh-ns103711", # rolled 2026-07-05; /dev/sdb repartitioned seaweedfs-data -> local-path-ovh-hdd
+  ])
 
   # Per-node user-volume patches. KS-5 nodes expose /dev/sdb; KS-GAME nodes
   # expose a second NVMe. Both are mounted at the same path so local-path-ovh


### PR DESCRIPTION
First node of the OVH data-disk mount rename (`cluster/docs/plans/ovh_storage_tiering.md`). Opts `ovh-ns103711` into `data_disk_mount_renamed_nodes` (repartitions `/dev/sdb` → `local-path-ovh-hdd`) and flips its `nodePathMap` entry to `/var/mnt/local-path-ovh-hdd/local-path` in lockstep.

Executed live 2026-07-05 with: SeaweedFS `hdd-0` evacuated (163 vols 2-copy on `hdd-1`/`hdd-2`), FUSE consumers refreshed, 3 single-copy PVCs backed up (grocy ×2 + langfuse ZK), node cordoned+drained, then `tofu apply -target='talos_machine_configuration_apply.kimsufi["ovh-ns103711"]'`.

BAZEL_TEST_INVOCATIONS=none: single-node rename roll