### PR TITLE
[codex] Fix ActivityWatch Syncthing container startup

### DIFF
--- a/cluster/k8s/activitywatch/syncthing-deployment.yaml
+++ b/cluster/k8s/activitywatch/syncthing-deployment.yaml
@@ -45,8 +45,10 @@ spec:
       containers:
         - name: syncthing
           image: syncthing/syncthing:2.0.10
-          command:
-            - syncthing
+          env:
+            - name: STHOMEDIR
+              value: ""
+          args:
             - --config
             - /var/syncthing/config
             - --data


### PR DESCRIPTION
## Summary

- Lets the Syncthing image use its own entrypoint by moving CLI flags from Kubernetes command to args.
- Clears the image default `STHOMEDIR` so explicit `--config` and `--data` do not conflict with an implicit `--home`.
- Keeps the writable config/data split and read-only projected identity mounts from the ActivityWatch sync rollout.

## Live finding

After #2965 fixed scheduling, the receiver pod scheduled on OVH and the SeaweedFS inbox PVC bound, but the Syncthing container exited with:

`syncthing: error: --home must not be used together with --config and --data`

The upstream image sets `STHOMEDIR=/var/syncthing/config`.

## Validation

- `direnv exec . kustomize build cluster/k8s/activitywatch >/tmp/activitywatch-entrypoint-kustomize.yaml`
- `direnv exec . pre-commit run --files cluster/k8s/activitywatch/syncthing-deployment.yaml`
