### PR TITLE
[codex] Handle MCP OAuth state store timeouts

### DIFF
--- a/cluster/k8s/monitoring/rules/grocy-mcp-prometheus-rule.yaml
+++ b/cluster/k8s/monitoring/rules/grocy-mcp-prometheus-rule.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: grocy-mcp-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: grocy-mcp
+      rules:
+        - alert: GrocyMcpNoTools
+          expr: grocy_mcp_tools{namespace=~"grocy-.+"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Grocy MCP {{ $labels.namespace }}/{{ $labels.pod }} is advertising zero tools"
+            description: >
+              The Grocy MCP server is reachable on its metrics port, but its
+              local FastMCP registry reports zero advertised tools. Clients can
+              authenticate successfully and still see an empty tool list. Check
+              the pod logs for OpenAPI generation, TOOL_OVERRIDES, or batch tool
+              registration failures.

--- a/cluster/k8s/monitoring/rules/kustomization.yaml
+++ b/cluster/k8s/monitoring/rules/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - control-plane-io-prometheus-rule.yaml
   - external-secrets-prometheus-rule.yaml
   - flux-prometheus-rule.yaml
+  - grocy-mcp-prometheus-rule.yaml
   - mcp-auth-prometheus-rule.yaml

--- a/cluster/k8s/monitoring/rules/mcp-auth-prometheus-rule.yaml
+++ b/cluster/k8s/monitoring/rules/mcp-auth-prometheus-rule.yaml
@@ -10,7 +10,8 @@ spec:
     - name: mcp-auth
       rules:
         # An OIDCProxy-fronted MCP server (oauth facades, grocy-mcp) failed to
-        # refresh a client's token against Authentik. Before the
+        # refresh a client's token against Authentik or persist refreshed OAuth
+        # state. Before the
         # ResilientOIDCProxy fix this instantly killed the claude.ai connector
         # (invalid_grant is terminal); now transient failures answer 503, but
         # each one still means claude.ai saw an error and the connector may
@@ -21,13 +22,15 @@ spec:
           labels:
             severity: warning
           annotations:
-            summary: "MCP server {{ $labels.namespace }}/{{ $labels.pod }} failed an upstream token refresh (outcome: {{ $labels.outcome }})"
+            summary: "MCP server {{ $labels.namespace }}/{{ $labels.pod }} failed a token refresh (outcome: {{ $labels.outcome }})"
             description: >
-              {{ $value | printf "%.0f" }} upstream token refresh failure(s) in
+              {{ $value | printf "%.0f" }} token refresh failure(s) in
               the last hour on {{ $labels.namespace }}/{{ $labels.pod }}
               (outcome={{ $labels.outcome }}). outcome=transient means Authentik
               was unreachable/5xx (client got 503 and may recover on its own);
               outcome=oauth means Authentik genuinely rejected a grant — the
-              claude.ai connector is likely dead until manually reconnected.
-              Check Settings → Connectors in claude.ai and authentik-server
-              health.
+              claude.ai connector is likely dead until manually reconnected;
+              outcome=storage means the MCP server could not persist OAuth state
+              to its local store such as Valkey (client got 503 and may retry).
+              Check Settings → Connectors in claude.ai, authentik-server health,
+              and the MCP namespace's state-store pods.

--- a/grocy_mcp/BUILD.bazel
+++ b/grocy_mcp/BUILD.bazel
@@ -167,6 +167,7 @@ py_test(
         ":server",
         "//:conftest",
         "@pypi//httpx",
+        "@pypi//prometheus_client",
         "@pypi//pytest_bazel",
     ],
 )

--- a/grocy_mcp/server.py
+++ b/grocy_mcp/server.py
@@ -18,6 +18,7 @@ exchange is load-bearing.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -28,7 +29,7 @@ import uvicorn
 from fastmcp import FastMCP
 from fastmcp.server.providers.openapi import MCPType, OpenAPIResource, OpenAPIResourceTemplate, OpenAPITool, RouteMap
 from fastmcp.utilities.openapi import HTTPRoute
-from prometheus_client import start_http_server
+from prometheus_client import Gauge, start_http_server
 from pydantic.networks import AnyUrl
 
 from grocy_mcp.batch_tools import register_batch_tools
@@ -39,6 +40,8 @@ from mcp_infra.persistence import build_client_storage
 from util.bazel.runfiles import get_required_path
 
 logger = logging.getLogger(__name__)
+
+_TOOLS = Gauge("grocy_mcp_tools", "Number of tools advertised by the Grocy MCP server")
 
 # All routes become tools by default; TOOL_OVERRIDES controls which are
 # enabled, disabled, or promoted to MCP resources.
