### PR TITLE
haku/state_template: mirror the run-id convention change (ULID -> HHMMSSZ timestamp)

### DIFF
--- a/haku/state_template/README.md
+++ b/haku/state_template/README.md
@@ -38,7 +38,7 @@ it; if it only makes sense for this person, leave it in their `haku-state`.
 | `log/`                 | empty (`.gitkeep`)                                                                         | per-day run journal `log/YYYY-MM-DD.md`                       |
 | `intake/processed/`    | empty (`.gitkeep`)                                                                         | operator feedback lands in `intake/`; reduced → `processed/`  |
 | `responses/`           | empty (`.gitkeep`)                                                                         | operator affordance answers Haku reduces (below)              |
-| `runs/`                | `README.md`                                                                                | per-run propagation manifests `runs/<date>/<ulid>.md`         |
+| `runs/`                | `README.md`                                                                                | per-run propagation manifests `runs/<date>/<HHMMSSZ>.md`      |
 | `procedures/`          | the starter passes (README + topical files)                                                | Haku's playbook — read + grow (below)                         |
 | `ui/`                  | the starter multi-surface UI (React SPA + FastAPI backend + Dockerfile)                    | Haku's own UI service, CI-built (below)                       |
 | `items/`               | `README.md` (the example "items" model) + `.gitkeep`                                       | Haku writes one `<slug>.md` per item, if it keeps this format |

--- a/haku/state_template/procedures/propagation/README.md
+++ b/haku/state_template/procedures/propagation/README.md
@@ -6,7 +6,7 @@ for one change-domain: the surfaces I must consider when something in that domai
 
 **Each run, for each set of changes I saw, I walk the relevant checklist(s)** — for each surface,
 decide whether it needs the new info, and record the verdict (including "considered, no change")
-in that run's manifest (`runs/<date>/<ulid>.md` frontmatter: `checklists[]` + `propagation[]`).
+in that run's manifest (`runs/<date>/<HHMMSSZ>.md` frontmatter: `checklists[]` + `propagation[]`).
 
 These are a **FLOOR, not a ceiling.** They enumerate the surfaces I must not forget; free-form
 sources (a Gmail thread, a Tana note) carry meaning no checklist can pre-list — apply judgment

--- a/haku/state_template/runs/README.md
+++ b/haku/state_template/runs/README.md
@@ -4,16 +4,20 @@ Each run writes a manifest here proving every source was processed and recording
 propagated to every surface it belongs on. The UI's **Runs** tab reads these. See the base
 "Propagation discipline" obligation and `procedures/propagation/`.
 
