### PR TITLE
cluster: roll ovh-ns102453 data-disk mount rename (+ picks up nebula tuning)

### DIFF
--- a/cluster/k8s/local-path-provisioner/helmrelease.yaml
+++ b/cluster/k8s/local-path-provisioner/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
           - /var/mnt/local-path-ovh-hdd/local-path
       - node: ovh-ns102453
         paths:
-          - /var/mnt/seaweedfs-data/local-path
+          - /var/mnt/local-path-ovh-hdd/local-path
       - node: ovh-ns104952
         paths:
           - /var/mnt/seaweedfs-data/local-path

--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -314,6 +314,7 @@ locals {
   # nodePathMap path becomes `/var/mnt/local-path-ovh-${tier}/local-path`. First node: 103711.
   data_disk_mount_renamed_nodes = toset([
     "ovh-ns103711", # rolled 2026-07-05; /dev/sdb repartitioned seaweedfs-data -> local-path-ovh-hdd
+    "ovh-ns102453", # rolled 2026-07-05; /dev/sdb repartitioned seaweedfs-data -> local-path-ovh-hdd
   ])
 
   # Per-node user-volume patches. KS-5 nodes expose /dev/sdb; KS-GAME nodes


### PR DESCRIPTION
Second node of the OVH data-disk mount rename. Opts 102453 into data_disk_mount_renamed_nodes (repartitions /dev/sdb -> local-path-ovh-hdd) + nodePathMap flip. Its targeted apply also picks up the nebula tuning (#2926), enabling the 103711<->102453 throughput re-measurement. Executed live 2026-07-05 after SeaweedFS hdd-1 evacuation + drain. BAZEL_TEST_INVOCATIONS=none: single-node rename roll