### PR TITLE
[codex] allow haku CI to fetch GNU source archives

### DIFF
--- a/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
@@ -89,10 +89,11 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
-    # Bazel registry + release artifacts, GitHub source/release archives, and the
-    # Node.js toolchain — the haku-ci Bazel cold-fetch closure (NO RBE). Added ahead
-    # of the haku-ci rehoming (next PR) so the proxy allowlist is ready when the
-    # runner starts egressing through it.
+    # Bazel registry + release artifacts, GitHub source/release archives, GNU source
+    # archives (rules_oci pulls gawk for py_image_layer manifests), and the Node.js
+    # toolchain — the haku-ci Bazel cold-fetch closure (NO RBE). Added ahead of the
+    # haku-ci rehoming (next PR) so the proxy allowlist is ready when the runner
+    # starts egressing through it.
     - toFQDNs:
         - matchName: releases.bazel.build
         - matchName: bcr.bazel.build
@@ -101,6 +102,7 @@ spec:
         - matchName: objects.githubusercontent.com
         - matchName: release-assets.githubusercontent.com
         - matchName: raw.githubusercontent.com
+        - matchName: ftp.gnu.org
         - matchName: nodejs.org
       toPorts:
         - ports:


### PR DESCRIPTION
## Summary

- allow haku-egress-proxy to reach ftp.gnu.org for Bazel cold-fetches
- document that rules_oci pulls gawk for py_image_layer manifest work

## Why

haku-state Bazel CI failed while fetching gawk from ftp.gnu.org through the egress proxy. The temporary broad policy proved compilation and push can complete; this PR keeps the durable allowlist narrow.

Aspect telemetry endpoints were observed during the broad-policy probe, but are intentionally not allowlisted. haku-state now disables Aspect tools telemetry in CI with ASPECT_TOOLS_TELEMETRY=-all.

## Validation

- Applied the narrowed CiliumNetworkPolicy live; Cilium reports it Valid=True.
- haku-state bazel-ci succeeded once with the temporary broad policy before narrowing.
- A follow-up haku-state run on commit 6ea860f is in progress under the narrowed policy.