-One markdown file per run, ULID-keyed (like `items/`), date-foldered (like `log/`):
-`runs/<YYYY-MM-DD>/<ulid>.md` — the propagation manifest as YAML **frontmatter** (the structured
+One markdown file per run, timestamp-keyed, date-foldered (like `log/`):
+`runs/<YYYY-MM-DD>/<HHMMSSZ>.md` (the run's start time, UTC — e.g. `runs/2026-07-06/144100Z.md`
+for a run started 14:41:00 UTC) — the propagation manifest as YAML **frontmatter** (the structured
 spine, CI-validated against `RunManifest` and read by the UI), then free-form reasoning as the
-markdown **body** (rendered in the Runs tab).
+markdown **body** (rendered in the Runs tab). A run's identity is _when it happened_, so the
+filename says that directly rather than needing the frontmatter opened to find out; sorting is
+always a projection over frontmatter fields (`started`), never the filename, so collisions are not
+a real risk for a single-agent run cadence.
 
-## Manifest schema (the `<ulid>.md` frontmatter)
+## Manifest schema (the `<HHMMSSZ>.md` frontmatter)
 
 ```markdown
 ---
-run_id: <ulid> # matches the filename
+run_id: <HHMMSSZ> # matches the filename
 date: "YYYY-MM-DD" # operator-local (the log/ date)
 started: <iso8601>
 finished: <iso8601>

--- a/haku/state_template/ui/README.md
+++ b/haku/state_template/ui/README.md
@@ -54,7 +54,7 @@ FastAPI, port `8080`. Endpoints:
   built from.
 - `GET /api/repo/tree` + `GET /api/repo/blobs` — the generic read-only content proxy the SPA
   composes to read `items/*.md`, `memory/improvements/*.md`, the run manifests
-  (`runs/<date>/<ulid>.md`, frontmatter + body parsed on the frontend), and any repo markdown at HEAD.
+  (`runs/<date>/<HHMMSSZ>.md`, frontmatter + body parsed on the frontend), and any repo markdown at HEAD.
 - `PUT/DELETE /api/responses/{scope}/{field}` — record/clear an operator response
   (item status, form answer) as `responses/<scope>/<field>.yaml`.
 - `POST /api/trace/feedback` — append an intake note (`text`, optional `item_id`).

--- a/haku/state_template/ui/backend/app.py
+++ b/haku/state_template/ui/backend/app.py
@@ -156,7 +156,7 @@ def create_app(settings: Settings) -> FastAPI:
     # generic tree+blobs proxy and rendered by the <improvement-board/> garden widget — no
     # bespoke endpoint. See plans/garden-gradient.md → Settled mechanism.
 
-    # The runs surface (runs/<date>/<ulid>.md) composes over the generic tree+blobs proxy — the
+    # The runs surface (runs/<date>/<HHMMSSZ>.md) composes over the generic tree+blobs proxy — the
     # frontend reads each run's manifest frontmatter + prose body and parses them (client.ts:fetchRuns).
     # No bespoke endpoint. RunManifest/RunsResponse stay in models.py as the wire contract.
 

--- a/haku/state_template/ui/backend/models.py
+++ b/haku/state_template/ui/backend/models.py
@@ -1,7 +1,7 @@
 """Typed models the backend reads from haku-state and serves over JSON.
 
 Each content collection carries thin, typed frontmatter (``items/<slug>.md``,
-``memory/improvements/<id>.md``, ``runs/<date>/<ulid>.md``); the validate-state gate
+``memory/improvements/<id>.md``, ``runs/<date>/<HHMMSSZ>.md``); the validate-state gate
 parses every file through these models so a malformed frontmatter file can't silently
 parse into a wrong shape. Typed values (enum, dates) validate strictly.
 
@@ -120,7 +120,7 @@ class ImprovementDoc(BaseModel):
     summary: str = ""  # ideas carry a one-liner; friction usually omits it
 
 
-# --- Runs surface (runs/<date>/<ulid>.md) --------------------------------------
+# --- Runs surface (runs/<date>/<HHMMSSZ>.md) --------------------------------------
 # Per-run propagation record: proves every source was processed and shows how each change
 # propagated to every surface. One markdown file per run — this manifest as YAML frontmatter (the
 # machine-checkable spine, validated below), prose reasoning as the body (rendered in the Runs

--- a/haku/state_template/ui/backend/test_models.py
+++ b/haku/state_template/ui/backend/test_models.py
@@ -50,7 +50,7 @@ def test_improvement_doc_rejects_bad_weight_kind_and_class():
             ImprovementDoc.model_validate({**base, **bad})
 
 
-# --- run manifests (runs/<date>/<ulid>.md frontmatter) ------------------------
+# --- run manifests (runs/<date>/<HHMMSSZ>.md frontmatter) ------------------------
 # The runs surface is composed on the frontend now (client.ts reads each run's frontmatter + prose
 # body over the tree+blobs proxy); this schema stays the floor those manifests must satisfy.
 

--- a/haku/state_template/ui/frontend/src/client.ts
+++ b/haku/state_template/ui/frontend/src/client.ts
@@ -87,7 +87,7 @@ export async function readResponse(scope: string, field: string): Promise<string
   return typeof parsed.value === "string" ? parsed.value : null;
 }
 
-// Recent per-run propagation records. Each run is one `runs/<date>/<ulid>.md`: the manifest as YAML
+// Recent per-run propagation records. Each run is one `runs/<date>/<HHMMSSZ>.md`: the manifest as YAML
 // frontmatter, prose notes as the body. `docsUnder` parses both; keep the docs that carry a
 // manifest (a `run_id`) so `runs/README.md` and any dangling note drop out. Newest-first by
 // `started`; missing optional fields default (mirrors the backend RunManifest) so one lean manifest

--- a/haku/state_template/ui/frontend/src/runs.tsx
+++ b/haku/state_template/ui/frontend/src/runs.tsx
@@ -196,8 +196,7 @@ function RunDetail({
 }
 
 // The Runs surface: a scannable table of runs → click into the full per-run propagation detail.
-// Proves every source was processed and shows how each change reached its surfaces. Read-only;
-// backed by runs/<date>/<ulid>.{yaml,md}.
+// Proves every source was processed and shows how each change reached its surfaces. Read-only.
 export function RunsPage({ openInGarden }: { openInGarden: (path: string) => void }) {
   const [runs, setRuns] = useState<RunManifest[] | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/haku/state_template/ui/frontend/src/types.ts
+++ b/haku/state_template/ui/frontend/src/types.ts
@@ -19,7 +19,7 @@ export interface MetaResponse {
 // Improvements are a content collection (memory/improvements/<id>.md) rendered by the
 // <improvement-board/> widget — no wire type; the widget parses frontmatter itself.
 
-// --- Runs surface (runs/<date>/<ulid>.md) ---
+// --- Runs surface (runs/<date>/<HHMMSSZ>.md) ---
 // Per-run propagation record: each source processed + how each change reached every surface.
 // A source was either scanned (bookmarks + count) or skipped (reason) — a discriminated union
 // (mirrors the backend's ScannedSource | SkippedSource); discriminate on the `skipped` key.


### PR DESCRIPTION
## Summary

- Haku's live `haku-state` deployment switched its run-manifest filenames from ULIDs
  (`runs/<date>/<ulid>.md`) to a plain UTC timestamp (`runs/<date>/<HHMMSSZ>.md`) — a run's
  identity is *when it happened*, and the filename should say that directly rather than needing
  the frontmatter opened to find out. Sorting was already a projection over the `started`
  frontmatter field, never the filename, so this is purely a naming convention change (no
  parsing/validation logic depended on the ULID shape — `run_id` is just `str` in the Pydantic
  model, and the frontend sorts `RunManifest[]` by `started`, not by filename).
- Mirrors that generic convention into `haku/state_template/` per its own sync boundary
  (`memory/haku-ui.md`'s "Template sync boundary" in the live `haku-state` repo — generic
  architecture/method changes seed into the template, operator-specific content stays in the
  live deployment).
- Comment/doc-only diff: `runs/README.md` (+ template's copy), `procedures/propagation/README.md`,
  `README.md`, `ui/README.md`, and code comments in `models.py`/`app.py`/`test_models.py`/
  `client.ts`/`runs.tsx`/`types.ts` that referenced the old `<ulid>.md` path shape. Also dropped
  one stale trailing comment in `runs.tsx` that still mentioned a long-migrated `.yaml` format.

## Test plan

- [x] Verified no code depends on the ULID shape (grepped for `ulid` across both `haku-state` and
  `haku/state_template`; only doc/comment references remained).
- [x] `haku-state`'s own copy of this change: `bash tools/validate_local.sh` (78/78 files valid),
  frontend `tsc -b` + `eslint` + `vitest run` (140/140 tests) all green, and CI (`validate-state` +
  `bazel-ci`) green on the live push.
- [x] `prettier --check`/`--write` on the touched `.md`/`.ts` files in this ducktape checkout;
  `ruff check` on the touched `.py` files (pre-existing unrelated import-sort warnings in
  `state_template/ui/backend/{app,test_models}.py` predate this change and aren't touched by it).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JYkiBvQZ3WS4uVaJUfBFNa)_