### PR TITLE
[codex] haku-console operator MCP OAuth links

### DIFF
--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -89,6 +89,7 @@ py_library(
         "@pypi//fastapi",
         "@pypi//fastapi_csrf_protect",
         "@pypi//fastmcp",
+        "@pypi//httpx",
         "@pypi//mcp",
         "@pypi//psycopg",
         "@pypi//pydantic",

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -60,6 +60,11 @@ Core endpoints:
 - `GET /api/capabilities/mcp-servers` — reflect the configured connected MCP servers and each
   server's `tools/list` metadata. Entries are explicitly `alive` or `degraded`; the console config
   names reachable servers, and each live MCP server remains the tool schema source.
+- `GET /api/mcp/operator-auth`, `POST /api/mcp/operator-auth/{server_id}/start`,
+  `DELETE /api/mcp/operator-auth/{server_id}`, and `GET /api/mcp/operator-auth/callback` —
+  operator account association for MCP servers whose config enables `operator_oauth`. The catalog
+  stays in the console YAML/ConfigMap; Postgres stores only short-lived DCR/PKCE flow state and
+  per-operator token associations.
 - `POST /api/tool-calls` — submit a call with `server_id`, `tool_name`, exact
   `arguments`, and explicit `wait_for_ms`. The console mints the canonical `tool_call_id`.
 - `GET /api/approvals/pending`, `GET /api/approvals/events?after_event_id=...`, and
@@ -72,7 +77,11 @@ Core endpoints:
 
 Backend callers authenticate with the shared `HAKU_CONSOLE_AGENT_API_TOKEN`. Browser-origin
 approvals use the operator's Authentik session plus CSRF. The approval dialog renders in trusted
-console chrome, not inside Haku's iframe.
+console chrome, not inside Haku's iframe. If a server enables `operator_oauth`, approval execution
+uses the approving operator's linked OAuth token and refuses to move the call out of
+`pending_approval` until that association exists. Static bearer credentials can remain configured
+for reflection or fallback wiring, but they are not silently substituted for operator-approved
+execution on an `operator_oauth` server.
 
 ## Free-form UI — Haku's own UI, embedded
 
@@ -92,7 +101,8 @@ schema-validates, and decides/confirms before acting. It also mirrors the iframe
 (`routeChanged`, validated as a path) into the console's own URL fragment so refresh and deep
 links restore the view. A persistent ⚙ escape button opens the shell's own console panel
 (`console_panel.tsx`) — trusted chrome hosting shell-owned controls like the
-location-sharing stop/withdraw. See <docs/containment.md>.
+location-sharing stop/withdraw and MCP account connect/reconnect/disconnect controls. See
+<docs/containment.md>.
 
 ## Layout
 
@@ -120,7 +130,8 @@ shared web volume is used.
 Non-root, dropped caps, no service-account token. Credentials: the
 `haku-routine-launch-token` secret (the launch capability bearer; `HAKU_CONSOLE_LAUNCH_ROUTINE__TOKEN`)
 and, when MCP approval is enabled, the config-file/API-token/database settings:
-`HAKU_CONSOLE_CONFIG_FILE`, `HAKU_CONSOLE_DATABASE_URL`, and `HAKU_CONSOLE_AGENT_API_TOKEN`.
+`HAKU_CONSOLE_CONFIG_FILE`, `HAKU_CONSOLE_DATABASE_URL`, `HAKU_CONSOLE_AGENT_API_TOKEN`, and
+optionally `HAKU_CONSOLE_PUBLIC_BASE_URL` for OAuth redirect URI generation.
 It no longer holds a haku-state git credential — feedback/trace writes moved into haku-ui.
 As trusted ducktape code in its own namespace it is **not** behind the `haku-egress-proxy`
 fence — it gets ordinary cluster egress (which the capability tier needs to reach the

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -55,6 +55,11 @@ def create_app(settings: Settings) -> FastAPI:
         if settings.database_url is not None
         else None
     )
+    app.state.mcp_operator_oauth_store = (
+        mcp_approval.PostgresMcpOperatorOAuthStore(settings.database_url.get_secret_value())
+        if settings.database_url is not None
+        else None
+    )
     app.state.tool_call_event_hub = mcp_approval.ToolCallEventHub()
     app.state.tool_call_executor = mcp_approval.McpToolExecutor()
     app.state.tool_call_metadata_provider = mcp_approval.McpMetadataProvider()

--- a/haku/console/config.py
+++ b/haku/console/config.py
@@ -58,6 +58,9 @@ class Settings(BaseSettings):
     # The console never renders Haku's UI itself. See docs/containment.md.
     haku_ui_url: str
     auth_origin: str = "https://auth.allegedly.works"
+    # Public console origin used for OAuth redirect URIs. When unset, the MCP
+    # operator-auth API derives it from Host/X-Forwarded-* request headers.
+    public_base_url: str | None = None
 
     # Optional YAML file for deploy-time console configuration that does not belong
     # in env vars. Secret values stay in env/Kubernetes Secret references; this file

--- a/haku/console/database_schema.py
+++ b/haku/console/database_schema.py
@@ -94,4 +94,48 @@ class McpToolCallEvent(Base):
         )
 
 
