### PR TITLE
[codex] Fix ActivityWatch Syncthing OVH selector

### DIFF
--- a/cluster/k8s/activitywatch/syncthing-deployment.yaml
+++ b/cluster/k8s/activitywatch/syncthing-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       securityContext:
         fsGroup: 1000
       nodeSelector:
-        topology.kubernetes.io/region: hil-ovh
+        topology.kubernetes.io/zone: hil-ovh
       initContainers:
         - name: stage-syncthing-config
           image: busybox:1.37


### PR DESCRIPTION
## Summary

- Changes the ActivityWatch Syncthing receiver nodeSelector from region=hil-ovh to zone=hil-ovh.
- Matches the live OVH node labels and existing SeaweedFS-local workload convention.
- Unblocks the seaweedfs-ovh WaitForFirstConsumer PVC and Syncthing receiver scheduling.

## Validation

- `direnv exec . kustomize build cluster/k8s/activitywatch >/tmp/activitywatch-zone-kustomize.yaml`
- `direnv exec . pre-commit run --files cluster/k8s/activitywatch/syncthing-deployment.yaml`
