### PR TITLE
cluster: roll ovh-ns103656 data-disk mount rename (CP anchor)

### DIFF
--- a/cluster/k8s/local-path-provisioner/helmrelease.yaml
+++ b/cluster/k8s/local-path-provisioner/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
       # every node that should be eligible for local-path-ovh placement.
       - node: ovh-ns103656
         paths:
-          - /var/mnt/seaweedfs-data/local-path
+          - /var/mnt/local-path-ovh-hdd/local-path
       - node: ovh-ns103711
         paths:
           - /var/mnt/local-path-ovh-hdd/local-path

--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -315,6 +315,7 @@ locals {
   data_disk_mount_renamed_nodes = toset([
     "ovh-ns103711", # rolled 2026-07-05; /dev/sdb repartitioned seaweedfs-data -> local-path-ovh-hdd
     "ovh-ns102453", # rolled 2026-07-05; /dev/sdb repartitioned seaweedfs-data -> local-path-ovh-hdd
+    "ovh-ns103656", # rolled 2026-07-05; /dev/sdb repartitioned seaweedfs-data -> local-path-ovh-hdd (CP anchor; etcd on /dev/sda untouched)
   ])
 
   # Per-node user-volume patches. KS-5 nodes expose /dev/sdb; KS-GAME nodes


### PR DESCRIPTION
Third/last HDD node, the KS-5 CP anchor. Opt-in + nodePathMap flip; etcd on /dev/sda untouched (auto-mode, no reboot). Executed live after hdd-2 evacuation + drain. BAZEL_TEST_INVOCATIONS=none: single-node rename roll