### PR TITLE
Fix haku UI publish credential refresh

### DIFF
--- a/haku/state_template/ui/BUILD.bazel
+++ b/haku/state_template/ui/BUILD.bazel
@@ -7,11 +7,11 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 # Replaces ui/Dockerfile's multi-stage build. Layers:
 #   - //ui/backend:backend_layers  — hermetic CPython 3.13 + site-packages + app
 #                                    (aspect_rules_py py_image_layer over :server)
-#   - :web_tar                     — the built React SPA at /app/web
+#   - :web_tar                     — the built React SPA under /app/web/web_files
 # on debian:bookworm-slim (bash for the aspect py venv launcher; glibc/libstdc++).
 # Runtime contract preserved: uvicorn on :8080, non-root uid 10001, the app reads
-# the SPA from HAKU_UI_STATIC_DIR (=/app/web); git creds + Forgejo URLs come from
-# the Deployment env (HAKU_UI_*), not the image.
+# the SPA from HAKU_UI_STATIC_DIR (=/app/web/web_files); git creds + Forgejo URLs
+# come from the Deployment env (HAKU_UI_*), not the image.
 
 # Flatten the vite dist/ TreeArtifact to the docroot root (index.html at top).
 copy_to_directory(
@@ -32,7 +32,7 @@ oci_image(
     # py_image_layer places the launcher at /<package>/<binary_name>.
     entrypoint = ["/ui/backend/server"],
     env = {
-        "HAKU_UI_STATIC_DIR": "/app/web",
+        "HAKU_UI_STATIC_DIR": "/app/web/web_files",
         "PYTHONDONTWRITEBYTECODE": "1",
         "PYTHONUNBUFFERED": "1",
     },

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -157,6 +157,22 @@ resource "forgejo_repository_action_secret" "registry_push" {
   repository_id = forgejo_repository.state.id
   name          = "REGISTRY_PUSH_TOKEN"
   data          = random_password.haku.result
+
+  lifecycle {
+    replace_triggered_by = [
+      random_password.haku,
+      terraform_data.registry_push_secret_refresh,
+    ]
+  }
+}
+
+# The Forgejo provider cannot read back Actions secret values, so opaque value
+# drift can look like "NoDrift" to Terraform while CI still receives stale auth.
+# This controller-owned refresh marker forces the provider to rewrite the secret
+# once now; bump the marker if the secret ever needs an explicit declarative
+# rewrite again.
+resource "terraform_data" "registry_push_secret_refresh" {
+  triggers_replace = ["2026-07-06-haku-registry-push-token-resync"]
 }
 
 # Registration token for the contained Forgejo Actions runner (cluster/k8s/haku-ci),


### PR DESCRIPTION
## Summary
- force the haku-state Forgejo Actions REGISTRY_PUSH_TOKEN secret to be rewritten by Terraform via a controller-owned refresh marker
- make the haku-state UI starter serve the Bazel-packaged SPA from /app/web/web_files

## Context
Live haku-state run 414, a push-triggered bazel-ci run on a8d0946, built successfully but failed at image push with Forgejo registry auth returning 403. Direct haku basic auth works against the registry. A later manual workflow_dispatch run 416 on the same commit succeeded and rolled out the fixed image, so the push-event-specific auth failure is not fully proven from current evidence.

This PR still makes the credential path safer: the opaque Actions secret is rewritten under the in-cluster GitOps Terraform controller by replacing the provider-managed secret once now, and future haku password replacements also force a secret replacement. It also carries the live UI docroot fix back into the haku-state starter.

## Validation
- tofu fmt -check tf/gitops/haku-state/main.tf
- bbr test //tf/gitops/haku-state:validate
- bazelisk query //ui:image_build_test from haku/state_template
