### PR TITLE
[codex] wire Claude Code OTEL direct export

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -152,17 +152,23 @@ rotator in <cluster/k8s/agents/authentik-jwt-rotation/>. Rotation is normally
 automatic; to force a refresh, delete `secrets/alloy-otlp-bearer-token.yaml`
 from `devel` or manually run the `authentik-jwt-rotation` CronJob.
 
-### Claude Code native telemetry (session OTLP forwarder)
+### Claude Code native telemetry
 
-Claude Code's own OTel exporter (enabled per environment via UI env vars,
-`OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318`) exports through a
-localhost relay: <otlp_forwarder.py>, started idempotently on every claude
-launch by <ensure_otel_forwarder.sh> (a profile background command in the web,
-home-manager, and haku profiles). The relay attaches the rotated bearer (from
+Claude Code's own OTel exporter is enabled system-wide for local machines by
+the Home Manager Claude Code module: <../../nix/home/claude_code/default.nix>.
+It sets `OTEL_EXPORTER_OTLP_ENDPOINT=https://alloy-otlp.allegedly.works` and an
+`otelHeadersHelper` script that reads the rotated bearer from the sops-nix
+materialized `secrets/alloy-otlp-bearer-token.yaml` token and emits headers JSON
+for Claude Code.
+
+Web/Haku sessions still use the localhost relay path
+(`OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318`): <otlp_forwarder.py>,
+started idempotently by <ensure_otel_forwarder.sh> from the web, home-manager,
+and haku profiles. The relay attaches the rotated bearer (from
 `DUCKTAPE_OTEL_BEARER_TOKEN`, else the `alloy-otlp-bearer` Secret mirrored into
 the sandbox namespaces — <cluster/k8s/agents/alloy-otlp-bearer/>) and forwards
 to `alloy-otlp.allegedly.works`. Rationale, probe evidence, and the env-var
-block to paste per environment: <plans/transcript_collection.md>.
+block to paste per hosted environment: <plans/transcript_collection.md>.
 
 ## Web Setup
 

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -159,7 +159,8 @@ the Home Manager Claude Code module: <../../nix/home/claude_code/default.nix>.
 It sets `OTEL_EXPORTER_OTLP_ENDPOINT=https://alloy-otlp.allegedly.works` and an
 `otelHeadersHelper` script that reads the rotated bearer from the sops-nix
 materialized `secrets/alloy-otlp-bearer-token.yaml` token and emits headers JSON
-for Claude Code.
+for Claude Code. This is inherited by the NixOS inline Home Manager hosts such
+as `iguana` and `wyrm2` through <../../nix/home/home.nix>.
 
 Web/Haku sessions still use the localhost relay path
 (`OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318`): <otlp_forwarder.py>,

--- a/devinfra/claude/plans/transcript_collection.md
+++ b/devinfra/claude/plans/transcript_collection.md
@@ -133,9 +133,10 @@ forwarder** (the exporter can't egress directly; see Facts):
   OTEL_LOG_RAW_API_BODIES=1
   ```
 
-- CLI / operator machines need no forwarder: direct export with `otelHeadersHelper`
-  in settings.json (a script emitting headers JSON, re-run every ~29 min; HTTP
-  protocols only) reading the `cli_env.sh` bearer. Not yet wired.
+- CLI / operator machines need no forwarder: direct export is wired in
+  <../../../nix/home/claude_code/default.nix> with `otelHeadersHelper` (a script
+  emitting headers JSON, re-run every ~29 min; HTTP protocols only) reading the
+  sops-nix materialized `secrets/alloy-otlp-bearer-token.yaml` bearer.
 - Possible later simplification (untested): if the hosted-egress block was only the
   environment domain allowlist, allowlisting `alloy-otlp.allegedly.works` +
   `otelHeadersHelper` would remove the forwarder. Test before assuming.
@@ -149,4 +150,4 @@ forwarder** (the exporter can't egress directly; see Facts):
 3. **Sink processor**: summary.json per session; wire Haku's run-manifest rows to it.
 4. **Grafana**: claude-code `GrafanaDashboard` CR once data flows; `web_selfcheck`
    check for the forwarder (4318 bound, token file fresh).
-5. CLI/machines OTel: `otelHeadersHelper` + direct export.
+5. Grafana dashboard and alerting around native Claude Code telemetry.

--- a/nix/TODO.md
+++ b/nix/TODO.md
@@ -31,10 +31,6 @@ Consider whether `nix/nixos/hosts/rugged` should switch from the current single 
 
 Evaluate whether console TTY password prompts can show visual feedback (for example `*` per keystroke) on NixOS hosts. This is not a standard NixOS knob like `sudo` `pwfeedback`; TTY login goes through `agetty` into `login`/PAM, so this likely requires a downstream package override or alternate login program. Scope and risks need review before implementing.
 
-## Wire Claude Code OTEL export to cluster collector
-
-Add OTEL env vars to `nix/home/claude_code/default.nix` `settings.env` block to export traces/logs/metrics to the cluster's OTEL collector endpoint. Key vars: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_EXPORTER`, `OTEL_LOGS_EXPORTER`, `OTEL_METRICS_EXPORTER`. Consider also `OTEL_LOG_TOOL_CONTENT=1` and `OTEL_LOG_TOOL_DETAILS=1` for full tool visibility. The `SRT_DEBUG=1` env var (already configured) provides sandbox-level network logging; OTEL would give structured traces for API calls, tool execution, and query latency.
-
 ## Roll out private-cache substituter + drivefs to remaining hosts
 
 drivefs and the `cache.allegedly.works/gaffer` substituter are wired on **wyrm2**

--- a/nix/home/claude_code/default.nix
+++ b/nix/home/claude_code/default.nix
@@ -454,6 +454,26 @@ let
       ) parsedPlugins
     );
   };
