### PR TITLE
[codex] Fix Flux ntfy notifier headers

### DIFF
--- a/cluster/k8s/flux-webhook/ntfy-webhook.sops.yaml
+++ b/cluster/k8s/flux-webhook/ntfy-webhook.sops.yaml
@@ -10,13 +10,15 @@ stringData:
     address: ENC[AES256_GCM,data:szI+rMWSSfVSzW6GySklYS3P/v/zXmBbYDemG28U+bgkkyeoQ77QiJeHEhQCwg==,iv:U1YglRfcjGJMmDZpSzNGXPlAhPyCvL5I7itC3KX97S0=,tag:hcaoygzHA4gPV5SWnAaAxw==,type:str]
     # ntfy inline message templating (Template: yes makes Title/Message Go
     # templates over the Flux event JSON body) so previews show a readable
-    # title + body instead of the raw event JSON. Non-secret presentation
-    # config: left plaintext and excluded from the MAC (see .sops.yaml).
+    # title + body instead of the raw event JSON. notification-controller
+    # parses this value as a YAML map; quote Go-template values so the braces
+    # are strings, not YAML flow mappings. Non-secret presentation config:
+    # left plaintext and excluded from the MAC (see .sops.yaml).
     headers: |
-        Template: yes
-        X-Title: {{.involvedObject.kind}} {{.involvedObject.name}}
-        X-Message: {{.severity}}: {{.reason}} - {{.message}}
-        X-Tags: rotating_light
+        Template: "yes"
+        X-Title: "{{.involvedObject.kind}} {{.involvedObject.name}}"
+        X-Message: "{{.severity}}: {{.reason}} - {{.message}}"
+        X-Tags: "rotating_light"
 sops:
     age:
         - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0

--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -353,6 +353,7 @@ py_test(
         "//util/bazel:runfiles",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
+        "@pypi//pyyaml",
     ],
 )
 

--- a/cluster/validation/test_cluster_integration.py
+++ b/cluster/validation/test_cluster_integration.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 import pytest_bazel
+import yaml
 
 from cluster.validation.authentik_blueprints import (
     check_blueprint_completeness,
@@ -135,6 +136,17 @@ def test_sops_secrets_have_decryption_block(cluster: ParsedCluster, k8s_dir: Pat
     """Active flux kustomizations rendering a SOPS Secret must declare decryption.provider: sops."""
     errors = check_sops_decryption_blocks(cluster, k8s_dir)
     assert not errors, "\n".join(errors)
+
+
+def test_ntfy_provider_headers_parse_as_yaml_map(k8s_dir: Path) -> None:
+    """notification-controller parses Provider secret `headers` as a YAML string map."""
+    secret_path = k8s_dir / "flux-webhook" / "ntfy-webhook.sops.yaml"
+    secret = yaml.safe_load(secret_path.read_text())
+    headers = yaml.safe_load(secret["stringData"]["headers"])
+
+    assert isinstance(headers, dict)
+    assert headers
+    assert all(isinstance(key, str) and isinstance(value, str) for key, value in headers.items())
 
 
 def test_retry_policy(cluster: ParsedCluster) -> None:


### PR DESCRIPTION
## Summary

Fix the Flux on-call ntfy Provider secret so notification-controller can parse its `headers` payload.

The secret stores non-secret ntfy presentation headers as plaintext. notification-controller parses that `headers` string as YAML, but the Go-template values were unquoted, so YAML treated the `{{...}}` braces as flow mapping syntax and failed with:

`failed to read headers from secret: error converting YAML to JSON: yaml: line 1: did not find expected key`

That made Flux health-check failures reach notification-controller but fail before delivery to ntfy.

## Changes

- Quote the ntfy header values in `cluster/k8s/flux-webhook/ntfy-webhook.sops.yaml`.
- Document the YAML-map parsing requirement next to the secret.
- Add an integration regression check that the ntfy Provider `headers` value parses as a non-empty YAML map of strings.

## Validation

- Confirmed the live notification-controller log failure for `Provider/ntfy`.
- Confirmed the fixed embedded `headers` string parses as the expected YAML map locally.
- Ran `bbr test //cluster/validation:test_cluster_integration` successfully on RBE.