+class McpOperatorOAuthAssociation(Base):
+    __tablename__ = "mcp_operator_oauth_associations"
+    __table_args__ = (Index("idx_mcp_operator_oauth_associations_operator", "operator_principal"),)
+
+    server_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    operator_principal: Mapped[str] = mapped_column(Text, primary_key=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    client_id: Mapped[str] = mapped_column(Text, nullable=False)
+    client_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
+    client_secret_expires_at: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    token_endpoint_auth_method: Mapped[str | None] = mapped_column(Text, nullable=True)
+    token_endpoint: Mapped[str] = mapped_column(Text, nullable=False)
+    resource: Mapped[str | None] = mapped_column(Text, nullable=True)
+    access_token: Mapped[str] = mapped_column(Text, nullable=False)
+    refresh_token: Mapped[str | None] = mapped_column(Text, nullable=True)
+    token_type: Mapped[str] = mapped_column(Text, nullable=False)
+    scope: Mapped[str | None] = mapped_column(Text, nullable=True)
+    token_expires_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class McpOperatorOAuthFlow(Base):
+    __tablename__ = "mcp_operator_oauth_flows"
+    __table_args__ = (
+        Index("idx_mcp_operator_oauth_flows_server_operator", "server_id", "operator_principal"),
+        Index("idx_mcp_operator_oauth_flows_expires_at", "expires_at"),
+    )
+
+    state: Mapped[str] = mapped_column(Text, primary_key=True)
+    server_id: Mapped[str] = mapped_column(Text, nullable=False)
+    operator_principal: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    redirect_uri: Mapped[str] = mapped_column(Text, nullable=False)
+    code_verifier: Mapped[str] = mapped_column(Text, nullable=False)
+    client_id: Mapped[str] = mapped_column(Text, nullable=False)
+    client_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
+    client_secret_expires_at: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    token_endpoint_auth_method: Mapped[str | None] = mapped_column(Text, nullable=True)
+    token_endpoint: Mapped[str] = mapped_column(Text, nullable=False)
+    resource: Mapped[str | None] = mapped_column(Text, nullable=True)
+    scope: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
 metadata = Base.metadata

--- a/haku/console/frontend/README.md
+++ b/haku/console/frontend/README.md
@@ -17,9 +17,13 @@ components + **Tailwind v4** utilities — modeled on
 - `client.ts` — typed `openapi-fetch` client; the types come from the backend's
   OpenAPI schema (the `:schema` target runs `//haku/console:export_schema_bin`), so
   the Pydantic models are the single source of truth for the wire contract. Includes the
-  launch-routine helper and the MCP approval queue helpers (`pending`, approve, deny).
+  launch-routine helper, MCP approval queue helpers (`pending`, approve, deny), and
+  MCP operator-account association helpers.
 - `confirm_dialog.tsx` — trusted top-layer confirmations for bridge launches, geolocation
   grants, off-whitelist opens, and MCP tool-call approvals.
+- `console_panel.tsx` — the single settings-button drawer for shell-owned controls. Keep
+  MCP account connect/reconnect/disconnect affordances here rather than adding more visible
+  widgets above the framed haku-ui.
 - `markdown.ts` — item `body` → sanitized HTML (`marked` + `dompurify`).
 - `styles.src.css` — `@import`s Tailwind + `@mantine/core` CSS; compiled by
   `@tailwindcss/cli` to `generated/styles.css`, then fingerprinted into

--- a/haku/console/frontend/client.ts
+++ b/haku/console/frontend/client.ts
@@ -12,6 +12,8 @@ export type ApprovalDecisionResponse = components["schemas"]["ApprovalDecisionRe
 type ApprovalDecisionRequest = components["schemas"]["ApprovalDecisionRequest"];
 export type PendingApproval = components["schemas"]["PendingApproval"];
 export type ToolCallRecord = components["schemas"]["ToolCallRecord"];
+export type McpOperatorAuthStatus = components["schemas"]["McpOperatorAuthStatus"];
+export type McpOperatorAuthStartResponse = components["schemas"]["McpOperatorAuthStartResponse"];
 
 // FastAPI error responses are `{detail: string}`; surface that real reason rather
 // than a generic message, falling back when the body isn't shaped that way.
@@ -52,6 +54,32 @@ export async function fetchPendingApprovals(): Promise<PendingApproval[]> {
   const { data, error } = await api.GET("/api/approvals/pending");
   if (error || !data) throw new Error(errorDetail(error, "Failed to load pending approvals"));
   return data.approvals ?? [];
+}
+
+export async function fetchMcpOperatorAuthStatuses(): Promise<McpOperatorAuthStatus[]> {
+  const { data, error } = await api.GET("/api/mcp/operator-auth");
+  if (error || !data) throw new Error(errorDetail(error, "Failed to load MCP account links"));
+  return data.associations ?? [];
+}
+
+export async function startMcpOperatorAuth(serverId: string): Promise<McpOperatorAuthStartResponse> {
+  const csrfToken = await fetchCsrfToken();
+  const { data, error } = await api.POST("/api/mcp/operator-auth/{server_id}/start", {
+    params: { path: { server_id: serverId } },
+    headers: { "X-CSRF-Token": csrfToken },
+  });
+  if (error || !data) throw new Error(errorDetail(error, "Failed to start MCP account link"));
+  return data;
+}
+
+export async function disconnectMcpOperatorAuth(serverId: string): Promise<McpOperatorAuthStatus> {
+  const csrfToken = await fetchCsrfToken();
+  const { data, error } = await api.DELETE("/api/mcp/operator-auth/{server_id}", {
+    params: { path: { server_id: serverId } },
+    headers: { "X-CSRF-Token": csrfToken },
+  });
+  if (error || !data) throw new Error(errorDetail(error, "Failed to disconnect MCP account"));
+  return data;
 }
 
 async function decideToolCall(

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -1,4 +1,6 @@
-import { Badge, Button, Drawer, Group, Stack, Text } from "@mantine/core";
+import { Badge, Button, Divider, Drawer, Group, Stack, Text } from "@mantine/core";
+
+import type { McpOperatorAuthStatus } from "./client.ts";
 
 // The shell's own operator control surface — trusted chrome the agent-owned iframe cannot
 // render into, opened by the floating escape button over the (full-page) frame. It hosts
@@ -16,12 +18,31 @@ export interface ConsolePanelProps {
   geoGranted: boolean;
   tracking: boolean;
   onWithdrawGeolocation: () => void;
+  mcpAuthStatuses: McpOperatorAuthStatus[];
+  onConnectMcp: (serverId: string) => void;
+  onDisconnectMcp: (serverId: string) => void;
+  onRefreshMcp: () => void;
 }
 
 // zIndex maxed so the Drawer sits above the full-page iframe; the escape button is one below.
 export const PANEL_Z = 2147483647;
 
-export function ConsolePanel({ opened, onClose, geoGranted, tracking, onWithdrawGeolocation }: ConsolePanelProps) {
+function shortDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return new Date(value).toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
+}
+
+export function ConsolePanel({
+  opened,
+  onClose,
+  geoGranted,
+  tracking,
+  onWithdrawGeolocation,
+  mcpAuthStatuses,
+  onConnectMcp,
+  onDisconnectMcp,
+  onRefreshMcp,
+}: ConsolePanelProps) {
   return (
     <Drawer opened={opened} onClose={onClose} position="right" size="sm" title="Console" zIndex={PANEL_Z}>
       <Stack gap="lg">
@@ -48,6 +69,66 @@ export function ConsolePanel({ opened, onClose, geoGranted, tracking, onWithdraw
             <Text size="sm" c="dimmed">
               Not shared — Haku will ask when it needs your location.
             </Text>
+          )}
+        </Stack>
+        <Divider />
+        <Stack gap="sm">
+          <Group justify="space-between">
+            <Text fw={600} size="sm">
+              MCP accounts
+            </Text>
+            <Button size="compact-xs" variant="subtle" onClick={onRefreshMcp}>
+              Refresh
+            </Button>
+          </Group>
+          {mcpAuthStatuses.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              No operator-linked MCP servers are configured.
+            </Text>
+          ) : (
+            mcpAuthStatuses.map((status) => (
+              <Stack key={status.server_id} gap={5}>
+                <Group justify="space-between" align="flex-start" gap="xs">
+                  <Stack gap={2}>
+                    <Text size="sm" fw={500}>
+                      {status.server_id}
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                      {status.status === "connected"
+                        ? `Linked for ${status.operator_principal}${
+                            shortDate(status.token_expires_at) ? ` until ${shortDate(status.token_expires_at)}` : ""
+                          }`
+                        : `Not linked for ${status.operator_principal}`}
+                    </Text>
+                  </Stack>
+                  {status.status === "connected" ? (
+                    <Badge color="teal" variant="light">
+                      Connected
+                    </Badge>
+                  ) : (
+                    <Badge color="gray" variant="light">
+                      Unconnected
+                    </Badge>
+                  )}
+                </Group>
+                <Group justify="flex-end" gap="xs">
+                  {status.status === "connected" ? (
+                    <>
+                      <Button size="xs" variant="light" onClick={() => onConnectMcp(status.server_id)}>
+                        Reconnect
+                      </Button>
+                      <Button size="xs" variant="subtle" color="red" onClick={() => onDisconnectMcp(status.server_id)}>
+                        Disconnect
+                      </Button>
+                    </>
+                  ) : (
+                    <Button size="xs" variant="light" onClick={() => onConnectMcp(status.server_id)}>
+                      Connect
+                    </Button>
+                  )}
+                </Group>
+              </Stack>
+            ))
           )}
         </Stack>
       </Stack>

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -2,7 +2,17 @@ import { ActionIcon, Anchor, Indicator } from "@mantine/core";
 import { useEffect, useRef, useState } from "react";
 
 import { type GeolocationOptions, isRoutePath, type Outbound, parseInbound, vetOpenLink } from "./bridge.ts";
-import { approveToolCall, denyToolCall, fetchPendingApprovals, launchRoutine, type PendingApproval } from "./client.ts";
+import {
+  approveToolCall,
+  denyToolCall,
+  disconnectMcpOperatorAuth,
+  fetchMcpOperatorAuthStatuses,
+  fetchPendingApprovals,
+  launchRoutine,
+  type McpOperatorAuthStatus,
+  type PendingApproval,
+  startMcpOperatorAuth,
+} from "./client.ts";
 import { ConfirmDialog, type Escalation } from "./confirm_dialog.tsx";
 import { ConsolePanel, PANEL_Z } from "./console_panel.tsx";
 import { GEO_PERMISSION_DENIED, GeolocationWatcher, getGeolocation } from "./geolocation.ts";
@@ -34,6 +44,7 @@ export function openExternal(url: string): boolean {
 
 const POPUP_HINT = "Allow pop-ups for this site so the console can open links.";
 const TOOL_APPROVAL_CHANNEL = "haku-console-tool-approvals";
+const MCP_AUTH_CHANNEL = "haku-console-mcp-auth";
 
 type ToolApprovalChannelMessage = { type: "toolApprovalsChanged" };
 
@@ -65,11 +76,13 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
   // to launch). One typed action, dispatched on its `kind` — see ConfirmDialog's Escalation.
   const [pending, setPending] = useState<Escalation | null>(null);
   const [toolApprovals, setToolApprovals] = useState<PendingApproval[]>([]);
+  const [mcpAuthStatuses, setMcpAuthStatuses] = useState<McpOperatorAuthStatus[]>([]);
   // Computed once: later routeChanged mirroring must not rewrite `src` (that would
   // reload the frame); the iframe navigates itself, the console only reflects.
   const [frameSrc] = useState(() => initialFrameSrc(uiUrl, window.location.hash));
   const origin = new URL(uiUrl).origin;
   const toolApprovalChannelRef = useRef<BroadcastChannel | null>(null);
+  const mcpAuthChannelRef = useRef<BroadcastChannel | null>(null);
   const activeAction: Escalation | null =
     pending ?? (toolApprovals[0] ? { kind: "toolApproval", approval: toolApprovals[0] } : null);
 
@@ -149,6 +162,36 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
     );
   }
 
+  function refreshMcpAuthStatuses(notifyPeers = false) {
+    if (notifyPeers) mcpAuthChannelRef.current?.postMessage({ type: "mcpAuthChanged" });
+    void fetchMcpOperatorAuthStatuses().then(
+      (statuses) => setMcpAuthStatuses(statuses),
+      (e: unknown) => toastError("Couldn't load MCP account links", e)
+    );
+  }
+
+  function connectMcp(serverId: string) {
+    void startMcpOperatorAuth(serverId)
+      .then((started) => {
+        if (!openExternal(started.authorization_url)) {
+          toastError("Pop-up blocked", POPUP_HINT);
+          return;
+        }
+        toastSuccess("MCP account link started", "Finish the authorization in the new tab.");
+      })
+      .catch((e: unknown) => toastError("Couldn't start MCP account link", e));
+  }
+
+  function disconnectMcp(serverId: string) {
+    void disconnectMcpOperatorAuth(serverId).then(
+      () => {
+        toastSuccess("MCP account disconnected", serverId);
+        refreshMcpAuthStatuses(true);
+      },
+      (e: unknown) => toastError("Couldn't disconnect MCP account", e)
+    );
+  }
+
   // Tear down any live browser watches if the console unmounts.
   useEffect(() => () => void watcher.stopAll(), [watcher]);
 
@@ -161,6 +204,18 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
     };
     return () => {
       if (toolApprovalChannelRef.current === channel) toolApprovalChannelRef.current = null;
+      channel.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    refreshMcpAuthStatuses();
+    if (!("BroadcastChannel" in window)) return;
+    const channel = new BroadcastChannel(MCP_AUTH_CHANNEL);
+    mcpAuthChannelRef.current = channel;
+    channel.onmessage = () => refreshMcpAuthStatuses();
+    return () => {
+      if (mcpAuthChannelRef.current === channel) mcpAuthChannelRef.current = null;
       channel.close();
     };
   }, []);
@@ -353,6 +408,10 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
         geoGranted={geoGranted}
         tracking={tracking}
         onWithdrawGeolocation={withdrawGeolocation}
+        mcpAuthStatuses={mcpAuthStatuses}
+        onConnectMcp={connectMcp}
+        onDisconnectMcp={disconnectMcp}
+        onRefreshMcp={() => refreshMcpAuthStatuses(true)}
       />
       <ConfirmDialog action={activeAction} onApprove={onApprove} onCancel={onCancel} />
     </>

--- a/haku/console/mcp_approval.py
+++ b/haku/console/mcp_approval.py
@@ -9,26 +9,58 @@ console chrome.
 from __future__ import annotations
 
 import asyncio
+import base64
 import datetime as dt
+import html
 import logging
 import os
 import re
 import secrets
 from collections.abc import Iterable
 from typing import Annotated, Any, Literal, Protocol, cast
+from urllib.parse import quote, urlencode, urljoin
 
+import httpx
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
 from fastapi_csrf_protect import CsrfProtect
 from fastmcp.client import Client
 from mcp import types as mcp_types
-from pydantic import BaseModel, Field
-from sqlalchemy import create_engine, select
+from mcp.client.auth.oauth2 import PKCEParameters
+from mcp.client.auth.utils import (
+    build_oauth_authorization_server_metadata_discovery_urls,
+    build_protected_resource_metadata_discovery_urls,
+    extract_resource_metadata_from_www_auth,
+    extract_scope_from_www_auth,
+    get_client_metadata_scopes,
+    handle_auth_metadata_response,
+    handle_protected_resource_response,
+    handle_registration_response,
+    handle_token_response_scopes,
+)
+from mcp.client.streamable_http import MCP_PROTOCOL_VERSION
+from mcp.shared.auth import (
+    OAuthClientInformationFull,
+    OAuthClientMetadata,
+    OAuthMetadata,
+    OAuthToken,
+    ProtectedResourceMetadata,
+)
+from mcp.shared.auth_utils import check_resource_allowed, resource_url_from_server_url
+from mcp.types import LATEST_PROTOCOL_VERSION
+from pydantic import BaseModel, Field, ValidationError
+from sqlalchemy import create_engine, delete, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from haku.console.config import Settings
 from haku.console.database_migrate import run_migrations_for_connection
-from haku.console.database_schema import McpToolCall, McpToolCallEvent
+from haku.console.database_schema import (
+    McpOperatorOAuthAssociation,
+    McpOperatorOAuthFlow,
+    McpToolCall,
+    McpToolCallEvent,
+)
 from haku.console.deps import SettingsDep
 from haku.console.mcp_models import (
     ApprovalDecisionRequest,
@@ -46,12 +78,22 @@ Csrf = Annotated[CsrfProtect, Depends()]
 
 
 TERMINAL_STATUSES = {ToolCallStatus.OK, ToolCallStatus.ERROR, ToolCallStatus.DENIED}
+MCP_OPERATOR_AUTH_CALLBACK_PATH = "/api/mcp/operator-auth/callback"
+MCP_OPERATOR_AUTH_FLOW_TTL = dt.timedelta(minutes=10)
+MCP_OPERATOR_AUTH_REFRESH_SKEW = dt.timedelta(seconds=60)
+
+
+class McpOperatorOAuthConfig(BaseModel):
+    enabled: bool = True
+    client_name: str = "Haku Console"
+    scopes: list[str] | None = None
 
 
 class McpServerEntry(BaseModel):
     id: str
     server_url: str
     bearer_token_secret: str | None = None
+    operator_oauth: McpOperatorOAuthConfig | None = None
 
 
 class ConsoleMcpConfig(BaseModel):
@@ -102,6 +144,25 @@ class ToolCapabilitiesResponse(BaseModel):
     servers: list[ServerMetadata] = Field(default_factory=list)
 
 
+class McpOperatorAuthStatus(BaseModel):
+    server_id: str
+    status: Literal["connected", "unconnected"]
+    operator_principal: str
+    connected_at: dt.datetime | None = None
+    token_expires_at: dt.datetime | None = None
+    scope: str | None = None
+
+
+class McpOperatorAuthStatusResponse(BaseModel):
+    associations: list[McpOperatorAuthStatus] = Field(default_factory=list)
+
+
+class McpOperatorAuthStartResponse(BaseModel):
+    server_id: str
+    authorization_url: str
+    expires_at: dt.datetime
+
+
 class PendingApproval(BaseModel):
     tool_call_id: str
     server_id: str
@@ -149,6 +210,22 @@ class ToolCallLedgerProtocol(Protocol):
     def finish(
         self, tool_call_id: str, *, result: dict[str, Any] | None, error: str | None
     ) -> tuple[ToolCallRecord, ToolCallEvent]: ...
+
+
+class McpOperatorOAuthStoreProtocol(Protocol):
+    def list_statuses(
+        self, *, servers: list[McpServerEntry], operator_principal: str
+    ) -> McpOperatorAuthStatusResponse: ...
+
+    async def start_flow(
+        self, *, server: McpServerEntry, operator_principal: str, public_base_url: str
+    ) -> McpOperatorAuthStartResponse: ...
+
+    async def complete_callback(self, *, state: str, code: str) -> McpOperatorAuthStatus: ...
+
+    def disconnect(self, *, server_id: str, operator_principal: str) -> None: ...
+
+    async def access_token_for(self, *, server: McpServerEntry, operator_principal: str) -> str | None: ...
 
 
 class PostgresToolCallLedger:
@@ -269,6 +346,154 @@ class PostgresToolCallLedger:
         return row
 
 
+class PostgresMcpOperatorOAuthStore:
+    """Postgres-backed operator OAuth association store for connected MCP servers."""
+
+    def __init__(self, database_url: str) -> None:
+        self._engine = create_engine(database_url, pool_pre_ping=True)
+        with self._engine.begin() as conn:
+            run_migrations_for_connection(conn)
+        self._sessions = sessionmaker(self._engine, expire_on_commit=False)
+
+    def list_statuses(self, *, servers: list[McpServerEntry], operator_principal: str) -> McpOperatorAuthStatusResponse:
+        oauth_servers = [server for server in servers if _operator_oauth_enabled(server)]
+        if not oauth_servers:
+            return McpOperatorAuthStatusResponse()
+        server_ids = [server.id for server in oauth_servers]
+        with self._sessions.begin() as session:
+            rows = session.scalars(
+                select(McpOperatorOAuthAssociation)
+                .where(McpOperatorOAuthAssociation.operator_principal == operator_principal)
+                .where(McpOperatorOAuthAssociation.server_id.in_(server_ids))
+            ).all()
+        by_server = {row.server_id: row for row in rows}
+        return McpOperatorAuthStatusResponse(
+            associations=[
+                _oauth_status_from_row(server.id, operator_principal, by_server.get(server.id))
+                for server in oauth_servers
+            ]
+        )
+
+    async def start_flow(
+        self, *, server: McpServerEntry, operator_principal: str, public_base_url: str
+    ) -> McpOperatorAuthStartResponse:
+        if not _operator_oauth_enabled(server):
+            raise HTTPException(status_code=404, detail=f"MCP server {server.id} does not use operator OAuth")
+        flow = await _build_operator_oauth_flow(server, operator_principal, public_base_url.rstrip("/"))
+        with self._sessions.begin() as session:
+            now = dt.datetime.now(dt.UTC)
+            session.execute(delete(McpOperatorOAuthFlow).where(McpOperatorOAuthFlow.expires_at < now))
+            session.execute(
+                delete(McpOperatorOAuthFlow)
+                .where(McpOperatorOAuthFlow.server_id == server.id)
+                .where(McpOperatorOAuthFlow.operator_principal == operator_principal)
+            )
+            session.add(
+                McpOperatorOAuthFlow(
+                    state=flow.state,
+                    server_id=server.id,
+                    operator_principal=operator_principal,
+                    created_at=now,
+                    expires_at=flow.expires_at,
+                    redirect_uri=flow.redirect_uri,
+                    code_verifier=flow.code_verifier,
+                    client_id=flow.client_info.client_id or "",
+                    client_secret=flow.client_info.client_secret,
+                    client_secret_expires_at=flow.client_info.client_secret_expires_at,
+                    token_endpoint_auth_method=flow.client_info.token_endpoint_auth_method,
+                    token_endpoint=flow.token_endpoint,
+                    resource=flow.resource,
+                    scope=flow.scope,
+                )
+            )
+        return McpOperatorAuthStartResponse(
+            server_id=server.id, authorization_url=flow.authorization_url, expires_at=flow.expires_at
+        )
+
+    async def complete_callback(self, *, state: str, code: str) -> McpOperatorAuthStatus:
+        with self._sessions.begin() as session:
+            row = session.get(McpOperatorOAuthFlow, state)
+            if row is None:
+                raise HTTPException(status_code=404, detail="OAuth flow not found or already used")
+            session.delete(row)
+            flow = _oauth_flow_snapshot(row)
+        now = dt.datetime.now(dt.UTC)
+        if flow["expires_at"] < now:
+            raise HTTPException(status_code=410, detail="OAuth flow expired; start connection again")
+        token = await _exchange_operator_oauth_code(flow, code)
+        token_expires_at = _token_expires_at(token, now)
+        with self._sessions.begin() as session:
+            existing = session.get(
+                McpOperatorOAuthAssociation, (flow["server_id"], flow["operator_principal"]), with_for_update=True
+            )
+            if existing is None:
+                existing = McpOperatorOAuthAssociation(
+                    server_id=flow["server_id"],
+                    operator_principal=flow["operator_principal"],
+                    created_at=now,
+                    updated_at=now,
+                    client_id=flow["client_id"],
+                    client_secret=flow["client_secret"],
+                    client_secret_expires_at=flow["client_secret_expires_at"],
+                    token_endpoint_auth_method=flow["token_endpoint_auth_method"],
+                    token_endpoint=flow["token_endpoint"],
+                    resource=flow["resource"],
+                    access_token=token.access_token,
+                    refresh_token=token.refresh_token,
+                    token_type=token.token_type,
+                    scope=token.scope or flow["scope"],
+                    token_expires_at=token_expires_at,
+                )
+                session.add(existing)
+            else:
+                existing.updated_at = now
+                existing.client_id = flow["client_id"]
+                existing.client_secret = flow["client_secret"]
+                existing.client_secret_expires_at = flow["client_secret_expires_at"]
+                existing.token_endpoint_auth_method = flow["token_endpoint_auth_method"]
+                existing.token_endpoint = flow["token_endpoint"]
+                existing.resource = flow["resource"]
+                existing.access_token = token.access_token
+                existing.refresh_token = token.refresh_token
+                existing.token_type = token.token_type
+                existing.scope = token.scope or flow["scope"]
+                existing.token_expires_at = token_expires_at
+            return _oauth_status_from_row(flow["server_id"], flow["operator_principal"], existing)
+
+    def disconnect(self, *, server_id: str, operator_principal: str) -> None:
+        with self._sessions.begin() as session:
+            row = session.get(McpOperatorOAuthAssociation, (server_id, operator_principal), with_for_update=True)
+            if row is not None:
+                session.delete(row)
+
+    async def access_token_for(self, *, server: McpServerEntry, operator_principal: str) -> str | None:
+        if not _operator_oauth_enabled(server):
+            return None
+        with self._sessions.begin() as session:
+            row = session.get(McpOperatorOAuthAssociation, (server.id, operator_principal), with_for_update=True)
+            if row is None:
+                return None
+            now = dt.datetime.now(dt.UTC)
+            if row.token_expires_at is None or row.token_expires_at > now + MCP_OPERATOR_AUTH_REFRESH_SKEW:
+                return row.access_token
+            if not row.refresh_token:
+                return None
+            snapshot = _oauth_association_snapshot(row)
+        refreshed = await _refresh_operator_oauth_token(snapshot)
+        token_expires_at = _token_expires_at(refreshed, dt.datetime.now(dt.UTC))
+        with self._sessions.begin() as session:
+            row = session.get(McpOperatorOAuthAssociation, (server.id, operator_principal), with_for_update=True)
+            if row is None:
+                return None
+            row.updated_at = dt.datetime.now(dt.UTC)
+            row.access_token = refreshed.access_token
+            row.refresh_token = refreshed.refresh_token or row.refresh_token
+            row.token_type = refreshed.token_type
+            row.scope = refreshed.scope or row.scope
+            row.token_expires_at = token_expires_at
+            return row.access_token
+
+
 class ToolCallEventHub:
     def __init__(self) -> None:
         self._connections: set[WebSocket] = set()
@@ -296,8 +521,10 @@ class ToolCallEventHub:
 
 
 class McpToolExecutor:
-    async def execute(self, server: McpServerEntry, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
-        async with Client(server.server_url, auth=_credential_token(server)) as client:
+    async def execute(
+        self, server: McpServerEntry, tool_name: str, arguments: dict[str, Any], auth_token: str | None
+    ) -> dict[str, Any]:
+        async with Client(server.server_url, auth=auth_token) as client:
             result = await client.call_tool_mcp(tool_name, arguments)
         if result.isError:
             raise RuntimeError(_mcp_error_message(result))
@@ -339,10 +566,320 @@ def _metadata_provider(request: Request) -> McpMetadataProvider:
     return cast(McpMetadataProvider, request.app.state.tool_call_metadata_provider)
 
 
+def _oauth_store(request: Request) -> McpOperatorOAuthStoreProtocol:
+    store = request.app.state.mcp_operator_oauth_store
+    if store is None:
+        raise HTTPException(status_code=503, detail="MCP operator OAuth database is not configured")
+    return cast(McpOperatorOAuthStoreProtocol, store)
+
+
 LedgerDep = Annotated[ToolCallLedgerProtocol, Depends(_ledger)]
 HubDep = Annotated[ToolCallEventHub, Depends(_hub)]
 ExecutorDep = Annotated[McpToolExecutor, Depends(_executor)]
 MetadataProviderDep = Annotated[McpMetadataProvider, Depends(_metadata_provider)]
+OAuthStoreDep = Annotated[McpOperatorOAuthStoreProtocol, Depends(_oauth_store)]
+
+
+class _BuiltOperatorOAuthFlow(BaseModel):
+    state: str
+    authorization_url: str
+    expires_at: dt.datetime
+    redirect_uri: str
+    code_verifier: str
+    client_info: OAuthClientInformationFull
+    token_endpoint: str
+    resource: str | None = None
+    scope: str | None = None
+
+
+def _operator_oauth_enabled(server: McpServerEntry) -> bool:
+    return bool(server.operator_oauth and server.operator_oauth.enabled)
+
+
+def _oauth_status_from_row(
+    server_id: str, operator_principal: str, row: McpOperatorOAuthAssociation | None
+) -> McpOperatorAuthStatus:
+    if row is None:
+        return McpOperatorAuthStatus(server_id=server_id, status="unconnected", operator_principal=operator_principal)
+    return McpOperatorAuthStatus(
+        server_id=server_id,
+        status="connected",
+        operator_principal=operator_principal,
+        connected_at=row.created_at,
+        token_expires_at=row.token_expires_at,
+        scope=row.scope,
+    )
+
+
+def _token_expires_at(token: OAuthToken, now: dt.datetime) -> dt.datetime | None:
+    if token.expires_in is None:
+        return None
+    return now + dt.timedelta(seconds=token.expires_in)
+
+
+def _oauth_flow_snapshot(row: McpOperatorOAuthFlow) -> dict[str, Any]:
+    return {
+        "state": row.state,
+        "server_id": row.server_id,
+        "operator_principal": row.operator_principal,
+        "expires_at": row.expires_at,
+        "redirect_uri": row.redirect_uri,
+        "code_verifier": row.code_verifier,
+        "client_id": row.client_id,
+        "client_secret": row.client_secret,
+        "client_secret_expires_at": row.client_secret_expires_at,
+        "token_endpoint_auth_method": row.token_endpoint_auth_method,
+        "token_endpoint": row.token_endpoint,
+        "resource": row.resource,
+        "scope": row.scope,
+    }
+
+
+def _oauth_association_snapshot(row: McpOperatorOAuthAssociation) -> dict[str, Any]:
+    return {
+        "server_id": row.server_id,
+        "operator_principal": row.operator_principal,
+        "client_id": row.client_id,
+        "client_secret": row.client_secret,
+        "token_endpoint_auth_method": row.token_endpoint_auth_method,
+        "token_endpoint": row.token_endpoint,
+        "resource": row.resource,
+        "refresh_token": row.refresh_token,
+    }
+
+
+def _metadata_request_headers() -> dict[str, str]:
+    return {MCP_PROTOCOL_VERSION: LATEST_PROTOCOL_VERSION}
+
+
+async def _discover_protected_resource(
+    client: httpx.AsyncClient, server_url: str, auth_probe: httpx.Response
+) -> ProtectedResourceMetadata | None:
+    metadata_url = extract_resource_metadata_from_www_auth(auth_probe)
+    for url in build_protected_resource_metadata_discovery_urls(metadata_url, server_url):
+        response = await client.get(url, headers=_metadata_request_headers())
+        metadata = await handle_protected_resource_response(response)
+        if metadata:
+            return metadata
+    return None
+
+
+async def _discover_oauth_metadata(
+    client: httpx.AsyncClient, server_url: str, resource_metadata: ProtectedResourceMetadata | None
+) -> OAuthMetadata | None:
+    auth_server_url = str(resource_metadata.authorization_servers[0]) if resource_metadata else None
+    for url in build_oauth_authorization_server_metadata_discovery_urls(auth_server_url, server_url):
+        response = await client.get(url, headers=_metadata_request_headers())
+        ok, metadata = await handle_auth_metadata_response(response)
+        if metadata:
+            return metadata
+        if not ok:
+            break
+    return None
+
+
+def _resource_for_oauth(server_url: str, resource_metadata: ProtectedResourceMetadata | None) -> str | None:
+    if resource_metadata is None:
+        return None
+    requested = resource_url_from_server_url(server_url)
+    configured = str(resource_metadata.resource)
+    if check_resource_allowed(requested_resource=requested, configured_resource=configured):
+        return configured
+    return requested
+
+
+async def _register_oauth_client(
+    client: httpx.AsyncClient,
+    server_url: str,
+    oauth_metadata: OAuthMetadata | None,
+    client_metadata: OAuthClientMetadata,
+) -> OAuthClientInformationFull:
+    if oauth_metadata and oauth_metadata.registration_endpoint:
+        registration_url = str(oauth_metadata.registration_endpoint)
+    else:
+        registration_url = urljoin(_authorization_base_url(server_url), "/register")
+    response = await client.post(
+        registration_url,
+        json=client_metadata.model_dump(by_alias=True, mode="json", exclude_none=True),
+        headers={"Content-Type": "application/json"},
+    )
+    return await handle_registration_response(response)
+
+
+def _authorization_base_url(server_url: str) -> str:
+    parsed = httpx.URL(server_url)
+    return f"{parsed.scheme}://{parsed.host}{f':{parsed.port}' if parsed.port else ''}"
+
+
+async def _build_operator_oauth_flow(
+    server: McpServerEntry, operator_principal: str, public_base_url: str
+) -> _BuiltOperatorOAuthFlow:
+    assert server.operator_oauth is not None
+    redirect_uri = f"{public_base_url}{MCP_OPERATOR_AUTH_CALLBACK_PATH}"
+    try:
+        async with httpx.AsyncClient(follow_redirects=False, timeout=10.0) as client:
+            auth_probe = await client.get(server.server_url, headers=_metadata_request_headers())
+            resource_metadata = await _discover_protected_resource(client, server.server_url, auth_probe)
+            oauth_metadata = await _discover_oauth_metadata(client, server.server_url, resource_metadata)
+            scope = (
+                " ".join(server.operator_oauth.scopes)
+                if server.operator_oauth.scopes is not None
+                else get_client_metadata_scopes(
+                    extract_scope_from_www_auth(auth_probe), resource_metadata, oauth_metadata
+                )
+            )
+            client_metadata = OAuthClientMetadata(
+                client_name=server.operator_oauth.client_name,
+                redirect_uris=[redirect_uri],
+                grant_types=["authorization_code", "refresh_token"],
+                response_types=["code"],
+                scope=scope,
+            )
+            client_info = await _register_oauth_client(client, server.server_url, oauth_metadata, client_metadata)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"failed to start MCP OAuth flow for {server.id}: {e}") from e
+
+    if not client_info.client_id:
+        raise HTTPException(status_code=502, detail=f"MCP OAuth registration for {server.id} did not return client_id")
+    pkce = PKCEParameters.generate()
+    state = secrets.token_urlsafe(32)
+    if oauth_metadata and oauth_metadata.authorization_endpoint:
+        auth_endpoint = str(oauth_metadata.authorization_endpoint)
+    else:
+        auth_endpoint = urljoin(_authorization_base_url(server.server_url), "/authorize")
+    if oauth_metadata and oauth_metadata.token_endpoint:
+        token_endpoint = str(oauth_metadata.token_endpoint)
+    else:
+        token_endpoint = urljoin(_authorization_base_url(server.server_url), "/token")
+    resource = _resource_for_oauth(server.server_url, resource_metadata)
+    params = {
+        "response_type": "code",
+        "client_id": client_info.client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "code_challenge": pkce.code_challenge,
+        "code_challenge_method": "S256",
+    }
+    if resource:
+        params["resource"] = resource
+    if scope:
+        params["scope"] = scope
+    return _BuiltOperatorOAuthFlow(
+        state=state,
+        authorization_url=f"{auth_endpoint}?{urlencode(params)}",
+        expires_at=dt.datetime.now(dt.UTC) + MCP_OPERATOR_AUTH_FLOW_TTL,
+        redirect_uri=redirect_uri,
+        code_verifier=pkce.code_verifier,
+        client_info=client_info,
+        token_endpoint=token_endpoint,
+        resource=resource,
+        scope=scope,
+    )
+
+
+def _token_request_auth(
+    data: dict[str, str], *, client_id: str, client_secret: str | None, token_endpoint_auth_method: str | None
+) -> tuple[dict[str, str], dict[str, str]]:
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    if token_endpoint_auth_method == "client_secret_basic" and client_secret:
+        encoded_id = quote(client_id, safe="")
+        encoded_secret = quote(client_secret, safe="")
+        credentials = base64.b64encode(f"{encoded_id}:{encoded_secret}".encode()).decode()
+        headers["Authorization"] = f"Basic {credentials}"
+    elif token_endpoint_auth_method == "client_secret_post" and client_secret:
+        data["client_secret"] = client_secret
+    return data, headers
+
+
+async def _exchange_operator_oauth_code(flow: dict[str, Any], code: str) -> OAuthToken:
+    data: dict[str, str] = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": flow["redirect_uri"],
+        "client_id": flow["client_id"],
+        "code_verifier": flow["code_verifier"],
+    }
+    if flow["resource"]:
+        data["resource"] = flow["resource"]
+    data, headers = _token_request_auth(
+        data,
+        client_id=flow["client_id"],
+        client_secret=flow["client_secret"],
+        token_endpoint_auth_method=flow["token_endpoint_auth_method"],
+    )
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(flow["token_endpoint"], data=data, headers=headers)
+    if response.status_code != 200:
+        raise HTTPException(status_code=502, detail=f"MCP OAuth token exchange failed: {response.status_code}")
+    try:
+        return await handle_token_response_scopes(response)
+    except ValidationError as e:
+        raise HTTPException(status_code=502, detail=f"MCP OAuth token response was invalid: {e}") from e
+
+
+async def _refresh_operator_oauth_token(association: dict[str, Any]) -> OAuthToken:
+    refresh_token = association["refresh_token"]
+    if not refresh_token:
+        raise RuntimeError("MCP OAuth association has no refresh token; reconnect in the console")
+    data: dict[str, str] = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": association["client_id"],
+    }
+    if association["resource"]:
+        data["resource"] = association["resource"]
+    data, headers = _token_request_auth(
+        data,
+        client_id=association["client_id"],
+        client_secret=association["client_secret"],
+        token_endpoint_auth_method=association["token_endpoint_auth_method"],
+    )
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(association["token_endpoint"], data=data, headers=headers)
+    if response.status_code != 200:
+        raise RuntimeError(f"MCP OAuth token refresh failed: {response.status_code}")
+    try:
+        return await handle_token_response_scopes(response)
+    except ValidationError as e:
+        raise RuntimeError(f"MCP OAuth refresh response was invalid: {e}") from e
+
+
+def _oauth_callback_response(ok: bool, message: str, *, status_code: int = 200) -> HTMLResponse:
+    title = "MCP account connected" if ok else "MCP account connection failed"
+    safe_title = html.escape(title)
+    safe_message = html.escape(message)
+    payload = "mcpAuthChanged" if ok else "mcpAuthFailed"
+    return HTMLResponse(
+        status_code=status_code,
+        content=f"""<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>{safe_title}</title>
+    <style>
+      body {{
+        color-scheme: light dark;
+        font: 16px system-ui, sans-serif;
+        margin: 3rem auto;
+        max-width: 36rem;
+        line-height: 1.4;
+      }}
+      code {{
+        overflow-wrap: anywhere;
+      }}
+    </style>
+  </head>
+  <body>
+    <h1>{safe_title}</h1>
+    <p><code>{safe_message}</code></p>
+    <script>
+      try {{
+        new BroadcastChannel("haku-console-mcp-auth").postMessage({{ type: "{payload}" }});
+      }} catch (_) {{}}
+    </script>
+  </body>
+</html>""",
+    )
 
 
 def _mcp_result_to_json(result: mcp_types.CallToolResult) -> dict[str, Any]:
