### PR TITLE
[codex] document full Claude OTEL logging

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -187,9 +187,9 @@ These must be configured as env vars in the Claude Code web UI so they are injec
 `DUCKTAPE_CLAUDE_HOOKS_PROFILE` is needed so Claude Code injects the profile path into all hook subprocesses.
 `SOPS_AGE_KEY` is the age private key for decrypting secrets. The hook daemon receives it from the Claude process environment via `startup_env_script`.
 
-**Optional — Claude Code native telemetry** (Grafana dashboards via the session
-OTLP forwarder; see the OTEL Tracing section above and
-<plans/transcript_collection.md> for rationale and the content-detail knobs):
+**Claude Code native telemetry** (Grafana dashboards via the session OTLP
+forwarder; see the OTEL Tracing section above and
+<plans/transcript_collection.md> for rationale):
 
 ```text
 CLAUDE_CODE_ENABLE_TELEMETRY=1
@@ -199,13 +199,16 @@ OTEL_TRACES_EXPORTER=otlp
 CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+OTEL_LOG_USER_PROMPTS=1
+OTEL_LOG_TOOL_DETAILS=1
+OTEL_LOG_TOOL_CONTENT=1
+OTEL_LOG_RAW_API_BODIES=1
 ```
 
 Content-inclusion knobs (`OTEL_LOG_USER_PROMPTS`, `OTEL_LOG_TOOL_DETAILS`,
-`OTEL_LOG_TOOL_CONTENT`, `OTEL_LOG_RAW_API_BODIES`) are a per-environment
-sensitivity call — everything exported lands in the operator-only Loki. These
-must be **UI env vars**: only that mechanism reaches the claude process
-(startup-script exports reach Bash subprocesses only).
+`OTEL_LOG_TOOL_CONTENT`, `OTEL_LOG_RAW_API_BODIES`) are enabled for full logging
+to operator-only ingestion. These must be **UI env vars**: only that mechanism
+reaches the claude process (startup-script exports reach Bash subprocesses only).
 
 ### 2. Setup Script
 

--- a/devinfra/claude/plans/transcript_collection.md
+++ b/devinfra/claude/plans/transcript_collection.md
@@ -116,8 +116,8 @@ forwarder** (the exporter can't egress directly; see Facts):
   `claude-sandbox` and `haku-sandbox` (openclaw-sandbox deliberately excluded —
   nothing there runs the forwarder, and its Kustomization is suspended).
 - **Operator step — paste into each environment's UI env vars** (Haku env + default
-  web env; content knobs per env sensitivity; OTel events truncate at 60 KB, so the
-  rsync path remains the lossless record):
+  web env; full logging to operator-only ingestion; OTel events truncate at 60 KB,
+  so the rsync path remains the lossless record):
 
   ```text
   CLAUDE_CODE_ENABLE_TELEMETRY=1


### PR DESCRIPTION
## Summary
- include all Claude Code OTEL exporter and content logging knobs in the web UI env-var block
- remove the per-environment sensitivity wording and make full logging to operator-only ingestion explicit
- align the transcript collection plan with the full-logging policy

## Notes
- Nix-managed local Claude config already had traces, logs, metrics, user prompts, tool details, tool content, and raw API body logging enabled.

## Validation
- `pre-commit run --files devinfra/claude/README.md devinfra/claude/plans/transcript_collection.md`