### PR TITLE
fix(monitoring): stop ntfy alerts being dropped as oversized (HTTP 400)

### DIFF
--- a/cluster/k8s/monitoring/stack/helmrelease.yaml
+++ b/cluster/k8s/monitoring/stack/helmrelease.yaml
@@ -109,6 +109,17 @@ spec:
               matchers:
                 - alertname =~ "FluxKustomizationNotReady|FluxHelmReleaseNotReady|FluxGitRepositoryNotReady|FluxMainGitRepositoryArtifactLarge|ControlPlaneSystemDiskBusy|ControlPlanePodSystemDiskWriterHigh|ControlPlaneLeasePutLatencyHigh|ControlPlaneLeasePutLatencyCritical"
               repeat_interval: 2h
+              # One alert per ntfy message. ntfy.sh caps a published message at
+              # ~4KB; the parent route's group_by ["namespace"] bundled every
+              # flux-system alert (21+ FluxKustomizationNotReady during a storm)
+              # into one notification that, expanded by the X-Template
+              # "alertmanager" renderer, exceeded the cap and was rejected with
+              # HTTP 400 code 40041 ("message or title is too large after
+              # replacing template"). Alertmanager treats 4xx as unrecoverable,
+              # so alerts were silently dropped exactly when many were firing.
+              # group_by ["..."] disables aggregation so each alert is its own
+              # small message.
+              group_by: ["..."]
         receivers:
           - name: "null"
           - name: ntfy


### PR DESCRIPTION
## Problem

`AlertmanagerClusterFailedToSendAlerts` (critical) has been firing since the 2026-07-05 cluster reschedule. Alertmanager could not deliver **any** Flux/ControlPlane notification to the ntfy receiver — the cluster was effectively **un-paged during an incident**.

Root cause from the Alertmanager pod logs:

```text
ntfy/webhook[0]: notify retry canceled due to unrecoverable error after 1 attempts:
unexpected status code 400: {"code":40041,"http":400,
"error":"invalid request: message or title is too large after replacing template"}
num_alerts=25
```

The ntfy route inherited the parent route's `group_by: ["namespace"]`, so all `flux-system` alerts (21+ `FluxKustomizationNotReady` during the storm) grouped into **one** notification. Expanded by the `X-Template: alertmanager` renderer, that single message blew past ntfy.sh's ~4 KB body cap → HTTP 400. Alertmanager treats a 4xx as unrecoverable and drops the notification, so nothing was delivered.

A single-alert POST to the same topic returns HTTP 200 — the failure only manifests when many alerts are grouped, i.e. during a real incident.

## Fix

Override `group_by: ["..."]` on the ntfy route to disable aggregation. Each alert becomes its own small message, always under the cap. Trade-off: a storm produces several ntfy pushes instead of one — acceptable (and self-throttled by `repeat_interval: 2h`), and strictly better than total silence.

## Verification

- `pre-commit run --files cluster/k8s/monitoring/stack/helmrelease.yaml` — all pass (incl. `kubeconform`).
- Takes effect once Flux reconciles the HelmRelease and the operator regenerates the Alertmanager config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)