@@ -410,17 +947,48 @@ def _caller_principal(request: Request, settings: Settings) -> str:
     return "operator"
 
 
+def _operator_principal(request: Request) -> str:
+    return request.headers.get("x-authentik-username") or "operator"
+
+
+def _public_base_url(request: Request, settings: Settings) -> str:
+    if settings.public_base_url:
+        return settings.public_base_url.rstrip("/")
+    proto = (request.headers.get("x-forwarded-proto") or request.url.scheme).split(",", 1)[0].strip()
+    host = (
+        (request.headers.get("x-forwarded-host") or request.headers.get("host") or request.url.netloc)
+        .split(",", 1)[0]
+        .strip()
+    )
+    return f"{proto}://{host}"
+
+
+async def _execution_auth(
+    server: McpServerEntry, operator_principal: str, oauth_store: McpOperatorOAuthStoreProtocol
+) -> str | None:
+    if _operator_oauth_enabled(server):
+        token = await oauth_store.access_token_for(server=server, operator_principal=operator_principal)
+        if not token:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Connect your {server.id} MCP account in the console before approving this tool call.",
+            )
+        return token
+    return _credential_token(server)
+
+
 async def _maybe_execute(
     record: ToolCallRecord,
     server: McpServerEntry,
     ledger: ToolCallLedgerProtocol,
     hub: ToolCallEventHub,
     executor: McpToolExecutor,
+    auth_token: str | None,
 ) -> ToolCallRecord:
     if record.status != ToolCallStatus.RUNNING:
         return record
     try:
