### PR TITLE
[codex] fix Forgejo log helper step listing

### DIFF
--- a/skills/forgejo/scripts/fetch_forgejo_logs.py
+++ b/skills/forgejo/scripts/fetch_forgejo_logs.py
@@ -198,15 +198,15 @@ def fetch_step_logs(client: httpx.Client, forgejo_url: str, state: RunPageState,
     )
 
 
-def _step_index(step: dict[str, Any]) -> str:
+def _step_index(position: int, step: dict[str, Any]) -> str:
     for key in ("index", "number", "step"):
         if key in step:
             return str(step[key])
-    return "?"
+    return str(position)
 
 
 def _step_name(step: dict[str, Any]) -> str:
-    for key in ("name", "title", "displayName"):
+    for key in ("name", "title", "displayName", "summary"):
         if key in step:
             return str(step[key])
     return ""
@@ -220,8 +220,8 @@ def _step_status(step: dict[str, Any]) -> str:
 
 
 def _print_steps(steps: list[dict[str, Any]]) -> None:
-    for step in steps:
-        print("\t".join([_step_index(step), _step_status(step), _step_name(step)]))
+    for position, step in enumerate(steps):
+        print("\t".join([_step_index(position, step), _step_status(step), _step_name(step)]))
 
 
 def _print_logs(lines: list[LogLine], timestamps: bool) -> None:

--- a/skills/forgejo/test_fetch_forgejo_logs.py
+++ b/skills/forgejo/test_fetch_forgejo_logs.py
@@ -42,6 +42,22 @@ def test_extract_steps_prefers_current_job_steps() -> None:
     ]
 
 
+def test_print_steps_falls_back_to_position_and_summary(capsys: pytest.CaptureFixture[str]) -> None:
+    fetch_forgejo_logs._print_steps(
+        [
+            {"duration": "4s", "status": "success", "summary": "Set up job"},
+            {"duration": "3m3s", "status": "failure", "summary": "Test"},
+            {"index": 10, "status": "failure", "summary": "Complete job"},
+        ]
+    )
+
+    assert capsys.readouterr().out.splitlines() == [
+        "0\tsuccess\tSet up job",
+        "1\tfailure\tTest",
+        "10\tfailure\tComplete job",
+    ]
+
+
 def test_parse_run_page_unescapes_initial_post_response() -> None:
     escaped = RUN_HTML.replace('"state"', "&quot;state&quot;")
 


### PR DESCRIPTION
## Summary

Fix the Forgejo log helper's `--list-steps` output for run pages whose step objects do not include explicit `index`/`number` fields. The helper now falls back to the positional step cursor and treats Forgejo's `summary` field as the display name.

## Root Cause

The haku-state run page for run 405 exposes step objects shaped like `duration/status/summary`, so the helper printed `?` and blank names even though those positions are the values needed by the log cursor endpoint.

## Validation

- `python3 /home/agentydragon/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/forgejo`
- `bazelisk test //skills/forgejo:forgejo_frontmatter_test //skills/forgejo:test_fetch_forgejo_logs`
- Live smoke against `haku/haku-state` run 405: `--list-steps` now prints positional indexes including `5	failure	Test` and `10	failure	Complete job`.