+
+  claudeOtelHeadersHelper = pkgs.writeShellApplication {
+    name = "claude-otel-headers";
+    runtimeInputs = [ pkgs.jq ];
+    text = ''
+      token_file="''${CLAUDE_CODE_OTEL_BEARER_TOKEN_FILE:-${config.sops.secrets.claude_code_otel_bearer_token.path}}"
+      if [ ! -r "$token_file" ]; then
+        echo "Claude Code OTEL bearer token file is not readable: $token_file" >&2
+        exit 1
+      fi
+
+      token="$(cat "$token_file")"
+      if [ -z "$token" ]; then
+        echo "Claude Code OTEL bearer token file is empty: $token_file" >&2
+        exit 1
+      fi
+
+      jq -n --arg token "$token" '{"Authorization": ("Bearer " + $token)}'
+    '';
+  };
 in
 {
   options.programs.claude-code.extraAllowedReadDirs = lib.mkOption {
@@ -592,6 +612,23 @@ in
       # ~/.claude/debug/ session logs.
       env.SRT_DEBUG = "1";
       env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+      # Native Claude Code telemetry direct to Grafana Alloy. The bearer is
+      # loaded by otelHeadersHelper from the sops-nix file below so the token is
+      # never embedded in settings.json.
+      env.CLAUDE_CODE_ENABLE_TELEMETRY = "1";
+      env.CLAUDE_CODE_ENHANCED_TELEMETRY_BETA = "1";
+      env.CLAUDE_CODE_OTEL_HEADERS_HELPER_DEBOUNCE_MS = "1740000";
+      env.OTEL_TRACES_EXPORTER = "otlp";
+      env.OTEL_LOGS_EXPORTER = "otlp";
+      env.OTEL_METRICS_EXPORTER = "otlp";
+      env.OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf";
+      env.OTEL_EXPORTER_OTLP_ENDPOINT = "https://alloy-otlp.allegedly.works";
+      env.OTEL_LOG_USER_PROMPTS = "1";
+      env.OTEL_LOG_TOOL_DETAILS = "1";
+      env.OTEL_LOG_TOOL_CONTENT = "1";
+      env.OTEL_LOG_RAW_API_BODIES = "1";
+      env.CLAUDE_CODE_OTEL_BEARER_TOKEN_FILE = config.sops.secrets.claude_code_otel_bearer_token.path;
+      otelHeadersHelper = "${claudeOtelHeadersHelper}/bin/claude-otel-headers";
 
       # Auto-generated from cfg.plugins
       enabledPlugins = lib.listToAttrs (
@@ -623,6 +660,11 @@ in
         additionalDirectories = baseAdditionalDirs;
       };
     };
+  };
+
+  config.sops.secrets.claude_code_otel_bearer_token = {
+    sopsFile = ../../../secrets/alloy-otlp-bearer-token.yaml;
+    key = "token";
   };
 
   # Add gmail-mcp-server to PATH for auth setup command


### PR DESCRIPTION
## Summary
- enable native Claude Code OTEL export in the Home Manager Claude Code module
- add a sops-nix backed otelHeadersHelper that emits Alloy Authorization headers without embedding the bearer in settings.json
- document local direct export versus hosted-session localhost forwarder behavior, including iguana/wyrm2 coverage through the shared Home Manager module
- remove the completed Claude Code OTEL TODO

## Validation
- nixfmt nix/home/claude_code/default.nix
- git diff --check
- nix eval --impure .#homeConfigurations.nixos-vm.config.programs.claude-code.settings.*
- nix eval --impure .#nixosConfigurations.iguana.config.home-manager.users.agentydragon.programs.claude-code.settings.{env.OTEL_EXPORTER_OTLP_ENDPOINT,otelHeadersHelper}
- nix eval --impure .#nixosConfigurations.wyrm2.config.home-manager.users.agentydragon.programs.claude-code.settings.{env.OTEL_EXPORTER_OTLP_ENDPOINT,otelHeadersHelper}
- helper smoke with fake token emitted Authorization JSON
- nix build --impure .#homeConfigurations.nixos-vm.activationPackage --no-link
- live smoke: local Claude Code session produced Tempo traces and Loki OTel logs via direct otelHeadersHelper path