### PR TITLE
fix(claude/web): make web_setup.sh's Nix install idempotent and PATH-safe

### DIFF
--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -165,7 +165,20 @@ reclaim_reserved_blocks
 #   - --init none skips systemd/launchd (not available in containers)
 # Pinned binary from GitHub releases, SHA256-verified.
 log "Installing Nix (Determinate installer)..."
-bash "${FLAKE#path:}/devinfra/install_nix_determinate.sh"
+# Idempotent: on a persistent rootfs, Nix from a prior session's install is
+# already present. The installer fetches its binary from a GitHub release, which
+# 403s in GitHub-repo-scoped sessions (see AGENTS.md "Repository Scope") — skip
+# the reinstall when a working Nix is already there instead of hard-failing.
+if [ -x /nix/var/nix/profiles/default/bin/nix ] && /nix/var/nix/profiles/default/bin/nix --version >/dev/null 2>&1; then
+  log "Nix already installed ($(/nix/var/nix/profiles/default/bin/nix --version)); skipping installer."
+else
+  bash "${FLAKE#path:}/devinfra/install_nix_determinate.sh"
+fi
+# nix-daemon.sh sources itself only once per shell (`__ETC_PROFILE_NIX_SOURCED`
+# guard). This script's shell can inherit that guard already set from the
+# harness's own shell init without ever having put Nix on PATH, which makes the
+# source below a silent no-op. Unset it first so PATH actually gets updated.
+unset __ETC_PROFILE_NIX_SOURCED
 # shellcheck disable=SC1091
 . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 log "Nix installation complete."


### PR DESCRIPTION
## Summary

- Two bugs in `devinfra/claude/web_setup.sh` left the web session environment broken this session: no `kubectl`/`bazel`/`claude-hook` on `PATH`, `~/haku-state` never cloned.
- The Nix-install step unconditionally re-downloads the Determinate installer binary from a GitHub release. In a GitHub-repo-scoped session (access limited to one repo), that download 403s — even though a working Nix was already present on the persistent rootfs from a prior session. Now skips the reinstall when `/nix/var/nix/profiles/default/bin/nix` already works.
- Separately, `nix-daemon.sh`'s own once-per-shell guard (`__ETC_PROFILE_NIX_SOURCED`) can already be set in this script's shell — inherited from the harness's own shell init — without Nix ever having been added to `PATH`. That makes the script's `. nix-daemon.sh` a silent no-op. Now unsets the guard first so the source actually runs.

## Test plan

- [x] Reproduced the failure: `curl` to the GitHub release URL returns `403` ("GitHub access to this repository is not enabled for this session") even though `/nix/var/nix/profiles/default/bin/nix --version` already works.
- [x] Reproduced the second bug: sourcing `nix-daemon.sh` after the guard was already set left `PATH` unchanged; unsetting the guard first fixed it.
- [x] Re-ran `haku/runtime/claude_web_env/setup.sh` end-to-end with both fixes: devtools installed, `kubectl`/`bazel`/`claude-hook` all resolve, SessionStart hook ran clean, and Haku's bootstrap (kubeconfig, `haku-state` clone) completed successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JYkiBvQZ3WS4uVaJUfBFNa)_