-        result = await executor.execute(server, record.tool_name, record.arguments)
+        result = await executor.execute(server, record.tool_name, record.arguments, auth_token)
     except Exception as e:
         updated, event = ledger.finish(record.tool_call_id, result=None, error=str(e))
     else:
@@ -462,6 +1030,7 @@ async def submit_tool_call(
     ledger: LedgerDep,
     hub: HubDep,
     executor: ExecutorDep,
+    oauth_store: OAuthStoreDep,
 ) -> ToolCallRecord:
     server = _server_entry(settings, body.server_id)
     caller = _caller_principal(request, settings)
@@ -477,7 +1046,8 @@ async def submit_tool_call(
             caller,
         )
     if record.status == ToolCallStatus.RUNNING:
-        record = await _maybe_execute(record, server, ledger, hub, executor)
+        auth_token = await _execution_auth(server, caller, oauth_store)
+        record = await _maybe_execute(record, server, ledger, hub, executor, auth_token)
     return await _wait_terminal(ledger, record.tool_call_id, body.wait_for_ms)
 
 
@@ -507,6 +1077,52 @@ async def approval_events(ledger: LedgerDep, after_event_id: int = 0) -> ToolCal
     return ledger.events_after_id(after_event_id)
 
 
+@router.get("/api/mcp/operator-auth")
+async def mcp_operator_auth_statuses(
+    request: Request, settings: SettingsDep, oauth_store: OAuthStoreDep
+) -> McpOperatorAuthStatusResponse:
+    return oauth_store.list_statuses(servers=_load_servers(settings), operator_principal=_operator_principal(request))
+
+
+@router.post("/api/mcp/operator-auth/{server_id}/start")
+async def start_mcp_operator_auth(
+    server_id: str, request: Request, csrf_protect: Csrf, settings: SettingsDep, oauth_store: OAuthStoreDep
+) -> McpOperatorAuthStartResponse:
+    await csrf_protect.validate_csrf(request)
+    server = _server_entry(settings, server_id)
+    return await oauth_store.start_flow(
+        server=server,
+        operator_principal=_operator_principal(request),
+        public_base_url=_public_base_url(request, settings),
+    )
+
+
+@router.delete("/api/mcp/operator-auth/{server_id}")
+async def disconnect_mcp_operator_auth(
+    server_id: str, request: Request, csrf_protect: Csrf, oauth_store: OAuthStoreDep
+) -> McpOperatorAuthStatus:
+    await csrf_protect.validate_csrf(request)
+    operator_principal = _operator_principal(request)
+    oauth_store.disconnect(server_id=server_id, operator_principal=operator_principal)
+    return McpOperatorAuthStatus(server_id=server_id, status="unconnected", operator_principal=operator_principal)
+
+
+@router.get(MCP_OPERATOR_AUTH_CALLBACK_PATH)
+async def mcp_operator_auth_callback(
+    oauth_store: OAuthStoreDep, state: str | None = None, code: str | None = None, error: str | None = None
+) -> HTMLResponse:
+    if error:
+        return _oauth_callback_response(False, f"MCP OAuth authorization failed: {error}", status_code=400)
+    if not state or not code:
+        return _oauth_callback_response(False, "MCP OAuth callback is missing state or code.", status_code=400)
+    try:
+        status = await oauth_store.complete_callback(state=state, code=code)
+    except HTTPException as e:
+        detail = e.detail if isinstance(e.detail, str) else "MCP OAuth callback failed."
+        return _oauth_callback_response(False, detail, status_code=e.status_code)
+    return _oauth_callback_response(True, f"Connected {status.server_id} for {status.operator_principal}.")
+
+
 @router.post("/api/tool-calls/{tool_call_id}/decision")
 async def decide_approval(
     tool_call_id: str,
@@ -517,6 +1133,7 @@ async def decide_approval(
     ledger: LedgerDep,
     hub: HubDep,
     executor: ExecutorDep,
+    oauth_store: OAuthStoreDep,
 ) -> ApprovalDecisionResponse:
     await csrf_protect.validate_csrf(request)
     if body.decision == "deny":
@@ -530,10 +1147,12 @@ async def decide_approval(
             body.reason,
         )
         return ApprovalDecisionResponse(tool_call=record)
+    pending = ledger.get(tool_call_id)
+    server = _server_entry(settings, pending.server_id)
+    auth_token = await _execution_auth(server, _operator_principal(request), oauth_store)
     running, running_event = ledger.mark_running(tool_call_id)
     await hub.broadcast([running_event])
-    server = _server_entry(settings, running.server_id)
-    finished = await _maybe_execute(running, server, ledger, hub, executor)
+    finished = await _maybe_execute(running, server, ledger, hub, executor, auth_token)
     return ApprovalDecisionResponse(tool_call=finished)
 
 

--- a/haku/console/migrations/versions/0002_mcp_operator_oauth.py
+++ b/haku/console/migrations/versions/0002_mcp_operator_oauth.py
@@ -1,0 +1,69 @@
+"""Add MCP operator OAuth associations.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-07-07
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import BigInteger, Column, DateTime, Text
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mcp_operator_oauth_associations",
+        Column("server_id", Text, primary_key=True),
+        Column("operator_principal", Text, primary_key=True),
+        Column("created_at", DateTime(timezone=True), nullable=False),
+        Column("updated_at", DateTime(timezone=True), nullable=False),
+        Column("client_id", Text, nullable=False),
+        Column("client_secret", Text, nullable=True),
+        Column("client_secret_expires_at", BigInteger, nullable=True),
+        Column("token_endpoint_auth_method", Text, nullable=True),
+        Column("token_endpoint", Text, nullable=False),
+        Column("resource", Text, nullable=True),
+        Column("access_token", Text, nullable=False),
+        Column("refresh_token", Text, nullable=True),
+        Column("token_type", Text, nullable=False),
+        Column("scope", Text, nullable=True),
+        Column("token_expires_at", DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "idx_mcp_operator_oauth_associations_operator", "mcp_operator_oauth_associations", ["operator_principal"]
+    )
+    op.create_table(
+        "mcp_operator_oauth_flows",
+        Column("state", Text, primary_key=True),
+        Column("server_id", Text, nullable=False),
+        Column("operator_principal", Text, nullable=False),
+        Column("created_at", DateTime(timezone=True), nullable=False),
+        Column("expires_at", DateTime(timezone=True), nullable=False),
+        Column("redirect_uri", Text, nullable=False),
+        Column("code_verifier", Text, nullable=False),
+        Column("client_id", Text, nullable=False),
+        Column("client_secret", Text, nullable=True),
+        Column("client_secret_expires_at", BigInteger, nullable=True),
+        Column("token_endpoint_auth_method", Text, nullable=True),
+        Column("token_endpoint", Text, nullable=False),
+        Column("resource", Text, nullable=True),
+        Column("scope", Text, nullable=True),
+    )
+    op.create_index(
+        "idx_mcp_operator_oauth_flows_server_operator", "mcp_operator_oauth_flows", ["server_id", "operator_principal"]
+    )
+    op.create_index("idx_mcp_operator_oauth_flows_expires_at", "mcp_operator_oauth_flows", ["expires_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_mcp_operator_oauth_flows_expires_at", table_name="mcp_operator_oauth_flows")
+    op.drop_index("idx_mcp_operator_oauth_flows_server_operator", table_name="mcp_operator_oauth_flows")
+    op.drop_table("mcp_operator_oauth_flows")
+    op.drop_index("idx_mcp_operator_oauth_associations_operator", table_name="mcp_operator_oauth_associations")
+    op.drop_table("mcp_operator_oauth_associations")

--- a/haku/console/test_mcp_approval.py
+++ b/haku/console/test_mcp_approval.py
@@ -8,6 +8,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 import pytest_bazel
@@ -18,7 +19,9 @@ from mcp import types as mcp_types
 from pydantic import SecretStr
 from sqlalchemy import create_engine, text
 from starlette.applications import Starlette
-from starlette.routing import Mount
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
 from testcontainers.postgres import PostgresContainer
 
 from haku.console.mcp_approval import _mcp_result_to_json
@@ -61,6 +64,104 @@ def _remote_mcp_url(server: FastMCP) -> Generator[str]:
         thread.join(timeout=10)
         if thread.is_alive():
             raise RuntimeError("test MCP server did not stop")
+
+
+@contextmanager
+def _remote_oauth_url() -> Generator[str]:
+    port = pick_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    async def mcp(request: Request) -> JSONResponse:
+        return JSONResponse(
+            {"detail": "auth required"},
+            status_code=401,
+            headers={
+                "WWW-Authenticate": f'Bearer resource_metadata="{base_url}/.well-known/oauth-protected-resource/mcp"'
+            },
+        )
+
+    async def protected_resource(request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "resource": f"{base_url}/mcp",
+                "authorization_servers": [f"{base_url}/auth"],
+                "scopes_supported": ["openid", "profile", "offline_access"],
+            }
+        )
+
+    async def oauth_metadata(request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "issuer": f"{base_url}/auth",
+                "authorization_endpoint": f"{base_url}/auth/authorize",
+                "token_endpoint": f"{base_url}/auth/token",
+                "registration_endpoint": f"{base_url}/auth/register",
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+                "code_challenge_methods_supported": ["S256"],
+            }
+        )
+
+    async def register(request: Request) -> JSONResponse:
+        body = await request.json()
+        return JSONResponse(
+            {
+                **body,
+                "client_id": "dynamic-client",
+                "client_secret": None,
+                "client_id_issued_at": 1,
+                "token_endpoint_auth_method": "none",
+            },
+            status_code=201,
+        )
+
+    async def token(request: Request) -> JSONResponse:
+        form = {k: v[0] for k, v in parse_qs((await request.body()).decode()).items()}
+        if form["grant_type"] == "authorization_code":
+            assert form["code"] == "operator-code"
+            assert form["client_id"] == "dynamic-client"
+            assert form["code_verifier"]
+            return JSONResponse(
+                {
+                    "access_token": "operator-access-token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "refresh_token": "operator-refresh-token",
+                    "scope": form.get("scope", "openid profile offline_access"),
+                }
+            )
+        assert form["grant_type"] == "refresh_token"
+        assert form["refresh_token"] == "operator-refresh-token"
+        return JSONResponse(
+            {
+                "access_token": "operator-refreshed-token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "operator-refresh-token",
+            }
+        )
+
+    app = Starlette(
+        routes=[
+            Route("/mcp", mcp),
+            Route("/.well-known/oauth-protected-resource/mcp", protected_resource),
+            Route("/.well-known/oauth-protected-resource", protected_resource),
+            Route("/.well-known/oauth-authorization-server/auth", oauth_metadata),
+            Route("/auth/register", register, methods=["POST"]),
+            Route("/auth/token", token, methods=["POST"]),
+        ]
+    )
+    uvicorn_server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning"))
+    thread = threading.Thread(target=uvicorn_server.run, daemon=True)
+    thread.start()
+    try:
+        wait_for_port("127.0.0.1", port, timeout_secs=10)
+        yield base_url
+    finally:
+        uvicorn_server.should_exit = True
+        thread.join(timeout=10)
+        if thread.is_alive():
+            raise RuntimeError("test OAuth server did not stop")
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -127,6 +228,21 @@ mcp:
     return path
 
 
+def _operator_oauth_config_file(tmp_path: Path, oauth_base_url: str) -> Path:
+    path = tmp_path / "haku_console_operator_oauth.yaml"
+    path.write_text(
+        f"""
+mcp:
+  servers:
+    - id: grocy-sf
+      server_url: {oauth_base_url}/mcp
+      operator_oauth: {{}}
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
 def _csrf(client: TestClient) -> str:
     token = client.get("/api/capabilities/csrf").json()["csrf_token"]
     assert isinstance(token, str)
@@ -147,6 +263,20 @@ def _submit(client: TestClient, *, amount: int = 1) -> dict[str, Any]:
     )
     assert resp.status_code == 200, resp.text
     return cast(dict[str, Any], resp.json())
