### PR TITLE
cluster(kyverno): remove reports-controller CPU limit + raise memory

### DIFF
--- a/cluster/k8s/kyverno/app/kyverno.yaml
+++ b/cluster/k8s/kyverno/app/kyverno.yaml
@@ -138,12 +138,16 @@ spec:
       enabled: true
       replicas: 1
       resources:
+        # No CPU limit: this controller syncs an informer cache over ALL resources
+        # (--skipResourceFilters=true) + runs background scans; the object
+        # deserialization is CPU-heavy. A 100m limit throttled cache sync to ~83s,
+        # blowing the leader-election lease deadline -> crashloop. Matches the
+        # admission-controller (also uncapped CPU). Memory raised to hold the cache.
         limits:
-          cpu: 100m
-          memory: 128Mi
+          memory: 512Mi
         requests:
-          cpu: 10m
-          memory: 32Mi
+          cpu: 100m
+          memory: 256Mi
 
     # CRD installation
     crds:


### PR DESCRIPTION
## Symptom
`kyverno-reports-controller` in CrashLoopBackOff (118 restarts): repeated `Error retrieving lease lock: client rate limiter Wait ... context deadline exceeded` / `Failed to renew lease` / `leadership lost`, with `Reflector WatchList` cache syncs taking **83 seconds**.

## Root cause
It's the **only** kyverno controller with a CPU limit (`100m`) — the admission-controller (the critical one) has none. It syncs an informer cache over **all** resources (`--skipResourceFilters=true`) plus runs background scans; that object deserialization is CPU-heavy. At 0.1 CPU the cache sync is throttled to ~83s, which blows the leader-election lease deadline → loses leadership → crash. The client-rate-limiter timeout is a downstream symptom of the CPU starvation (request contexts expiring while the process is throttled).

## Fix
Remove the CPU limit (match the admission-controller) and raise memory to `512Mi`/`256Mi` so the all-resource cache fits.

```diff
       resources:
         limits:
-          cpu: 100m
-          memory: 128Mi
+          memory: 512Mi
         requests:
-          cpu: 10m
-          memory: 32Mi
+          cpu: 100m
+          memory: 256Mi
```

Not an outage (admission enforcement runs on the healthy admission-controller; only policy *reports* lag). After merge + Flux reconcile the reports-controller redeploys uncapped — verify the crashloop stops.

BAZEL_TEST_INVOCATIONS=none: HelmRelease values change (validated by cluster pre-commit)