### PR TITLE
haku: add console MCP approval runtime substrate

### DIFF
--- a/cluster/k8s/haku/console/db/flux-kustomization.yaml
+++ b/cluster/k8s/haku/console/db/flux-kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-console-db
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  path: ./cluster/k8s/haku/console/db
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: haku-console-namespace
+    - name: cnpg
+    - name: local-path-provisioner

--- a/cluster/k8s/haku/console/db/kustomization.yaml
+++ b/cluster/k8s/haku/console/db/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - postgres-cluster.yaml

--- a/cluster/k8s/haku/console/db/postgres-cluster.yaml
+++ b/cluster/k8s/haku/console/db/postgres-cluster.yaml
@@ -1,0 +1,33 @@
+# Distributed approval ledger for haku-console MCP tool calls. The app runs
+# Alembic migrations at startup; CNPG owns the database, role, and Secret.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: haku-console-db
+  namespace: haku-console
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie
+
+  probes:
+    liveness:
+      isolationCheck:
+        enabled: false
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: hil-ovh
+    topologyKey: kubernetes.io/hostname
+
+  storage:
+    storageClass: local-path-ovh
+    size: 2Gi
+
+  monitoring:
+    enablePodMonitor: true
+
+  bootstrap:
+    initdb:
+      database: approval_store
+      owner: approval_store
+      # CNPG auto-generates credentials in Secret haku-console-db-app.

--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -72,7 +72,7 @@ spec:
               value: https://haku-ui.allegedly.works
             - name: HAKU_CONSOLE_AUTH_ORIGIN
               value: https://auth.allegedly.works
-            - name: HAKU_CONSOLE_MCP_APPROVAL_DATABASE_URL
+            - name: HAKU_CONSOLE_DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: haku-console-db-app

--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -72,6 +72,16 @@ spec:
               value: https://haku-ui.allegedly.works
             - name: HAKU_CONSOLE_AUTH_ORIGIN
               value: https://auth.allegedly.works
+            - name: HAKU_CONSOLE_MCP_APPROVAL_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: haku-console-db-app
+                  key: uri
+            - name: HAKU_CONSOLE_AGENT_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: haku-console-agent-api
+                  key: token
           resources:
             requests:
               cpu: 50m

--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -72,11 +72,33 @@ spec:
               value: https://haku-ui.allegedly.works
             - name: HAKU_CONSOLE_AUTH_ORIGIN
               value: https://auth.allegedly.works
-            - name: HAKU_CONSOLE_DATABASE_URL
+            - name: HAKU_CONSOLE_DB_USER
               valueFrom:
                 secretKeyRef:
                   name: haku-console-db-app
-                  key: uri
+                  key: username
+            - name: HAKU_CONSOLE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: haku-console-db-app
+                  key: password
+            - name: HAKU_CONSOLE_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: haku-console-db-app
+                  key: host
+            - name: HAKU_CONSOLE_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: haku-console-db-app
+                  key: port
+            - name: HAKU_CONSOLE_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: haku-console-db-app
+                  key: dbname
+            - name: HAKU_CONSOLE_DATABASE_URL
+              value: "postgresql+psycopg://$(HAKU_CONSOLE_DB_USER):$(HAKU_CONSOLE_DB_PASSWORD)@$(HAKU_CONSOLE_DB_HOST):$(HAKU_CONSOLE_DB_PORT)/$(HAKU_CONSOLE_DB_NAME)"
             - name: HAKU_CONSOLE_AGENT_API_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/cluster/k8s/haku/console/flux-kustomization.yaml
+++ b/cluster/k8s/haku/console/flux-kustomization.yaml
@@ -19,6 +19,7 @@ spec:
       name: sops-age-cluster-secrets
   dependsOn:
     - name: haku-console-namespace # the console's own trusted namespace (not haku-sandbox)
-    - name: haku-state # provisions haku-state-git-write into the haku-console namespace
+    - name: haku-console-db # distributed approval ledger
+    - name: haku-state # provisions the shared haku-ui/backend -> haku-console API token
     - name: gateway
     - name: authentik

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -226,6 +226,7 @@ resources:
   - haku/namespace/flux-kustomization.yaml
   - haku/rbac/flux-kustomization.yaml
   - haku/console-namespace/flux-kustomization.yaml # the console's own trusted namespace
+  - haku/console/db/flux-kustomization.yaml # CNPG approval ledger for console-approved tool calls
   - haku/console/flux-kustomization.yaml
   - haku/mailbox-namespace/flux-kustomization.yaml # the mailbox's own trusted namespace
   - haku/mailbox/db/flux-kustomization.yaml # CNPG store for the Stalwart mailserver

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -91,6 +91,28 @@ resource "kubernetes_secret" "haku_state_git_write" {
   }
 }
 
+resource "random_password" "haku_console_agent_api" {
+  length  = 48
+  special = false
+}
+
+# Shared token for the haku-ui backend / Haku worker -> haku-console agent API.
+# It does NOT approve calls; approval stays in trusted console chrome. Haku can see
+# this through haku-ui/Haku-owned pods, which is fine: it lets Haku request and sweep
+# console tool calls but not execute an approval-gated call by itself.
+resource "kubernetes_secret" "haku_console_agent_api" {
+  for_each = toset(["haku-sandbox", "haku-console"])
+
+  metadata {
+    name      = "haku-console-agent-api"
+    namespace = each.value
+  }
+
+  data = {
+    token = random_password.haku_console_agent_api.result
+  }
+}
+
 # Source credential for forgejo-token-rotation. The rotator uses Basic auth only
 # to mint full-account API tokens, then writes the distributed `tea` configs as
 # SOPS outputs in git.


### PR DESCRIPTION
Stacked on #2953.\n\nAdds the runtime substrate for the console approval ledger: CNPG database Flux wiring, haku-console DB env wiring, and the shared haku-console agent API token for haku-ui/Haku callers. This intentionally stops before connected MCP server catalog/credential configuration.\n\nValidation:\n- commit hooks passed, including kubeconform/checkov/tflint for the changed cluster/Terraform files\n- pre-commit run --all-files passed on the final stacked branch