### PR TITLE
[codex] make git push.default simple

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -179,7 +179,12 @@ in
       };
       core.autocrlf = false;
       color.ui = "auto";
-      push.default = "upstream";
+      # `simple` pushes only when the current branch name matches its upstream
+      # branch name, otherwise it refuses. This avoids the `upstream` footgun:
+      # `git worktree add -b foo ... origin/devel` makes `foo` track
+      # `origin/devel`, so a plain push from `foo` can update `devel` instead
+      # of creating/pushing `foo`.
+      push.default = "simple";
       log = {
         abbrevCommit = true;
         decorate = "short";


### PR DESCRIPTION
## Summary

- change the Nix-managed Git `push.default` from `upstream` to `simple`
- document the worktree-created upstream mismatch that made a local PR branch push to `devel`

## Why

`git worktree add -b foo ... origin/devel` makes `foo` track `origin/devel`. With `push.default = upstream`, a plain push from `foo` can update remote `devel` instead of creating/pushing `foo`. `simple` refuses when the local branch name and upstream branch name differ.

## Validation

- commit hooks: `nixfmt`, `statix`, `ducktape-precommit`, `ducktape pytest-main-check`, `ducktape enforce-bazel-tests`
