### PR TITLE
cluster(nebula): tune UDP buffers + routines for pod-network throughput

### DIFF
--- a/cluster/terraform/main/nebula.tf
+++ b/cluster/terraform/main/nebula.tf
@@ -83,8 +83,18 @@ locals {
   nebula_common = {
     pki             = local.nebula_pki
     static_host_map = local.nebula_static_host_map
-    listen          = { host = "0.0.0.0", port = 4242 }
-    punchy          = { punch = true, respond = true }
+    # read_buffer/write_buffer raised well above the small kernel default: nebula's
+    # UDP socket overflowed under sustained pod-network throughput and dropped packets
+    # -> heavy TCP retransmits -> single-stream throughput collapse (measured: iperf3
+    # pod-to-pod 205-730 Mbps with 1.3k-8.4k retransmits; SeaweedFS single-stream
+    # volume moves ~256 Mbps). This is the primary single-stream fix. See issue #2917.
+    listen = { host = "0.0.0.0", port = 4242, read_buffer = 10485760, write_buffer = 10485760 }
+    # 2 UDP-processing routines (nebula default is 1 = single-threaded). Nodes are
+    # 4-core/8-thread (Xeon E3-1270 v6 / i7-7700K); 2 doubles packet parallelism while
+    # leaving cores for etcd/containerd/workloads. A single flow still hashes to one
+    # routine, so this mainly lifts aggregate (multi-flow) throughput.
+    routines = 2
+    punchy   = { punch = true, respond = true }
     # Raised from Nebula's default 1300. nebula1 + 60 (Nebula overhead) = 1480,
     # under the 1500 eno1 underlay; carries Cilium's VXLAN (pod 1370 + 50 = 1420).
     # Full MTU model + layering: cluster/docs/network.md.


### PR DESCRIPTION
## Evidence (measured, not guessed)
iperf3 pod-to-pod over the overlay between two idle NVMe nodes:

| Direction | Throughput | TCP retransmits |
|-----------|-----------|-----------------|
| fwd | 730 Mbps | 1,279 |
| rev | 205 Mbps | 8,361 |

- Not a bandwidth cap (hit 730). Not MTU (pod MTU ~1370, TCP clamps; DF-ping confirms).
- It's **packet loss on the nebula overlay** → thousands of TCP retransmits → single-stream TCP collapses. SeaweedFS `volume.move` is single-stream → ~256 Mbps.

## Root cause
`nebula_common` ran with defaults: one UDP-processing routine + small default socket buffers, which overflow and drop under sustained throughput.

## Change
- `listen.read_buffer`/`write_buffer` = 10 MiB — absorb bursts, cut the drops (**primary single-stream fix**).
- `routines = 2` (default 1) — parallel packet processing. Nodes are 4-core/8-thread (Xeon E3-1270 v6 / i7-7700K), so 2 leaves cores for etcd/containerd/workloads.

## Rollout
Per-node **targeted** applies — a nebula config change restarts the tunnel and briefly blips that node's overlay, so never all nodes at once (would risk etcd quorum). Plan: roll on `103711` (already repartitioned) + `102453` (bundled with its repartition), then re-measure iperf3 between them.

Fixes the throughput half of #2917.

BAZEL_TEST_INVOCATIONS=none: nebula config change (validated by cluster pre-commit)