+
+
+class RecordingExecutor:
+    def __init__(self) -> None:
+        self.auth_tokens: list[str | None] = []
+
+    async def execute(
+        self, server: Any, tool_name: str, arguments: dict[str, Any], auth_token: str | None
+    ) -> dict[str, Any]:
+        self.auth_tokens.append(auth_token)
+        return {
+            "content": [{"type": "text", "text": f"{server.id}:{tool_name}:{arguments['items'][0]['amount']}"}],
+            "isError": False,
+        }
 
 
 def test_reflection_lists_connected_servers_without_leaking_credentials(
@@ -229,6 +359,88 @@ def test_approval_executes_tool_and_records_terminal_result(
     assert decided["status"] == "ok"
     assert decided["result"]["content"][0]["text"] == "stock_add:123:1"
     assert fetched == decided
+
+
+def test_operator_oauth_association_drives_approved_tool_execution(make_client, tmp_path: Path, db_url: str) -> None:
+    executor = RecordingExecutor()
+    with (
+        _remote_oauth_url() as oauth_url,
+        make_client(
+            config_file=_operator_oauth_config_file(tmp_path, oauth_url),
+            csrf_secret=SecretStr("csrf"),
+            public_base_url="https://haku.test",
+            tool_call_executor=executor,
+            **_test_app_overrides(db_url),
+        ) as client,
+    ):
+        before = client.get("/api/mcp/operator-auth", headers={"X-authentik-username": "operator@example.com"}).json()
+        assert before["associations"] == [
+            {
+                "server_id": "grocy-sf",
+                "status": "unconnected",
+                "operator_principal": "operator@example.com",
+                "connected_at": None,
+                "token_expires_at": None,
+                "scope": None,
+            }
+        ]
+
+        started = client.post(
+            "/api/mcp/operator-auth/grocy-sf/start",
+            headers={"X-CSRF-Token": _csrf(client), "X-authentik-username": "operator@example.com"},
+        )
+        assert started.status_code == 200, started.text
+        authorization_url = started.json()["authorization_url"]
+        parsed_authorization = urlparse(authorization_url)
+        auth_query = parse_qs(parsed_authorization.query)
+        assert parsed_authorization.path == "/auth/authorize"
+        assert auth_query["client_id"] == ["dynamic-client"]
+        assert auth_query["redirect_uri"] == ["https://haku.test/api/mcp/operator-auth/callback"]
+        assert auth_query["code_challenge_method"] == ["S256"]
+
+        callback = client.get(
+            "/api/mcp/operator-auth/callback", params={"state": auth_query["state"][0], "code": "operator-code"}
+        )
+        assert callback.status_code == 200, callback.text
+        after = client.get("/api/mcp/operator-auth", headers={"X-authentik-username": "operator@example.com"}).json()
+        assert after["associations"][0]["status"] == "connected"
+        assert after["associations"][0]["connected_at"]
+
+        submitted = _submit(client)
+        approved = client.post(
+            f"/api/tool-calls/{submitted['tool_call_id']}/decision",
+            headers={"X-CSRF-Token": _csrf(client), "X-authentik-username": "operator@example.com"},
+            json={"decision": "approve"},
+        )
+
+    assert approved.status_code == 200, approved.text
+    assert approved.json()["tool_call"]["status"] == "ok"
+    assert executor.auth_tokens == ["operator-access-token"]
+
+
+def test_operator_oauth_approval_requires_existing_association(make_client, tmp_path: Path, db_url: str) -> None:
+    executor = RecordingExecutor()
+    with (
+        _remote_oauth_url() as oauth_url,
+        make_client(
+            config_file=_operator_oauth_config_file(tmp_path, oauth_url),
+            csrf_secret=SecretStr("csrf"),
+            tool_call_executor=executor,
+            **_test_app_overrides(db_url),
+        ) as client,
+    ):
+        submitted = _submit(client)
+        resp = client.post(
+            f"/api/tool-calls/{submitted['tool_call_id']}/decision",
+            headers={"X-CSRF-Token": _csrf(client), "X-authentik-username": "operator@example.com"},
+            json={"decision": "approve"},
+        )
+        fetched = client.get(f"/api/tool-calls/{submitted['tool_call_id']}").json()
+
+    assert resp.status_code == 409
+    assert "Connect your grocy-sf MCP account" in resp.json()["detail"]
+    assert fetched["status"] == "pending_approval"
+    assert executor.auth_tokens == []
 
 
 def test_approval_denial_is_terminal_and_does_not_execute(
@@ -343,6 +555,20 @@ def test_postgres_store_runs_alembic_and_persists_typed_ledger(
     try:
         with engine.connect() as conn:
             version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+            tables = {
+                row["table_name"]
+                for row in conn.execute(
+                    text(
+                        """
+                        SELECT table_name
+                        FROM information_schema.tables
+                        WHERE table_schema = 'public'
+                        """
+                    )
+                )
+                .mappings()
+                .all()
+            }
             columns = {
                 row["column_name"]
                 for row in conn.execute(
@@ -375,7 +601,8 @@ def test_postgres_store_runs_alembic_and_persists_typed_ledger(
     finally:
         engine.dispose()
 
-    assert version == "0001"
+    assert version == "0002"
+    assert {"mcp_operator_oauth_associations", "mcp_operator_oauth_flows"} <= tables
     assert {
         "tool_call_id",
         "server_id",


### PR DESCRIPTION
Core haku-console support for operator-linked MCP OAuth execution.

What changed:
- Adds Postgres-backed operator OAuth association/flow tables and Alembic migration.
- Adds console APIs for listing MCP account status, starting OAuth/DCR, callback handling, disconnecting, and using the approving operator's OAuth token for `operator_oauth` MCP servers.
- Keeps MCP server catalog/schema configuration in YAML/ConfigMap; mutable OAuth flow/token state lives in the console database.
- Extends the existing console settings panel with MCP account controls: Refresh, Connect/Reconnect, Disconnect. This keeps haku-ui to one small visible console affordance; there is no separate MCP banner/floating widget.
- Keeps static bearer support available for reflection/future fallback, while operator-OAuth servers require the approving operator to have a linked account for execution.

Validation:
- `bbr test //haku/console:test_mcp_approval --nocache_test_results //haku/console/frontend:tsc_test //haku/console/frontend:bridge_test` passed: BuildBuddy invocation `5ad681f9-ceb8-4a2d-b3e6-f8b5ec6fae3c`, Bazel invocation `631834d6-da46-44f4-83ce-0341c3bca51b`
- GitHub checks are green on the PR head