### PR TITLE
[codex] clarify Haku Forgejo token drift repair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,9 +99,11 @@ Forgejo tokens and credentials consumed by `haku-ci` or Haku pods must be produc
 the in-cluster GitOps Terraform controller, not minted, copied, or synchronized
 manually. Change the Terraform/GitOps wiring under <tf/gitops/haku-state> and the Flux
 wrapper under <cluster/k8s/forgejo/haku-state> so reconcile creates and repairs the
-Kubernetes Secrets and Forgejo Actions secrets. Manual `curl`, `tea`, or `kubectl`
-edits are only incident diagnostics; follow them with a PR that makes the controller own
-the state.
+Kubernetes Secrets and Forgejo Actions secrets. If live token state is stale, fix that
+Terraform/controller wiring and reconcile it; do not repair drift by updating live
+Forgejo repo Actions secrets or Kubernetes Secrets directly. Manual `curl`, `tea`, or
+`kubectl` edits are only incident diagnostics; follow them with a PR that makes the
+controller own the state.
 
 ## Flux Kustomization Wiring
 


### PR DESCRIPTION
## Summary

- Clarify that stale Haku Forgejo token state should be repaired by fixing the Terraform/controller wiring and reconciling it.
- Explicitly call out that live Forgejo repo Actions secrets or Kubernetes Secrets are not the durable drift-repair path.

## Why

Forgejo credentials consumed by `haku-ci` and Haku pods are owned by the in-cluster GitOps Terraform controller, so incident response should not normalize manual secret synchronization.

## Checks

- `git commit` hooks: prettier, ducktape pre-commit, pytest-main-check, enforce-bazel-tests, commit-msg