@@ -129,16 +132,29 @@ def build_server(settings: ServerSettings) -> FastMCP:
     return mcp
 
 
+async def record_tool_count(mcp: FastMCP) -> int:
+    tool_count = len(await mcp.list_tools())
+    _TOOLS.set(tool_count)
+    return tool_count
+
+
 def main() -> None:
     log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
     logging.basicConfig(level=log_level, format="%(asctime)s %(name)s %(levelname)s %(message)s", stream=sys.stderr)
     settings = ServerSettings()
     mcp = build_server(settings)
+    tool_count = asyncio.run(record_tool_count(mcp))
     app = mcp.http_app(path="/mcp")
     # Metrics (incl. mcp_auth_upstream_refresh_failures_total) on a dedicated
     # cluster-internal port, off the public HTTPRoute.
     start_http_server(settings.metrics_port, addr=settings.host)
-    logger.info("grocy-mcp listening on %s:%d, metrics on :%d", settings.host, settings.port, settings.metrics_port)
+    logger.info(
+        "grocy-mcp listening on %s:%d, metrics on :%d, tools=%d",
+        settings.host,
+        settings.port,
+        settings.metrics_port,
+        tool_count,
+    )
     uvicorn.run(app, host=settings.host, port=settings.port, log_level="info")
 
 

--- a/grocy_mcp/test_server.py
+++ b/grocy_mcp/test_server.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import httpx
 import pytest_bazel
+from prometheus_client import REGISTRY
 
 from grocy_mcp.mcp_types import ServerSettings
-from grocy_mcp.server import build_mcp
+from grocy_mcp.server import build_mcp, record_tool_count
 
 
 def test_build_mcp_accepts_grocy_spec() -> None:
     settings = ServerSettings(grocy_url="https://grocy.example.com")
     client = httpx.AsyncClient(base_url=f"{settings.grocy_url}/api")
     build_mcp(settings, client=client)
+
+
+def test_record_tool_count_exports_metric() -> None:
+    async def _run() -> int:
+        settings = ServerSettings(grocy_url="https://grocy.example.com")
+        async with httpx.AsyncClient(base_url=f"{settings.grocy_url}/api") as client:
+            mcp = build_mcp(settings, client=client)
+            return await record_tool_count(mcp)
+
+    tool_count = asyncio.run(_run())
+
+    assert tool_count > 0
+    assert REGISTRY.get_sample_value("grocy_mcp_tools") == tool_count
 
 
 if __name__ == "__main__":

--- a/mcp_infra/authentik_auth/BUILD.bazel
+++ b/mcp_infra/authentik_auth/BUILD.bazel
@@ -14,6 +14,7 @@ py_library(
         "@pypi//pydantic",
         "@pypi//starlette",
         "@pypi//tenacity",
+        "@pypi//valkey_glide",
     ],
 )
 
@@ -44,5 +45,6 @@ py_test(
         "@pypi//pytest_bazel",
         "@pypi//starlette",
         "@pypi//tenacity",
+        "@pypi//valkey_glide",
     ],
 )

--- a/mcp_infra/authentik_auth/auth.py
+++ b/mcp_infra/authentik_auth/auth.py
@@ -38,6 +38,7 @@ from fastmcp.server.auth.auth import AuthProvider, TokenVerifier
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from fastmcp.server.dependencies import get_access_token
+from glide_shared.exceptions import TimeoutError as GlideTimeoutError
 from key_value.aio.protocols import AsyncKeyValue
 from mcp.server.auth.provider import TokenError
 from prometheus_client import Counter
@@ -124,8 +125,8 @@ class AuthentikAuthConfig(BaseModel):
 
 UPSTREAM_REFRESH_FAILURES = Counter(
     "mcp_auth_upstream_refresh_failures_total",
-    "MCP client token refreshes that failed at the upstream Authentik token endpoint",
-    ["outcome"],  # transient (upstream unreachable/5xx) | oauth (real OAuth error response)
+    "MCP client token refreshes that failed while talking to Authentik or persisting OAuth state",
+    ["outcome"],  # transient (upstream unreachable/5xx) | oauth (real OAuth error response) | storage
 )
 
 _RETRY_AFTER_SECONDS = 60
@@ -140,6 +141,15 @@ def _transient_upstream_error(exc: BaseException | None) -> bool:
 
 def _is_transient_token_error(exc: BaseException) -> bool:
     return isinstance(exc, TokenError) and _transient_upstream_error(exc.__cause__)
+
+
+def _transient_oauth_state_storage_error(exc: BaseException) -> bool:
+    """True for local OAuth-state store failures that should be retryable."""
+    return isinstance(exc, GlideTimeoutError)
+
+
+def _transient_refresh_error(exc: BaseException) -> bool:
+    return _is_transient_token_error(exc) or _transient_oauth_state_storage_error(exc)
 
 
 def _upstream_oauth_rejection(exc: BaseException | None) -> bool:
@@ -185,7 +195,7 @@ class ResilientOIDCProxy(OIDCProxy):
     ) -> OAuthToken:
         try:
             async for attempt in AsyncRetrying(
-                retry=retry_if_exception(_is_transient_token_error),
+                retry=retry_if_exception(_transient_refresh_error),
                 stop=self.refresh_retry_stop,
                 wait=self.refresh_retry_wait,
                 before_sleep=before_sleep_log(logger, logging.WARNING),
@@ -204,6 +214,16 @@ class ResilientOIDCProxy(OIDCProxy):
                 ) from e.__cause__
             if _upstream_oauth_rejection(e.__cause__):
                 UPSTREAM_REFRESH_FAILURES.labels(outcome="oauth").inc()
+            raise
+        except Exception as e:
+            if _transient_oauth_state_storage_error(e):
+                UPSTREAM_REFRESH_FAILURES.labels(outcome="storage").inc()
+                logger.exception("OAuth state store unavailable during token refresh")
+                raise HTTPException(
+                    status_code=503,
+                    detail="OAuth state store temporarily unavailable; retry later.",
+                    headers={"Retry-After": str(_RETRY_AFTER_SECONDS)},
+                ) from e
             raise
         raise AssertionError("unreachable")  # the retry loop always returns or raises
 

--- a/mcp_infra/authentik_auth/test_auth.py
+++ b/mcp_infra/authentik_auth/test_auth.py
@@ -13,6 +13,7 @@ from authlib.oauth2 import OAuth2Error
 from authlib.oauth2.rfc6749.wrappers import OAuth2Token
 from fastmcp.server.auth.auth import TokenVerifier
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
+from glide_shared.exceptions import TimeoutError as GlideTimeoutError
 from key_value.aio.stores.memory import MemoryStore
 from mcp.server.auth.provider import TokenError
 from prometheus_client import REGISTRY
@@ -435,6 +436,37 @@ async def test_resilient_proxy_retries_then_succeeds(proxy: ResilientOIDCProxy) 
     token = object()
     with patch.object(
         OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=[_invalid_grant_from(_http_error(503)), token])
+    ) as upstream:
+        assert await proxy.exchange_refresh_token(AsyncMock(), AsyncMock(), []) is token
+    assert upstream.call_count == 2
+
+
+async def test_resilient_proxy_oauth_state_store_timeout_becomes_503(proxy: ResilientOIDCProxy) -> None:
+    """A Valkey/glide timeout while persisting rotated OAuth state is transient.
+
+    This is the path seen in grocy-sf logs: Authentik returned 200, then
+    fastmcp timed out writing the refreshed upstream token to Valkey. It should
+    not leak as a raw 500 to claude.ai.
+    """
+    before = _failures("storage")
+    with (
+        patch.object(
+            OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=GlideTimeoutError("timed out"))
+        ) as upstream,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await proxy.exchange_refresh_token(AsyncMock(), AsyncMock(), [])
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.headers is not None
+    assert "Retry-After" in exc_info.value.headers
+    assert upstream.call_count == 3
+    assert _failures("storage") == before + 1
+
+
+async def test_resilient_proxy_oauth_state_store_timeout_retries_then_succeeds(proxy: ResilientOIDCProxy) -> None:
+    token = object()
+    with patch.object(
+        OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=[GlideTimeoutError("timed out"), token])
     ) as upstream:
         assert await proxy.exchange_refresh_token(AsyncMock(), AsyncMock(), []) is token
     assert upstream.call_count == 2


### PR DESCRIPTION
## Summary

- retry transient Valkey/glide OAuth state-store timeouts during MCP token refresh
- return HTTP 503 with Retry-After instead of leaking a raw 500 to claude.ai
- add Grocy MCP advertised-tool-count metric and alert when a Grocy MCP server advertises zero tools
- extend the MCP auth alert docs with `outcome=storage`

## Root cause

Grocy-SF showed Authentik returning 200 for a Claude token refresh, followed by `glide_shared.exceptions.TimeoutError` while FastMCP persisted rotated OAuth state to Valkey. That exception escaped outside the existing retry predicate, which only handled Authentik failures wrapped in `TokenError`, so Claude saw a raw 500 and could keep a stale connector runtime even though the connector UI still looked configured.

## Validation

- `bazelisk test //mcp_infra/authentik_auth:test_auth`
- `bazelisk test //grocy_mcp:test_server`
- `kubectl kustomize cluster/k8s/monitoring/rules`
- commit hooks, including `kubeconform (cluster)`
