### PR TITLE
Add LiteLLM model probe and local dispatch plan (#2968)b

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -23,9 +23,6 @@ cluster/.direnv
 wt/.direnv
 props/.direnv
 
-# Debug investigations - no BUILD files
-debug
-
 # Legacy k8s cluster configs - deps not in main requirements
 x/k8s_old
 

--- a/cluster/k8s/litellm/app/BUILD.bazel
+++ b/cluster/k8s/litellm/app/BUILD.bazel
@@ -2,6 +2,11 @@
 
 load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
 
+exports_files(
+    ["proxy-config.yaml"],
+    visibility = ["//debug/litellm_probe:__pkg__"],
+)
+
 py_library(
     name = "generate_litellm",
     srcs = ["generate_litellm.py"],
@@ -17,19 +22,6 @@ py_binary(
     name = "generate_litellm_bin",
     main_module = "cluster.k8s.litellm.app.generate_litellm",
     deps = [":generate_litellm"],
-)
-
-py_binary(
-    name = "probe_models",
-    srcs = ["probe_models.py"],
-    data = ["proxy-config.yaml"],
-    main_module = "cluster.k8s.litellm.app.probe_models",
-    deps = [
-        "//util/bazel:runfiles",
-        "@pypi//httpx",
-        "@pypi//jinja2",
-        "@pypi//pyyaml",
-    ],
 )
 
 py_test(

--- a/cluster/k8s/litellm/app/BUILD.bazel
+++ b/cluster/k8s/litellm/app/BUILD.bazel
@@ -19,6 +19,19 @@ py_binary(
     deps = [":generate_litellm"],
 )
 
+py_binary(
+    name = "probe_models",
+    srcs = ["probe_models.py"],
+    data = ["proxy-config.yaml"],
+    main_module = "cluster.k8s.litellm.app.probe_models",
+    deps = [
+        "//util/bazel:runfiles",
+        "@pypi//httpx",
+        "@pypi//jinja2",
+        "@pypi//pyyaml",
+    ],
+)
+
 py_test(
     name = "test_generate_litellm",
     srcs = ["test_generate_litellm.py"],

--- a/cluster/k8s/litellm/app/probe_models.py
+++ b/cluster/k8s/litellm/app/probe_models.py
@@ -1,0 +1,1009 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import yaml
+from jinja2 import Environment
+
+from util.bazel.runfiles import get_required_path
+
+DEFAULT_BASE_URL = "https://litellm.allegedly.works"
+DEFAULT_CONFIG_RUNFILE = "ducktape/cluster/k8s/litellm/app/proxy-config.yaml"
+RESULTS_JSONL = "results.jsonl"
+EXPECTED_TEXT = "OK"
+EXPECTED_TOOL_NAME = "lookup_demo_fact"
+EXPECTED_TOOL_ARGS = {"topic": "litellm-probe"}
+DEFAULT_BACKENDS = {"ollama"}
+DEFAULT_PARITY_MODELS = {"gemini-2.5-flash", "glm-4.5-air-anthropic"}
+TEXT_MODES = {"chat", "responses"}
+
+
+@dataclass(frozen=True)
+class ModelProbe:
+    name: str
+    mode: str
+    backend: str
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    model: ModelProbe
+    shape: str
+    scenario: str
+    status: str
+    elapsed_seconds: float
+    detail: str
+    request_path: Path | None
+    response_path: Path | None
+    request_key: str | None = None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Probe configured LiteLLM models with tiny requests.")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="LiteLLM proxy base URL.")
+    parser.add_argument(
+        "--api-key", default=None, help="LiteLLM API key. Prefer LITELLM_API_KEY to avoid shell history."
+    )
+    parser.add_argument(
+        "--api-key-env", default="LITELLM_API_KEY", help="Environment variable containing the LiteLLM API key."
+    )
+    parser.add_argument(
+        "--config", type=Path, default=None, help="LiteLLM proxy config YAML. Defaults to the Bazel runfile."
+    )
+    parser.add_argument(
+        "--backend",
+        action="append",
+        default=None,
+        help=(
+            "Probe models backed by this provider. Repeatable. Defaults to ollama plus cheap z.ai/gemini parity "
+            "models. Use 'all' to disable filtering."
+        ),
+    )
+    parser.add_argument(
+        "--model", action="append", help="Probe one model. Repeatable. Defaults to all selected models."
+    )
+    parser.add_argument(
+        "--shape",
+        action="append",
+        choices=["openai-chat", "openai-responses", "anthropic-messages"],
+        default=None,
+        help="API shape to probe. Repeatable. Defaults to all supported text shapes.",
+    )
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        choices=["text", "tool"],
+        default=None,
+        help="Probe scenario. Repeatable. Defaults to text and tool.",
+    )
+    parser.add_argument(
+        "--timeout-seconds", type=float, default=900.0, help="Per-request timeout, including cold model load."
+    )
+    parser.add_argument("--max-output-tokens", type=int, default=1024, help="Maximum generated tokens per probe.")
+    parser.add_argument(
+        "--response-dir",
+        type=Path,
+        default=None,
+        help="Directory for request/response bodies. Defaults to /tmp/litellm-probe-responses/<timestamp>.",
+    )
+    parser.add_argument(
+        "--html-report", type=Path, default=None, help="HTML report path. Defaults to <response-dir>/report.html."
+    )
+    parser.add_argument(
+        "--aggregate-dir",
+        type=Path,
+        action="append",
+        default=[],
+        help="Prior probe response directory to include in the HTML report. Repeatable.",
+    )
+    parser.add_argument(
+        "--resume-dir",
+        type=Path,
+        action="append",
+        default=[],
+        help="Prior probe response directory to resume from: keep OK records, rerun failed or missing cases.",
+    )
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="Do not run probes; only render a report from --aggregate-dir result records.",
+    )
+    parser.add_argument("--continue-on-error", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--include-unsupported",
+        action="store_true",
+        help="Report unsupported non-text modes as failures instead of skips.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON lines instead of tab-separated text.")
+    return parser.parse_args()
+
+
+def _load_model_probes(config_path: Path | None) -> list[ModelProbe]:
+    if config_path is None:
+        config_path = get_required_path(DEFAULT_CONFIG_RUNFILE)
+    config = yaml.safe_load(config_path.read_text())
+    probes: list[ModelProbe] = []
+    for entry in config["model_list"]:
+        model_info = entry.get("model_info") or {}
+        litellm_params = entry.get("litellm_params") or {}
+        probes.append(
+            ModelProbe(
+                name=entry["model_name"], mode=model_info.get("mode", "chat"), backend=_backend_name(litellm_params)
+            )
+        )
+    return probes
+
+
+def _backend_name(litellm_params: dict[str, Any]) -> str:
+    api_base = str(litellm_params.get("api_base", ""))
+    if "ollama" in api_base:
+        return "ollama"
+    model = str(litellm_params.get("model", ""))
+    if "api.z.ai" in api_base or "z.ai" in api_base:
+        return "z.ai"
+    if model.startswith("chatgpt/"):
+        return "chatgpt"
+    if "/" in model:
+        return model.split("/", 1)[0]
+    return "unknown"
+
+
+def _default_selected_probe(probe: ModelProbe) -> bool:
+    return probe.backend in DEFAULT_BACKENDS or probe.name in DEFAULT_PARITY_MODELS
+
+
+def _headers(args: argparse.Namespace) -> dict[str, str]:
+    api_key = args.api_key or os.environ.get(args.api_key_env)
+    if not api_key:
+        return {}
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _parse_json(response: httpx.Response) -> Any:
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        return response.text
+
+
+def _detail_from_body(body: Any) -> str:
+    if isinstance(body, str):
+        return body.strip().replace("\n", " ")[:240]
+    if isinstance(body, dict):
+        error = body.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if isinstance(message, str):
+                return message.replace("\n", " ")[:240]
+        choices = body.get("choices")
+        if isinstance(choices, list) and choices:
+            first = choices[0]
+            if isinstance(first, dict):
+                message = first.get("message")
+                if isinstance(message, dict):
+                    content = message.get("content")
+                    if isinstance(content, str):
+                        return content.strip().replace("\n", " ")[:240]
+        output = body.get("output")
+        if output is not None:
+            return json.dumps(output)[:240]
+        content = body.get("content")
+        if content is not None:
+            return json.dumps(content)[:240]
+    return json.dumps(body, sort_keys=True)[:240]
+
+
+def _save_body(path: Path | None, body: str) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def _save_json_body(path: Path | None, body: dict[str, Any]) -> None:
+    _save_body(path, json.dumps(body, indent=2, sort_keys=True))
+
+
+def _post_json(
+    client: httpx.Client,
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    request_path: Path | None,
+    response_path: Path | None,
+) -> tuple[Any, str]:
+    _save_json_body(request_path, body)
+    response = client.post(url, headers=headers, json=body)
+    _save_body(response_path, response.text)
+    parsed = _parse_json(response)
+    detail = _detail_from_body(parsed)
+    response.raise_for_status()
+    return parsed, detail
+
+
+def _first_chat_message(body: Any) -> dict[str, Any]:
+    if not isinstance(body, dict):
+        return {}
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return {}
+    first = choices[0]
+    if not isinstance(first, dict):
+        return {}
+    message = first.get("message")
+    if isinstance(message, dict):
+        return message
+    return {}
+
+
+def _assert_chat_text(body: Any) -> str:
+    content = _first_chat_message(body).get("content")
+    if isinstance(content, str) and content.strip() == EXPECTED_TEXT:
+        return ""
+    raise ValueError(f"chat final text is not {EXPECTED_TEXT!r}: {_detail_from_body(body)}")
+
+
+def _parse_json_object(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _assert_tool_args(value: Any, body: Any) -> None:
+    args = _parse_json_object(value)
+    if args == EXPECTED_TOOL_ARGS:
+        return
+    raise ValueError(f"tool args are not {EXPECTED_TOOL_ARGS!r}: {_detail_from_body(body)}")
+
+
+def _assert_chat_tool_call(body: Any) -> str:
+    tool_calls = _first_chat_message(body).get("tool_calls")
+    if not isinstance(tool_calls, list) or not tool_calls:
+        raise ValueError(f"no chat tool_calls in response: {_detail_from_body(body)}")
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            continue
+        function = call.get("function")
+        if not isinstance(function, dict):
+            continue
+        if function.get("name") != EXPECTED_TOOL_NAME:
+            continue
+        _assert_tool_args(function.get("arguments"), body)
+        return ""
+    raise ValueError(f"no chat tool_call named {EXPECTED_TOOL_NAME!r}: {_detail_from_body(body)}")
+
+
+def _responses_output_items(body: Any) -> list[Any]:
+    if not isinstance(body, dict):
+        return []
+    output = body.get("output")
+    if isinstance(output, list):
+        return output
+    return []
+
+
+def _assert_responses_text(body: Any) -> str:
+    if isinstance(body, dict):
+        output_text = body.get("output_text")
+        if isinstance(output_text, str) and output_text.strip() == EXPECTED_TEXT:
+            return ""
+    for item in _responses_output_items(body):
+        if not isinstance(item, dict):
+            continue
+        content = item.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            text = part.get("text")
+            if isinstance(text, str) and text.strip() == EXPECTED_TEXT:
+                return ""
+    raise ValueError(f"Responses final text is not {EXPECTED_TEXT!r}: {_detail_from_body(body)}")
+
+
+def _assert_responses_tool_call(body: Any) -> str:
+    for item in _responses_output_items(body):
+        if not isinstance(item, dict) or item.get("type") not in {"function_call", "tool_call"}:
+            continue
+        if item.get("name") != EXPECTED_TOOL_NAME:
+            continue
+        _assert_tool_args(item.get("arguments"), body)
+        return ""
+    raise ValueError(f"no Responses function_call named {EXPECTED_TOOL_NAME!r}: {_detail_from_body(body)}")
+
+
+def _responses_body_from_stream_events(events: list[Any]) -> dict[str, Any]:
+    body: dict[str, Any] = {"output": []}
+    output_items_by_index: dict[int, dict[str, Any]] = {}
+    output_text_parts: list[str] = []
+    function_call_arguments_by_index: dict[int, list[str]] = {}
+    function_call_names_by_index: dict[int, str] = {}
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if event_type == "response.completed":
+            response = event.get("response")
+            if isinstance(response, dict):
+                return response
+        if event_type == "response.output_item.done":
+            item = event.get("item")
+            if isinstance(item, dict):
+                body["output"].append(item)
+            continue
+        if event_type == "response.output_text.delta":
+            delta = event.get("delta")
+            if isinstance(delta, str):
+                output_text_parts.append(delta)
+            continue
+        if event_type == "response.function_call_arguments.delta":
+            index = event.get("output_index")
+            delta = event.get("delta")
+            if isinstance(index, int) and isinstance(delta, str):
+                function_call_arguments_by_index.setdefault(index, []).append(delta)
+            continue
+        if event_type == "response.output_item.added":
+            index = event.get("output_index")
+            item = event.get("item")
+            if isinstance(index, int) and isinstance(item, dict):
+                output_items_by_index[index] = item
+                name = item.get("name")
+                if isinstance(name, str):
+                    function_call_names_by_index[index] = name
+
+    if output_text_parts:
+        body["output"].append(
+            {"type": "message", "content": [{"type": "output_text", "text": "".join(output_text_parts)}]}
+        )
+    for index, argument_parts in function_call_arguments_by_index.items():
+        item = dict(output_items_by_index.get(index) or {})
+        item["type"] = "function_call"
+        item["name"] = function_call_names_by_index.get(index, item.get("name"))
+        item["arguments"] = "".join(argument_parts)
+        body["output"].append(item)
+    return body
+
+
+def _assert_anthropic_text(body: Any) -> str:
+    if isinstance(body, dict):
+        content = body.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict) or part.get("type") != "text":
+                    continue
+                text = part.get("text")
+                if isinstance(text, str) and text.strip() == EXPECTED_TEXT:
+                    return ""
+    raise ValueError(f"Anthropic final text is not {EXPECTED_TEXT!r}: {_detail_from_body(body)}")
+
+
+def _assert_anthropic_tool_call(body: Any) -> str:
+    if isinstance(body, dict):
+        content = body.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict) or part.get("type") != "tool_use":
+                    continue
+                if part.get("name") == EXPECTED_TOOL_NAME:
+                    _assert_tool_args(part.get("input"), body)
+                    return ""
+    raise ValueError(f"no Anthropic tool_use named {EXPECTED_TOOL_NAME!r}: {_detail_from_body(body)}")
+
+
+def _tool_schema_openai() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": EXPECTED_TOOL_NAME,
+            "description": "Look up a demo fact by topic.",
+            "parameters": {
+                "type": "object",
+                "properties": {"topic": {"type": "string"}},
+                "required": ["topic"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def _tool_schema_responses() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "name": EXPECTED_TOOL_NAME,
+        "description": "Look up a demo fact by topic.",
+        "parameters": {
+            "type": "object",
+            "properties": {"topic": {"type": "string"}},
+            "required": ["topic"],
+            "additionalProperties": False,
+        },
+    }
+
+
+def _tool_schema_anthropic() -> dict[str, Any]:
+    return {
+        "name": EXPECTED_TOOL_NAME,
+        "description": "Look up a demo fact by topic.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"topic": {"type": "string"}},
+            "required": ["topic"],
+            "additionalProperties": False,
+        },
+    }
+
+
+def _chat_request_body(model: str, max_output_tokens: int, scenario: str) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": f"Reply with exactly: {EXPECTED_TEXT}"}],
+        "temperature": 0,
+        "max_tokens": max_output_tokens,
+    }
+    if scenario == "tool":
+        body["messages"] = [
+            {"role": "user", "content": f"Use the tool to look up the topic {EXPECTED_TOOL_ARGS['topic']}."}
+        ]
+        body["tools"] = [_tool_schema_openai()]
+        body["tool_choice"] = {"type": "function", "function": {"name": EXPECTED_TOOL_NAME}}
+    return body
+
+
+def _responses_request_body(model: str, max_output_tokens: int, scenario: str, stream: bool) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "model": model,
+        "input": f"Reply with exactly: {EXPECTED_TEXT}",
+        "stream": stream,
+        "max_output_tokens": max_output_tokens,
+    }
+    if scenario == "tool":
+        body["input"] = f"Use the tool to look up the topic {EXPECTED_TOOL_ARGS['topic']}."
+        body["tools"] = [_tool_schema_responses()]
+        body["tool_choice"] = {"type": "function", "name": EXPECTED_TOOL_NAME}
+    return body
+
+
+def _anthropic_request_body(model: str, max_output_tokens: int, scenario: str) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "model": model,
+        "max_tokens": max_output_tokens,
+        "temperature": 0,
+        "messages": [{"role": "user", "content": f"Reply with exactly: {EXPECTED_TEXT}"}],
+    }
+    if scenario == "tool":
+        body["messages"] = [
+            {"role": "user", "content": f"Use the tool to look up the topic {EXPECTED_TOOL_ARGS['topic']}."}
+        ]
+        body["tools"] = [_tool_schema_anthropic()]
+        body["tool_choice"] = {"type": "tool", "name": EXPECTED_TOOL_NAME}
+    return body
+
+
+def _request_url(base_url: str, shape: str) -> str:
+    if shape == "openai-chat":
+        return f"{base_url}/v1/chat/completions"
+    if shape == "openai-responses":
+        return f"{base_url}/v1/responses"
+    if shape == "anthropic-messages":
+        return f"{base_url}/v1/messages"
+    raise ValueError(f"unsupported shape: {shape}")
+
+
+def _planned_request_body(model: ModelProbe, shape: str, scenario: str, max_output_tokens: int) -> dict[str, Any]:
+    if shape == "openai-chat":
+        return _chat_request_body(model.name, max_output_tokens, scenario)
+    if shape == "openai-responses":
+        return _responses_request_body(model.name, max_output_tokens, scenario, stream=model.mode == "responses")
+    if shape == "anthropic-messages":
+        return _anthropic_request_body(model.name, max_output_tokens, scenario)
+    raise ValueError(f"unsupported shape: {shape}")
+
+
+def _request_key(url: str, body: dict[str, Any]) -> str:
+    canonical_body = json.dumps(body, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(f"POST\n{url}\n{canonical_body}".encode()).hexdigest()
+    return f"POST:{url}:sha256:{digest}"
+
+
+def _request_url_from_key(request_key: str) -> str | None:
+    if not request_key.startswith("POST:"):
+        return None
+    head, separator, _ = request_key.rpartition(":sha256:")
+    if not separator:
+        return None
+    return head.removeprefix("POST:")
+
+
+def _saved_exchange_matches_key(result: ProbeResult) -> bool:
+    if result.request_key is None or result.request_path is None or result.response_path is None:
+        return False
+    if not result.request_path.exists() or not result.response_path.exists():
+        return False
+    url = _request_url_from_key(result.request_key)
+    if url is None:
+        return False
+    try:
+        request_body = json.loads(result.request_path.read_text())
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(request_body, dict):
+        return False
+    return _request_key(url, request_body) == result.request_key
+
+
+def _probe_chat(
+    client: httpx.Client,
+    base_url: str,
+    headers: dict[str, str],
+    model: str,
+    max_output_tokens: int,
+    scenario: str,
+    request_path: Path | None,
+    response_path: Path | None,
+) -> str:
+    body = _chat_request_body(model, max_output_tokens, scenario)
+    body_json, _ = _post_json(client, f"{base_url}/v1/chat/completions", headers, body, request_path, response_path)
+    if scenario == "tool":
+        return _assert_chat_tool_call(body_json)
+    return _assert_chat_text(body_json)
+
+
+def _probe_responses(
+    client: httpx.Client,
+    base_url: str,
+    headers: dict[str, str],
+    model: str,
+    max_output_tokens: int,
+    scenario: str,
+    stream: bool,
+    request_path: Path | None,
+    response_path: Path | None,
+) -> str:
+    body = _responses_request_body(model, max_output_tokens, scenario, stream)
+    _save_json_body(request_path, body)
+    if not stream:
+        body_json, _ = _post_json(client, f"{base_url}/v1/responses", headers, body, None, response_path)
+        if scenario == "tool":
+            return _assert_responses_tool_call(body_json)
+        return _assert_responses_text(body_json)
+    raw_lines: list[str] = []
+    events: list[Any] = []
+    with client.stream("POST", f"{base_url}/v1/responses", headers=headers, json=body) as response:
+        if response.status_code >= 400:
+            response.read()
+            _save_body(response_path, response.text)
+            response.raise_for_status()
+        for line in response.iter_lines():
+            raw_lines.append(line)
+            if not line:
+                continue
+            if line.startswith("data: "):
+                payload = line.removeprefix("data: ").strip()
+                if payload and payload != "[DONE]":
+                    with suppress(json.JSONDecodeError):
+                        events.append(json.loads(payload))
+        _save_body(response_path, "\n".join(raw_lines))
+        body_json = _responses_body_from_stream_events(events)
+        if scenario == "tool":
+            return _assert_responses_tool_call(body_json)
+        return _assert_responses_text(body_json)
+
+
+def _probe_anthropic_messages(
+    client: httpx.Client,
+    base_url: str,
+    headers: dict[str, str],
+    model: str,
+    max_output_tokens: int,
+    scenario: str,
+    request_path: Path | None,
+    response_path: Path | None,
+) -> str:
+    body = _anthropic_request_body(model, max_output_tokens, scenario)
+    body_json, _ = _post_json(client, f"{base_url}/v1/messages", headers, body, request_path, response_path)
+    if scenario == "tool":
+        return _assert_anthropic_tool_call(body_json)
+    return _assert_anthropic_text(body_json)
+
+
+def _probe_one(
+    client: httpx.Client,
+    base_url: str,
+    headers: dict[str, str],
+    model: ModelProbe,
+    shape: str,
+    scenario: str,
+    max_output_tokens: int,
+    include_unsupported: bool,
+    request_path: Path | None,
+    response_path: Path | None,
+) -> ProbeResult:
+    started = time.monotonic()
+    request_key = _request_key(
+        _request_url(base_url, shape), _planned_request_body(model, shape, scenario, max_output_tokens)
+    )
+    try:
+        if model.mode not in TEXT_MODES:
+            detail = f"unsupported non-text mode for {shape}/{scenario} probe: {model.mode}"
+            status = "fail" if include_unsupported else "skip"
+        elif shape == "openai-chat":
+            detail = _probe_chat(
+                client, base_url, headers, model.name, max_output_tokens, scenario, request_path, response_path
+            )
+            status = "ok"
+        elif shape == "openai-responses":
+            detail = _probe_responses(
+                client,
+                base_url,
+                headers,
+                model.name,
+                max_output_tokens,
+                scenario,
+                stream=model.mode == "responses",
+                request_path=request_path,
+                response_path=response_path,
+            )
+            status = "ok"
+        elif shape == "anthropic-messages":
+            detail = _probe_anthropic_messages(
+                client, base_url, headers, model.name, max_output_tokens, scenario, request_path, response_path
+            )
+            status = "ok"
+        else:
+            detail = f"unsupported mode for {shape}/{scenario} probe: {model.mode}"
+            status = "fail" if include_unsupported else "skip"
+    except Exception as exc:
+        detail = f"{type(exc).__name__}: {exc}"
+        status = "fail"
+    return ProbeResult(
+        model=model,
+        shape=shape,
+        scenario=scenario,
+        status=status,
+        elapsed_seconds=time.monotonic() - started,
+        detail=detail,
+        request_path=request_path,
+        response_path=response_path,
+        request_key=request_key,
+    )
+
+
+def _print_result(result: ProbeResult, json_lines: bool) -> None:
+    if json_lines:
+        print(json.dumps(_result_record(result), sort_keys=True), flush=True)
+        return
+    print(
+        "\t".join(
+            [
+                result.status,
+                f"{result.elapsed_seconds:.1f}s",
+                result.model.backend,
+                result.model.mode,
+                result.shape,
+                result.scenario,
+                result.model.name,
+            ]
+            + ([result.detail] if result.detail else [])
+            + ([f"body={result.response_path}"] if result.status == "fail" and result.response_path is not None else [])
+        ),
+        flush=True,
+    )
+
+
+def _default_response_dir() -> Path:
+    return Path("/tmp/litellm-probe-responses") / time.strftime("%Y%m%dT%H%M%S")
+
+
+def _safe_filename_part(value: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in value)
+
+
+def _artifact_base(response_dir: Path, model: ModelProbe, shape: str, scenario: str) -> Path:
+    filename = "__".join([_safe_filename_part(model.name), _safe_filename_part(shape), _safe_filename_part(scenario)])
+    return response_dir / filename
+
+
+def _artifact_paths(response_dir: Path, model: ModelProbe, shape: str, scenario: str) -> tuple[Path, Path]:
+    base = _artifact_base(response_dir, model, shape, scenario)
+    return Path(f"{base}.request.json"), Path(f"{base}.response.json")
+
+
+def _results_path(response_dir: Path) -> Path:
+    return response_dir / RESULTS_JSONL
+
+
+def _result_record(result: ProbeResult) -> dict[str, Any]:
+    return {
+        "status": result.status,
+        "elapsed_seconds": round(result.elapsed_seconds, 3),
+        "model": result.model.name,
+        "mode": result.model.mode,
+        "backend": result.model.backend,
+        "shape": result.shape,
+        "scenario": result.scenario,
+        "detail": result.detail,
+        "request_path": str(result.request_path) if result.request_path is not None else None,
+        "response_path": str(result.response_path) if result.response_path is not None else None,
+        "request_key": result.request_key,
+    }
+
+
+def _append_result_record(response_dir: Path, result: ProbeResult) -> None:
+    path = _results_path(response_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as file:
+        file.write(json.dumps(_result_record(result), sort_keys=True))
+        file.write("\n")
+
+
+def _result_from_record(record: dict[str, Any]) -> ProbeResult:
+    model = ModelProbe(name=str(record["model"]), mode=str(record["mode"]), backend=str(record["backend"]))
+    request_path = record.get("request_path")
+    response_path = record.get("response_path")
+    return ProbeResult(
+        model=model,
+        shape=str(record["shape"]),
+        scenario=str(record["scenario"]),
+        status=str(record["status"]),
+        elapsed_seconds=float(record["elapsed_seconds"]),
+        detail=str(record.get("detail") or ""),
+        request_path=Path(request_path) if isinstance(request_path, str) else None,
+        response_path=Path(response_path) if isinstance(response_path, str) else None,
+        request_key=str(record["request_key"]) if isinstance(record.get("request_key"), str) else None,
+    )
+
+
+def _load_result_records(response_dir: Path) -> list[ProbeResult]:
+    path = _results_path(response_dir)
+    if not path.exists():
+        return []
+    results: list[ProbeResult] = []
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+            if not isinstance(record, dict):
+                raise ValueError("record is not a JSON object")
+            results.append(_result_from_record(record))
+        except Exception as exc:
+            raise ValueError(f"invalid result record in {path}:{line_number}: {exc}") from exc
+    return results
+
+
+def _load_aggregate_results(response_dirs: list[Path]) -> list[ProbeResult]:
+    results: list[ProbeResult] = []
+    for response_dir in response_dirs:
+        loaded = _load_result_records(response_dir)
+        if not loaded:
+            print(f"warning: no {RESULTS_JSONL} records found in {response_dir}", file=sys.stderr)
+        results.extend(loaded)
+    return results
+
+
+def _legacy_result_key(result: ProbeResult) -> str:
+    return "\x1f".join([result.model.name, result.shape, result.scenario])
+
+
+def _result_key(result: ProbeResult) -> str:
+    return result.request_key or f"legacy:{_legacy_result_key(result)}"
+
+
+def _case_key(base_url: str, model: ModelProbe, shape: str, scenario: str, max_output_tokens: int) -> str:
+    body = _planned_request_body(model, shape, scenario, max_output_tokens)
+    return _request_key(_request_url(base_url, shape), body)
+
+
+def _merge_results(results: list[ProbeResult]) -> dict[str, ProbeResult]:
+    merged: dict[str, ProbeResult] = {}
+    for result in results:
+        merged[_result_key(result)] = result
+    return merged
+
+
+def _planned_request_keys(
+    base_url: str, probes: list[ModelProbe], shapes: list[str], scenarios: list[str], max_output_tokens: int
+) -> set[str]:
+    return {
+        _case_key(base_url, probe, shape, scenario, max_output_tokens)
+        for probe in probes
+        for shape in shapes
+        for scenario in scenarios
+    }
+
+
+def _pretty_file(path: Path | None) -> str:
+    if path is None or not path.exists():
+        return ""
+    text = path.read_text()
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return text
+    return json.dumps(parsed, indent=2, sort_keys=True)
+
+
+def _status_counts(results: list[ProbeResult]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for result in results:
+        counts[result.status] = counts.get(result.status, 0) + 1
+    return counts
+
+
+_REPORT_TEMPLATE = """<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>LiteLLM Probe Report</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; }
+    details { border: 1px solid #ccc; border-radius: 6px; margin: 0.75rem 0; padding: 0.75rem; }
+    details.ok { border-color: #7ab77a; }
+    details.fail { border-color: #d36b6b; }
+    details.skip { border-color: #bbb; }
+    summary { cursor: pointer; font-weight: 600; }
+    pre { background: #f6f6f6; border-radius: 4px; overflow-x: auto; padding: 0.75rem; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <h1>LiteLLM Probe Report</h1>
+  <p><strong>Response directory:</strong> {{ response_dir }}</p>
+  <p><strong>Counts:</strong> {{ counts }}</p>
+  {% for row in rows %}
+  <details class="{{ row.status }}">
+    <summary>{{ row.title }}</summary>
+    <p><strong>Backend:</strong> {{ row.backend }} &nbsp; <strong>Mode:</strong> {{ row.mode }}</p>
+    {% if row.detail %}<p><strong>Detail:</strong> {{ row.detail }}</p>{% endif %}
+    <p><strong>Request:</strong> {{ row.request_path }}</p>
+    <pre>{{ row.request_body }}</pre>
+    <p><strong>Response:</strong> {{ row.response_path }}</p>
+    <pre>{{ row.response_body }}</pre>
+  </details>
+  {% endfor %}
+</body>
+</html>
+"""
+
+
+def _write_html_report(path: Path, results: list[ProbeResult], response_dir: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    counts = _status_counts(results)
+    rows: list[dict[str, str]] = []
+    for result in results:
+        title = " ".join(
+            [result.status.upper(), f"{result.elapsed_seconds:.1f}s", result.model.name, result.shape, result.scenario]
+        )
+        rows.append(
+            {
+                "status": result.status,
+                "title": title,
+                "backend": result.model.backend,
+                "mode": result.model.mode,
+                "detail": result.detail,
+                "request_path": str(result.request_path),
+                "request_body": _pretty_file(result.request_path),
+                "response_path": str(result.response_path),
+                "response_body": _pretty_file(result.response_path),
+            }
+        )
+    env = Environment(autoescape=True)
+    html_text = env.from_string(_REPORT_TEMPLATE).render(
+        counts=json.dumps(counts, sort_keys=True), response_dir=str(response_dir), rows=rows
+    )
+    path.write_text(html_text)
+
+
+def main() -> int:
+    args = _parse_args()
+    base_url = args.base_url.rstrip("/")
+    all_probes = _load_model_probes(args.config)
+    if args.model:
+        selected = set(args.model)
+        unknown = sorted(selected - {probe.name for probe in all_probes})
+        if unknown:
+            print(f"Unknown model(s): {', '.join(unknown)}", file=sys.stderr)
+            return 2
+        probes = [probe for probe in all_probes if probe.name in selected]
+    elif args.backend:
+        backends = set(args.backend)
+        probes = all_probes if "all" in backends else [probe for probe in all_probes if probe.backend in backends]
+    else:
+        probes = [probe for probe in all_probes if _default_selected_probe(probe)]
+
+    headers = _headers(args)
+    shapes = args.shape or ["openai-chat", "openai-responses", "anthropic-messages"]
+    scenarios = args.scenario or ["text", "tool"]
+    planned_keys = _planned_request_keys(base_url, probes, shapes, scenarios, args.max_output_tokens)
+    response_dir = args.response_dir or _default_response_dir()
+    response_dir.mkdir(parents=True, exist_ok=True)
+    print(f"response bodies: {response_dir}", file=sys.stderr, flush=True)
+    report_path = args.html_report or response_dir / "report.html"
+    prior_results = [
+        result
+        for result in _load_aggregate_results(args.aggregate_dir + args.resume_dir)
+        if _result_key(result) in planned_keys
+    ]
+    results_by_key = _merge_results(prior_results)
+    if args.report_only:
+        results = list(results_by_key.values())
+        _write_html_report(report_path, results, response_dir)
+        print(f"html report: {report_path}", file=sys.stderr, flush=True)
+        return 1 if any(result.status == "fail" for result in results) else 0
+    timeout = httpx.Timeout(args.timeout_seconds, connect=15.0)
+    stop_after_failure = False
+    interrupted = False
+    copied_resume_keys: set[str] = set()
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            for probe in probes:
+                for shape in shapes:
+                    for scenario in scenarios:
+                        if stop_after_failure:
+                            break
+                        key = _case_key(base_url, probe, shape, scenario, args.max_output_tokens)
+                        previous = results_by_key.get(key)
+                        if (
+                            args.resume_dir
+                            and previous is not None
+                            and previous.status == "ok"
+                            and _saved_exchange_matches_key(previous)
+                        ):
+                            if key not in copied_resume_keys:
+                                _append_result_record(response_dir, previous)
+                                copied_resume_keys.add(key)
+                            continue
+                        request_path, response_path = _artifact_paths(response_dir, probe, shape, scenario)
+                        result = _probe_one(
+                            client,
+                            base_url,
+                            headers,
+                            probe,
+                            shape,
+                            scenario,
+                            args.max_output_tokens,
+                            args.include_unsupported,
+                            request_path,
+                            response_path,
+                        )
+                        results_by_key[key] = result
+                        _append_result_record(response_dir, result)
+                        _print_result(result, args.json)
+                        if result.status == "fail" and not args.continue_on_error:
+                            stop_after_failure = True
+                            break
+                    if stop_after_failure:
+                        break
+                if stop_after_failure:
+                    break
+    except KeyboardInterrupt:
+        interrupted = True
+        print("interrupted: writing report for completed probe records", file=sys.stderr, flush=True)
+    results = list(results_by_key.values())
+    _write_html_report(report_path, results, response_dir)
+    print(f"html report: {report_path}", file=sys.stderr, flush=True)
+    if interrupted:
+        return 130
+    return 1 if any(result.status == "fail" for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/debug/litellm_probe/BUILD.bazel
+++ b/debug/litellm_probe/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//devinfra/python:defs.bzl", "py_binary")
+
+py_binary(
+    name = "probe_models",
+    srcs = ["probe_models.py"],
+    data = [
+        "report.html.j2",
+        "//cluster/k8s/litellm/app:proxy-config.yaml",
+    ],
+    main_module = "debug.litellm_probe.probe_models",
+    deps = [
+        "//util/bazel:runfiles",
+        "@pypi//httpx",
+        "@pypi//jinja2",
+        "@pypi//pyyaml",
+    ],
+)

--- a/debug/litellm_probe/BUILD.bazel
+++ b/debug/litellm_probe/BUILD.bazel
@@ -12,6 +12,7 @@ py_binary(
         "//util/bazel:runfiles",
         "@pypi//httpx",
         "@pypi//jinja2",
+        "@pypi//pydantic",
         "@pypi//pyyaml",
     ],
 )

--- a/debug/litellm_probe/probe_models.py
+++ b/debug/litellm_probe/probe_models.py
@@ -6,8 +6,9 @@ import json
 import os
 import sys
 import time
+from collections import Counter
 from collections.abc import Callable
-from contextlib import suppress
+from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -15,6 +16,7 @@ from typing import Any
 import httpx
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+from pydantic import BaseModel, ConfigDict
 
 from util.bazel.runfiles import get_required_path
 
@@ -25,22 +27,56 @@ RESULTS_JSONL = "results.jsonl"
 EXPECTED_TEXT = "OK"
 EXPECTED_TOOL_NAME = "lookup_demo_fact"
 EXPECTED_TOOL_ARGS = {"topic": "litellm-probe"}
+TEXT_PROMPT = f"Reply with exactly: {EXPECTED_TEXT}"
+TOOL_PROMPT = f"Use the tool to look up the topic {EXPECTED_TOOL_ARGS['topic']}."
+TOOL_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {"topic": {"type": "string"}},
+    "required": ["topic"],
+    "additionalProperties": False,
+}
+OPENAI_CHAT_TOOL_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": EXPECTED_TOOL_NAME,
+        "description": "Look up a demo fact by topic.",
+        "parameters": TOOL_PARAMETERS,
+    },
+}
+FUNCTION_TOOL_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "name": EXPECTED_TOOL_NAME,
+    "description": "Look up a demo fact by topic.",
+    "parameters": TOOL_PARAMETERS,
+}
+ANTHROPIC_TOOL_SCHEMA: dict[str, Any] = {
+    "name": EXPECTED_TOOL_NAME,
+    "description": "Look up a demo fact by topic.",
+    "input_schema": TOOL_PARAMETERS,
+}
+OPENAI_CHAT_TOOL_CHOICE: dict[str, Any] = {"type": "function", "function": {"name": EXPECTED_TOOL_NAME}}
+FUNCTION_TOOL_CHOICE: dict[str, Any] = {"type": "function", "name": EXPECTED_TOOL_NAME}
+ANTHROPIC_TOOL_CHOICE: dict[str, Any] = {"type": "tool", "name": EXPECTED_TOOL_NAME}
 DEFAULT_BACKENDS = {"ollama"}
 DEFAULT_PARITY_MODELS = {"gemini-2.5-flash", "glm-4.5-air-anthropic"}
 TEXT_MODES = {"chat", "responses"}
-RequestBuilder = Callable[["ModelProbe", int, str], dict[str, Any]]
-Validator = Callable[[Any], str]
 
 
-@dataclass(frozen=True)
-class ModelProbe:
+class ProbeError(Exception):
+    pass
+
+
+class ModelProbe(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     name: str
     mode: str
     backend: str
 
 
-@dataclass(frozen=True)
-class ProbeResult:
+class ProbeResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     model: ModelProbe
     shape: str
     scenario: str
@@ -49,17 +85,50 @@ class ProbeResult:
     detail: str
     request_path: Path | None
     response_path: Path | None
-    request_key: str | None = None
+    request_key: str
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    name: str
+    arguments: Any
+
+
+TextExtractor = Callable[[Any], list[str]]
+ToolCallExtractor = Callable[[Any], list[ToolCall]]
+DetailExtractor = Callable[[Any], str | None]
 
 
 @dataclass(frozen=True)
 class ProbeShape:
     name: str
     path: str
-    build_request: RequestBuilder
-    validate_text: Validator
-    validate_tool: Validator
+    input_field: str
+    token_field: str
+    extract_text: TextExtractor
+    extract_tool_calls: ToolCallExtractor
+    tool_schema: dict[str, Any] | None = None
+    tool_choice: dict[str, Any] | None = None
     stream: bool = False
+    temperature: float | None = None
+
+    def build_request(self, model: ModelProbe, max_output_tokens: int, scenario: str) -> dict[str, Any]:
+        prompt = TOOL_PROMPT if scenario == "tool" else TEXT_PROMPT
+        body: dict[str, Any] = {"model": model.name, self.token_field: max_output_tokens}
+        if self.temperature is not None:
+            body["temperature"] = self.temperature
+        if self.input_field == "messages":
+            body["messages"] = [{"role": "user", "content": prompt}]
+        else:
+            body[self.input_field] = prompt
+        if self.path == "/v1/responses":
+            body["stream"] = self.stream
+        if scenario == "tool":
+            if self.tool_schema is None or self.tool_choice is None:
+                raise ValueError(f"{self.name} does not define tool schema fields")
+            body["tools"] = [deepcopy(self.tool_schema)]
+            body["tool_choice"] = deepcopy(self.tool_choice)
+        return body
 
 
 def _parse_args() -> argparse.Namespace:
@@ -190,15 +259,30 @@ def _parse_json(response: httpx.Response) -> Any:
         return response.text
 
 
-def _detail_from_body(body: Any) -> str:
-    if isinstance(body, str):
-        return body.strip().replace("\n", " ")[:240]
+def _compact_detail(value: str) -> str:
+    return value.strip().replace("\n", " ")[:240]
+
+
+def _json_detail(value: Any) -> str:
+    return json.dumps(value, sort_keys=True)[:240]
+
+
+def _string_body_detail(body: Any) -> str | None:
+    return _compact_detail(body) if isinstance(body, str) else None
+
+
+def _error_detail(body: Any) -> str | None:
+    if not isinstance(body, dict):
+        return None
+    error = body.get("error")
+    if not isinstance(error, dict):
+        return None
+    message = error.get("message")
+    return _compact_detail(message) if isinstance(message, str) else None
+
+
+def _chat_content_detail(body: Any) -> str | None:
     if isinstance(body, dict):
-        error = body.get("error")
-        if isinstance(error, dict):
-            message = error.get("message")
-            if isinstance(message, str):
-                return message.replace("\n", " ")[:240]
         choices = body.get("choices")
         if isinstance(choices, list) and choices:
             first = choices[0]
@@ -207,14 +291,30 @@ def _detail_from_body(body: Any) -> str:
                 if isinstance(message, dict):
                     content = message.get("content")
                     if isinstance(content, str):
-                        return content.strip().replace("\n", " ")[:240]
-        output = body.get("output")
-        if output is not None:
-            return json.dumps(output)[:240]
-        content = body.get("content")
-        if content is not None:
-            return json.dumps(content)[:240]
-    return json.dumps(body, sort_keys=True)[:240]
+                        return _compact_detail(content)
+    return None
+
+
+def _json_field_detail(field: str) -> DetailExtractor:
+    def extract(body: Any) -> str | None:
+        if not isinstance(body, dict) or field not in body:
+            return None
+        return _json_detail(body[field])
+
+    return extract
+
+
+DETAIL_EXTRACTORS: tuple[DetailExtractor, ...] = (
+    _string_body_detail,
+    _error_detail,
+    _chat_content_detail,
+    _json_field_detail("output"),
+    _json_field_detail("content"),
+)
+
+
+def _detail_from_body(body: Any) -> str:
+    return next((detail for extract in DETAIL_EXTRACTORS if (detail := extract(body)) is not None), _json_detail(body))
 
 
 def _save_body(path: Path | None, body: str) -> None:
@@ -260,11 +360,9 @@ def _first_chat_message(body: Any) -> dict[str, Any]:
     return {}
 
 
-def _assert_chat_text(body: Any) -> str:
+def _chat_text(body: Any) -> list[str]:
     content = _first_chat_message(body).get("content")
-    if isinstance(content, str) and content.strip() == EXPECTED_TEXT:
-        return ""
-    raise ValueError(f"chat final text is not {EXPECTED_TEXT!r}: {_detail_from_body(body)}")
+    return [content] if isinstance(content, str) else []
 
 
 def _parse_json_object(value: Any) -> dict[str, Any] | None:
@@ -280,28 +378,28 @@ def _parse_json_object(value: Any) -> dict[str, Any] | None:
     return None
 
 
-def _assert_tool_args(value: Any, body: Any) -> None:
+def _assert_tool_args(value: Any, body: Any, shape: str) -> None:
     args = _parse_json_object(value)
     if args == EXPECTED_TOOL_ARGS:
         return
-    raise ValueError(f"tool args are not {EXPECTED_TOOL_ARGS!r}: {_detail_from_body(body)}")
+    raise ProbeError(f"{shape} tool args are not {EXPECTED_TOOL_ARGS!r}: {_detail_from_body(body)}")
 
 
-def _assert_chat_tool_call(body: Any) -> str:
+def _chat_tool_calls(body: Any) -> list[ToolCall]:
     tool_calls = _first_chat_message(body).get("tool_calls")
-    if not isinstance(tool_calls, list) or not tool_calls:
-        raise ValueError(f"no chat tool_calls in response: {_detail_from_body(body)}")
+    if not isinstance(tool_calls, list):
+        return []
+    parsed: list[ToolCall] = []
     for call in tool_calls:
         if not isinstance(call, dict):
             continue
         function = call.get("function")
         if not isinstance(function, dict):
             continue
-        if function.get("name") != EXPECTED_TOOL_NAME:
-            continue
-        _assert_tool_args(function.get("arguments"), body)
-        return ""
-    raise ValueError(f"no chat tool_call named {EXPECTED_TOOL_NAME!r}: {_detail_from_body(body)}")
+        name = function.get("name")
+        if isinstance(name, str):
+            parsed.append(ToolCall(name=name, arguments=function.get("arguments")))
+    return parsed
 
 
 def _responses_output_items(body: Any) -> list[Any]:
@@ -313,11 +411,12 @@ def _responses_output_items(body: Any) -> list[Any]:
     return []
 
 
-def _assert_responses_text(body: Any) -> str:
+def _responses_text(body: Any) -> list[str]:
+    texts: list[str] = []
     if isinstance(body, dict):
         output_text = body.get("output_text")
-        if isinstance(output_text, str) and output_text.strip() == EXPECTED_TEXT:
-            return ""
+        if isinstance(output_text, str):
+            texts.append(output_text)
     for item in _responses_output_items(body):
         if not isinstance(item, dict):
             continue
@@ -328,20 +427,20 @@ def _assert_responses_text(body: Any) -> str:
             if not isinstance(part, dict):
                 continue
             text = part.get("text")
-            if isinstance(text, str) and text.strip() == EXPECTED_TEXT:
-                return ""
-    raise ValueError(f"Responses final text is not {EXPECTED_TEXT!r}: {_detail_from_body(body)}")
+            if isinstance(text, str):
+                texts.append(text)
+    return texts
 
 
-def _assert_responses_tool_call(body: Any) -> str:
+def _responses_tool_calls(body: Any) -> list[ToolCall]:
+    calls: list[ToolCall] = []
     for item in _responses_output_items(body):
         if not isinstance(item, dict) or item.get("type") not in {"function_call", "tool_call"}:
             continue
-        if item.get("name") != EXPECTED_TOOL_NAME:
-            continue
-        _assert_tool_args(item.get("arguments"), body)
-        return ""
-    raise ValueError(f"no Responses function_call named {EXPECTED_TOOL_NAME!r}: {_detail_from_body(body)}")
+        name = item.get("name")
+        if isinstance(name, str):
+            calls.append(ToolCall(name=name, arguments=item.get("arguments")))
+    return calls
 
 
 def _responses_body_from_stream_events(events: list[Any]) -> dict[str, Any]:
@@ -397,7 +496,8 @@ def _responses_body_from_stream_events(events: list[Any]) -> dict[str, Any]:
     return body
 
 
-def _assert_anthropic_text(body: Any) -> str:
+def _anthropic_text(body: Any) -> list[str]:
+    texts: list[str] = []
     if isinstance(body, dict):
         content = body.get("content")
         if isinstance(content, list):
@@ -405,145 +505,89 @@ def _assert_anthropic_text(body: Any) -> str:
                 if not isinstance(part, dict) or part.get("type") != "text":
                     continue
                 text = part.get("text")
-                if isinstance(text, str) and text.strip() == EXPECTED_TEXT:
-                    return ""
-    raise ValueError(f"Anthropic final text is not {EXPECTED_TEXT!r}: {_detail_from_body(body)}")
+                if isinstance(text, str):
+                    texts.append(text)
+    return texts
 
 
-def _assert_anthropic_tool_call(body: Any) -> str:
+def _anthropic_tool_calls(body: Any) -> list[ToolCall]:
+    calls: list[ToolCall] = []
     if isinstance(body, dict):
         content = body.get("content")
         if isinstance(content, list):
             for part in content:
                 if not isinstance(part, dict) or part.get("type") != "tool_use":
                     continue
-                if part.get("name") == EXPECTED_TOOL_NAME:
-                    _assert_tool_args(part.get("input"), body)
-                    return ""
-    raise ValueError(f"no Anthropic tool_use named {EXPECTED_TOOL_NAME!r}: {_detail_from_body(body)}")
+                name = part.get("name")
+                if isinstance(name, str):
+                    calls.append(ToolCall(name=name, arguments=part.get("input")))
+    return calls
 
 
-def _tool_parameters() -> dict[str, Any]:
-    return {
-        "type": "object",
-        "properties": {"topic": {"type": "string"}},
-        "required": ["topic"],
-        "additionalProperties": False,
-    }
+def _assert_expected_text(shape: ProbeShape, body: Any) -> str:
+    if any(text.strip() == EXPECTED_TEXT for text in shape.extract_text(body)):
+        return ""
+    raise ProbeError(f"{shape.name} final text is not {EXPECTED_TEXT!r}: {_detail_from_body(body)}")
 
 
-def _tool_schema_openai_chat() -> dict[str, Any]:
-    return {
-        "type": "function",
-        "function": {
-            "name": EXPECTED_TOOL_NAME,
-            "description": "Look up a demo fact by topic.",
-            "parameters": _tool_parameters(),
-        },
-    }
-
-
-def _tool_schema_function() -> dict[str, Any]:
-    return {
-        "type": "function",
-        "name": EXPECTED_TOOL_NAME,
-        "description": "Look up a demo fact by topic.",
-        "parameters": _tool_parameters(),
-    }
-
-
-def _tool_schema_anthropic() -> dict[str, Any]:
-    schema = _tool_schema_function()
-    return {"name": schema["name"], "description": schema["description"], "input_schema": schema["parameters"]}
-
-
-def _chat_request_body(model: ModelProbe, max_output_tokens: int, scenario: str) -> dict[str, Any]:
-    body: dict[str, Any] = {
-        "model": model.name,
-        "messages": [{"role": "user", "content": f"Reply with exactly: {EXPECTED_TEXT}"}],
-        "temperature": 0,
-        "max_tokens": max_output_tokens,
-    }
-    if scenario == "tool":
-        body["messages"] = [
-            {"role": "user", "content": f"Use the tool to look up the topic {EXPECTED_TOOL_ARGS['topic']}."}
-        ]
-        body["tools"] = [_tool_schema_openai_chat()]
-        body["tool_choice"] = {"type": "function", "function": {"name": EXPECTED_TOOL_NAME}}
-    return body
-
-
-def _responses_request_body(
-    model: ModelProbe, max_output_tokens: int, scenario: str, *, stream: bool = False
-) -> dict[str, Any]:
-    body: dict[str, Any] = {
-        "model": model.name,
-        "input": f"Reply with exactly: {EXPECTED_TEXT}",
-        "stream": stream,
-        "max_output_tokens": max_output_tokens,
-    }
-    if scenario == "tool":
-        body["input"] = f"Use the tool to look up the topic {EXPECTED_TOOL_ARGS['topic']}."
-        body["tools"] = [_tool_schema_function()]
-        body["tool_choice"] = {"type": "function", "name": EXPECTED_TOOL_NAME}
-    return body
-
-
-def _streaming_responses_request_body(model: ModelProbe, max_output_tokens: int, scenario: str) -> dict[str, Any]:
-    return _responses_request_body(model, max_output_tokens, scenario, stream=True)
-
-
-def _anthropic_request_body(model: ModelProbe, max_output_tokens: int, scenario: str) -> dict[str, Any]:
-    body: dict[str, Any] = {
-        "model": model.name,
-        "max_tokens": max_output_tokens,
-        "temperature": 0,
-        "messages": [{"role": "user", "content": f"Reply with exactly: {EXPECTED_TEXT}"}],
-    }
-    if scenario == "tool":
-        body["messages"] = [
-            {"role": "user", "content": f"Use the tool to look up the topic {EXPECTED_TOOL_ARGS['topic']}."}
-        ]
-        body["tools"] = [_tool_schema_anthropic()]
-        body["tool_choice"] = {"type": "tool", "name": EXPECTED_TOOL_NAME}
-    return body
+def _assert_expected_tool_call(shape: ProbeShape, body: Any) -> str:
+    for call in shape.extract_tool_calls(body):
+        if call.name != EXPECTED_TOOL_NAME:
+            continue
+        _assert_tool_args(call.arguments, body, shape.name)
+        return ""
+    raise ProbeError(f"no {shape.name} tool call named {EXPECTED_TOOL_NAME!r}: {_detail_from_body(body)}")
 
 
 def _validate_for_scenario(shape: ProbeShape, scenario: str, body: Any) -> str:
     if scenario == "tool":
-        return shape.validate_tool(body)
-    return shape.validate_text(body)
+        return _assert_expected_tool_call(shape, body)
+    return _assert_expected_text(shape, body)
 
 
 SHAPE_DEFS = (
     ProbeShape(
         name="openai-chat",
         path="/v1/chat/completions",
-        build_request=_chat_request_body,
-        validate_text=_assert_chat_text,
-        validate_tool=_assert_chat_tool_call,
+        input_field="messages",
+        token_field="max_tokens",
+        extract_text=_chat_text,
+        extract_tool_calls=_chat_tool_calls,
+        tool_schema=OPENAI_CHAT_TOOL_SCHEMA,
+        tool_choice=OPENAI_CHAT_TOOL_CHOICE,
+        temperature=0,
     ),
     ProbeShape(
         name="openai-responses",
         path="/v1/responses",
-        build_request=_responses_request_body,
-        validate_text=_assert_responses_text,
-        validate_tool=_assert_responses_tool_call,
+        input_field="input",
+        token_field="max_output_tokens",
+        extract_text=_responses_text,
+        extract_tool_calls=_responses_tool_calls,
+        tool_schema=FUNCTION_TOOL_SCHEMA,
+        tool_choice=FUNCTION_TOOL_CHOICE,
     ),
     ProbeShape(
         name="openai-responses-streaming",
         path="/v1/responses",
-        build_request=_streaming_responses_request_body,
-        validate_text=_assert_responses_text,
-        validate_tool=_assert_responses_tool_call,
+        input_field="input",
+        token_field="max_output_tokens",
+        extract_text=_responses_text,
+        extract_tool_calls=_responses_tool_calls,
+        tool_schema=FUNCTION_TOOL_SCHEMA,
+        tool_choice=FUNCTION_TOOL_CHOICE,
         stream=True,
     ),
     ProbeShape(
         name="anthropic-messages",
         path="/v1/messages",
-        build_request=_anthropic_request_body,
-        validate_text=_assert_anthropic_text,
-        validate_tool=_assert_anthropic_tool_call,
+        input_field="messages",
+        token_field="max_tokens",
+        extract_text=_anthropic_text,
+        extract_tool_calls=_anthropic_tool_calls,
+        tool_schema=ANTHROPIC_TOOL_SCHEMA,
+        tool_choice=ANTHROPIC_TOOL_CHOICE,
+        temperature=0,
     ),
 )
 SHAPES = {shape.name: shape for shape in SHAPE_DEFS}
@@ -574,7 +618,7 @@ def _request_url_from_key(request_key: str) -> str | None:
 
 
 def _saved_exchange_matches_key(result: ProbeResult) -> bool:
-    if result.request_key is None or result.request_path is None or result.response_path is None:
+    if result.request_path is None or result.response_path is None:
         return False
     if not result.request_path.exists() or not result.response_path.exists():
         return False
@@ -613,8 +657,10 @@ def _post_streaming_responses(
             if line.startswith("data: "):
                 payload = line.removeprefix("data: ").strip()
                 if payload and payload != "[DONE]":
-                    with suppress(json.JSONDecodeError):
+                    try:
                         events.append(json.loads(payload))
+                    except json.JSONDecodeError as exc:
+                        raise ProbeError(f"invalid Responses stream JSON: {payload}") from exc
         _save_body(response_path, "\n".join(raw_lines))
     return _responses_body_from_stream_events(events)
 
@@ -662,7 +708,7 @@ def _probe_one(
             )
             detail = _validate_for_scenario(shape_spec, scenario, response_body)
             status = "ok"
-    except Exception as exc:
+    except (httpx.HTTPError, ProbeError) as exc:
         detail = f"{type(exc).__name__}: {exc}"
         status = "fail"
     return ProbeResult(
@@ -680,7 +726,7 @@ def _probe_one(
 
 def _print_result(result: ProbeResult, json_lines: bool) -> None:
     if json_lines:
-        print(json.dumps(_result_record(result), sort_keys=True), flush=True)
+        print(_result_record_json(result), flush=True)
         return
     print(
         "\t".join(
@@ -722,45 +768,18 @@ def _results_path(response_dir: Path) -> Path:
     return response_dir / RESULTS_JSONL
 
 
-def _result_record(result: ProbeResult) -> dict[str, Any]:
-    return {
-        "status": result.status,
-        "elapsed_seconds": round(result.elapsed_seconds, 3),
-        "model": result.model.name,
-        "mode": result.model.mode,
-        "backend": result.model.backend,
-        "shape": result.shape,
-        "scenario": result.scenario,
-        "detail": result.detail,
-        "request_path": str(result.request_path) if result.request_path is not None else None,
-        "response_path": str(result.response_path) if result.response_path is not None else None,
-        "request_key": result.request_key,
-    }
+def _result_record_json(result: ProbeResult) -> str:
+    record = result.model_dump(mode="json")
+    record["elapsed_seconds"] = round(result.elapsed_seconds, 3)
+    return json.dumps(record, sort_keys=True)
 
 
 def _append_result_record(response_dir: Path, result: ProbeResult) -> None:
     path = _results_path(response_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a") as file:
-        file.write(json.dumps(_result_record(result), sort_keys=True))
+        file.write(_result_record_json(result))
         file.write("\n")
-
-
-def _result_from_record(record: dict[str, Any]) -> ProbeResult:
-    model = ModelProbe(name=str(record["model"]), mode=str(record["mode"]), backend=str(record["backend"]))
-    request_path = record.get("request_path")
-    response_path = record.get("response_path")
-    return ProbeResult(
-        model=model,
-        shape=str(record["shape"]),
-        scenario=str(record["scenario"]),
-        status=str(record["status"]),
-        elapsed_seconds=float(record["elapsed_seconds"]),
-        detail=str(record.get("detail") or ""),
-        request_path=Path(request_path) if isinstance(request_path, str) else None,
-        response_path=Path(response_path) if isinstance(response_path, str) else None,
-        request_key=str(record["request_key"]) if isinstance(record.get("request_key"), str) else None,
-    )
 
 
 def _load_result_records(response_dir: Path) -> list[ProbeResult]:
@@ -772,11 +791,8 @@ def _load_result_records(response_dir: Path) -> list[ProbeResult]:
         if not line.strip():
             continue
         try:
-            record = json.loads(line)
-            if not isinstance(record, dict):
-                raise ValueError("record is not a JSON object")
-            results.append(_result_from_record(record))
-        except Exception as exc:
+            results.append(ProbeResult.model_validate_json(line))
+        except ValueError as exc:
             raise ValueError(f"invalid result record in {path}:{line_number}: {exc}") from exc
     return results
 
@@ -791,12 +807,8 @@ def _load_aggregate_results(response_dirs: list[Path]) -> list[ProbeResult]:
     return results
 
 
-def _legacy_result_key(result: ProbeResult) -> str:
-    return "\x1f".join([result.model.name, result.shape, result.scenario])
-
-
 def _result_key(result: ProbeResult) -> str:
-    return result.request_key or f"legacy:{_legacy_result_key(result)}"
+    return result.request_key
 
 
 def _case_key(base_url: str, model: ModelProbe, shape: str, scenario: str, max_output_tokens: int) -> str:
@@ -834,10 +846,7 @@ def _pretty_file(path: Path | None) -> str:
 
 
 def _status_counts(results: list[ProbeResult]) -> dict[str, int]:
-    counts: dict[str, int] = {}
-    for result in results:
-        counts[result.status] = counts.get(result.status, 0) + 1
-    return counts
+    return dict(Counter(result.status for result in results))
 
 
 def _write_html_report(path: Path, results: list[ProbeResult], response_dir: Path) -> None:
@@ -869,6 +878,53 @@ def _write_html_report(path: Path, results: list[ProbeResult], response_dir: Pat
         counts=json.dumps(counts, sort_keys=True), response_dir=str(response_dir), rows=rows
     )
     path.write_text(html_text)
+
+
+def _run_probe_matrix(
+    client: httpx.Client,
+    args: argparse.Namespace,
+    base_url: str,
+    headers: dict[str, str],
+    probes: list[ModelProbe],
+    shapes: list[str],
+    scenarios: list[str],
+    response_dir: Path,
+    results_by_key: dict[str, ProbeResult],
+) -> None:
+    copied_resume_keys: set[str] = set()
+    for probe in probes:
+        for shape in shapes:
+            for scenario in scenarios:
+                key = _case_key(base_url, probe, shape, scenario, args.max_output_tokens)
+                previous = results_by_key.get(key)
+                if (
+                    args.resume_dir
+                    and previous is not None
+                    and previous.status == "ok"
+                    and _saved_exchange_matches_key(previous)
+                ):
+                    if key not in copied_resume_keys:
+                        _append_result_record(response_dir, previous)
+                        copied_resume_keys.add(key)
+                    continue
+                request_path, response_path = _artifact_paths(response_dir, probe, shape, scenario)
+                result = _probe_one(
+                    client,
+                    base_url,
+                    headers,
+                    probe,
+                    shape,
+                    scenario,
+                    args.max_output_tokens,
+                    args.include_unsupported,
+                    request_path,
+                    response_path,
+                )
+                results_by_key[key] = result
+                _append_result_record(response_dir, result)
+                _print_result(result, args.json)
+                if result.status == "fail" and not args.continue_on_error:
+                    return
 
 
 def main() -> int:
@@ -908,51 +964,10 @@ def main() -> int:
         print(f"html report: {report_path}", file=sys.stderr, flush=True)
         return 1 if any(result.status == "fail" for result in results) else 0
     timeout = httpx.Timeout(args.timeout_seconds, connect=15.0)
-    stop_after_failure = False
     interrupted = False
-    copied_resume_keys: set[str] = set()
     try:
         with httpx.Client(timeout=timeout, follow_redirects=True) as client:
-            for probe in probes:
-                for shape in shapes:
-                    for scenario in scenarios:
-                        if stop_after_failure:
-                            break
-                        key = _case_key(base_url, probe, shape, scenario, args.max_output_tokens)
-                        previous = results_by_key.get(key)
-                        if (
-                            args.resume_dir
-                            and previous is not None
-                            and previous.status == "ok"
-                            and _saved_exchange_matches_key(previous)
-                        ):
-                            if key not in copied_resume_keys:
-                                _append_result_record(response_dir, previous)
-                                copied_resume_keys.add(key)
-                            continue
-                        request_path, response_path = _artifact_paths(response_dir, probe, shape, scenario)
-                        result = _probe_one(
-                            client,
-                            base_url,
-                            headers,
-                            probe,
-                            shape,
-                            scenario,
-                            args.max_output_tokens,
-                            args.include_unsupported,
-                            request_path,
-                            response_path,
-                        )
-                        results_by_key[key] = result
-                        _append_result_record(response_dir, result)
-                        _print_result(result, args.json)
-                        if result.status == "fail" and not args.continue_on_error:
-                            stop_after_failure = True
-                            break
-                    if stop_after_failure:
-                        break
-                if stop_after_failure:
-                    break
+            _run_probe_matrix(client, args, base_url, headers, probes, shapes, scenarios, response_dir, results_by_key)
     except KeyboardInterrupt:
         interrupted = True
         print("interrupted: writing report for completed probe records", file=sys.stderr, flush=True)

--- a/debug/litellm_probe/probe_models.py
+++ b/debug/litellm_probe/probe_models.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 import time
+from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,12 +14,13 @@ from typing import Any
 
 import httpx
 import yaml
-from jinja2 import Environment
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from util.bazel.runfiles import get_required_path
 
 DEFAULT_BASE_URL = "https://litellm.allegedly.works"
 DEFAULT_CONFIG_RUNFILE = "ducktape/cluster/k8s/litellm/app/proxy-config.yaml"
+REPORT_TEMPLATE_RUNFILE = "ducktape/debug/litellm_probe/report.html.j2"
 RESULTS_JSONL = "results.jsonl"
 EXPECTED_TEXT = "OK"
 EXPECTED_TOOL_NAME = "lookup_demo_fact"
@@ -26,6 +28,8 @@ EXPECTED_TOOL_ARGS = {"topic": "litellm-probe"}
 DEFAULT_BACKENDS = {"ollama"}
 DEFAULT_PARITY_MODELS = {"gemini-2.5-flash", "glm-4.5-air-anthropic"}
 TEXT_MODES = {"chat", "responses"}
+RequestBuilder = Callable[["ModelProbe", int, str], dict[str, Any]]
+Validator = Callable[[Any], str]
 
 
 @dataclass(frozen=True)
@@ -46,6 +50,16 @@ class ProbeResult:
     request_path: Path | None
     response_path: Path | None
     request_key: str | None = None
+
+
+@dataclass(frozen=True)
+class ProbeShape:
+    name: str
+    path: str
+    build_request: RequestBuilder
+    validate_text: Validator
+    validate_tool: Validator
+    stream: bool = False
 
 
 def _parse_args() -> argparse.Namespace:
@@ -75,7 +89,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--shape",
         action="append",
-        choices=["openai-chat", "openai-responses", "anthropic-messages"],
+        choices=sorted(SHAPES),
         default=None,
         help="API shape to probe. Repeatable. Defaults to all supported text shapes.",
     )
@@ -409,52 +423,43 @@ def _assert_anthropic_tool_call(body: Any) -> str:
     raise ValueError(f"no Anthropic tool_use named {EXPECTED_TOOL_NAME!r}: {_detail_from_body(body)}")
 
 
-def _tool_schema_openai() -> dict[str, Any]:
+def _tool_parameters() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {"topic": {"type": "string"}},
+        "required": ["topic"],
+        "additionalProperties": False,
+    }
+
+
+def _tool_schema_openai_chat() -> dict[str, Any]:
     return {
         "type": "function",
         "function": {
             "name": EXPECTED_TOOL_NAME,
             "description": "Look up a demo fact by topic.",
-            "parameters": {
-                "type": "object",
-                "properties": {"topic": {"type": "string"}},
-                "required": ["topic"],
-                "additionalProperties": False,
-            },
+            "parameters": _tool_parameters(),
         },
     }
 
 
-def _tool_schema_responses() -> dict[str, Any]:
+def _tool_schema_function() -> dict[str, Any]:
     return {
         "type": "function",
         "name": EXPECTED_TOOL_NAME,
         "description": "Look up a demo fact by topic.",
-        "parameters": {
-            "type": "object",
-            "properties": {"topic": {"type": "string"}},
-            "required": ["topic"],
-            "additionalProperties": False,
-        },
+        "parameters": _tool_parameters(),
     }
 
 
 def _tool_schema_anthropic() -> dict[str, Any]:
-    return {
-        "name": EXPECTED_TOOL_NAME,
-        "description": "Look up a demo fact by topic.",
-        "input_schema": {
-            "type": "object",
-            "properties": {"topic": {"type": "string"}},
-            "required": ["topic"],
-            "additionalProperties": False,
-        },
-    }
+    schema = _tool_schema_function()
+    return {"name": schema["name"], "description": schema["description"], "input_schema": schema["parameters"]}
 
 
-def _chat_request_body(model: str, max_output_tokens: int, scenario: str) -> dict[str, Any]:
+def _chat_request_body(model: ModelProbe, max_output_tokens: int, scenario: str) -> dict[str, Any]:
     body: dict[str, Any] = {
-        "model": model,
+        "model": model.name,
         "messages": [{"role": "user", "content": f"Reply with exactly: {EXPECTED_TEXT}"}],
         "temperature": 0,
         "max_tokens": max_output_tokens,
@@ -463,28 +468,34 @@ def _chat_request_body(model: str, max_output_tokens: int, scenario: str) -> dic
         body["messages"] = [
             {"role": "user", "content": f"Use the tool to look up the topic {EXPECTED_TOOL_ARGS['topic']}."}
         ]
-        body["tools"] = [_tool_schema_openai()]
+        body["tools"] = [_tool_schema_openai_chat()]
         body["tool_choice"] = {"type": "function", "function": {"name": EXPECTED_TOOL_NAME}}
     return body
 
 
-def _responses_request_body(model: str, max_output_tokens: int, scenario: str, stream: bool) -> dict[str, Any]:
+def _responses_request_body(
+    model: ModelProbe, max_output_tokens: int, scenario: str, *, stream: bool = False
+) -> dict[str, Any]:
     body: dict[str, Any] = {
-        "model": model,
+        "model": model.name,
         "input": f"Reply with exactly: {EXPECTED_TEXT}",
         "stream": stream,
         "max_output_tokens": max_output_tokens,
     }
     if scenario == "tool":
         body["input"] = f"Use the tool to look up the topic {EXPECTED_TOOL_ARGS['topic']}."
-        body["tools"] = [_tool_schema_responses()]
+        body["tools"] = [_tool_schema_function()]
         body["tool_choice"] = {"type": "function", "name": EXPECTED_TOOL_NAME}
     return body
 
 
-def _anthropic_request_body(model: str, max_output_tokens: int, scenario: str) -> dict[str, Any]:
+def _streaming_responses_request_body(model: ModelProbe, max_output_tokens: int, scenario: str) -> dict[str, Any]:
+    return _responses_request_body(model, max_output_tokens, scenario, stream=True)
+
+
+def _anthropic_request_body(model: ModelProbe, max_output_tokens: int, scenario: str) -> dict[str, Any]:
     body: dict[str, Any] = {
-        "model": model,
+        "model": model.name,
         "max_tokens": max_output_tokens,
         "temperature": 0,
         "messages": [{"role": "user", "content": f"Reply with exactly: {EXPECTED_TEXT}"}],
@@ -498,24 +509,53 @@ def _anthropic_request_body(model: str, max_output_tokens: int, scenario: str) -
     return body
 
 
+def _validate_for_scenario(shape: ProbeShape, scenario: str, body: Any) -> str:
+    if scenario == "tool":
+        return shape.validate_tool(body)
+    return shape.validate_text(body)
+
+
+SHAPE_DEFS = (
+    ProbeShape(
+        name="openai-chat",
+        path="/v1/chat/completions",
+        build_request=_chat_request_body,
+        validate_text=_assert_chat_text,
+        validate_tool=_assert_chat_tool_call,
+    ),
+    ProbeShape(
+        name="openai-responses",
+        path="/v1/responses",
+        build_request=_responses_request_body,
+        validate_text=_assert_responses_text,
+        validate_tool=_assert_responses_tool_call,
+    ),
+    ProbeShape(
+        name="openai-responses-streaming",
+        path="/v1/responses",
+        build_request=_streaming_responses_request_body,
+        validate_text=_assert_responses_text,
+        validate_tool=_assert_responses_tool_call,
+        stream=True,
+    ),
+    ProbeShape(
+        name="anthropic-messages",
+        path="/v1/messages",
+        build_request=_anthropic_request_body,
+        validate_text=_assert_anthropic_text,
+        validate_tool=_assert_anthropic_tool_call,
+    ),
+)
+SHAPES = {shape.name: shape for shape in SHAPE_DEFS}
+DEFAULT_SHAPES = tuple(SHAPES)
+
+
 def _request_url(base_url: str, shape: str) -> str:
-    if shape == "openai-chat":
-        return f"{base_url}/v1/chat/completions"
-    if shape == "openai-responses":
-        return f"{base_url}/v1/responses"
-    if shape == "anthropic-messages":
-        return f"{base_url}/v1/messages"
-    raise ValueError(f"unsupported shape: {shape}")
+    return f"{base_url}{SHAPES[shape].path}"
 
 
 def _planned_request_body(model: ModelProbe, shape: str, scenario: str, max_output_tokens: int) -> dict[str, Any]:
-    if shape == "openai-chat":
-        return _chat_request_body(model.name, max_output_tokens, scenario)
-    if shape == "openai-responses":
-        return _responses_request_body(model.name, max_output_tokens, scenario, stream=model.mode == "responses")
-    if shape == "anthropic-messages":
-        return _anthropic_request_body(model.name, max_output_tokens, scenario)
-    raise ValueError(f"unsupported shape: {shape}")
+    return SHAPES[shape].build_request(model, max_output_tokens, scenario)
 
 
 def _request_key(url: str, body: dict[str, Any]) -> str:
@@ -550,44 +590,18 @@ def _saved_exchange_matches_key(result: ProbeResult) -> bool:
     return _request_key(url, request_body) == result.request_key
 
 
-def _probe_chat(
+def _post_streaming_responses(
     client: httpx.Client,
-    base_url: str,
+    url: str,
     headers: dict[str, str],
-    model: str,
-    max_output_tokens: int,
-    scenario: str,
+    body: dict[str, Any],
     request_path: Path | None,
     response_path: Path | None,
-) -> str:
-    body = _chat_request_body(model, max_output_tokens, scenario)
-    body_json, _ = _post_json(client, f"{base_url}/v1/chat/completions", headers, body, request_path, response_path)
-    if scenario == "tool":
-        return _assert_chat_tool_call(body_json)
-    return _assert_chat_text(body_json)
-
-
-def _probe_responses(
-    client: httpx.Client,
-    base_url: str,
-    headers: dict[str, str],
-    model: str,
-    max_output_tokens: int,
-    scenario: str,
-    stream: bool,
-    request_path: Path | None,
-    response_path: Path | None,
-) -> str:
-    body = _responses_request_body(model, max_output_tokens, scenario, stream)
+) -> dict[str, Any]:
     _save_json_body(request_path, body)
-    if not stream:
-        body_json, _ = _post_json(client, f"{base_url}/v1/responses", headers, body, None, response_path)
-        if scenario == "tool":
-            return _assert_responses_tool_call(body_json)
-        return _assert_responses_text(body_json)
     raw_lines: list[str] = []
     events: list[Any] = []
-    with client.stream("POST", f"{base_url}/v1/responses", headers=headers, json=body) as response:
+    with client.stream("POST", url, headers=headers, json=body) as response:
         if response.status_code >= 400:
             response.read()
             _save_body(response_path, response.text)
@@ -602,27 +616,24 @@ def _probe_responses(
                     with suppress(json.JSONDecodeError):
                         events.append(json.loads(payload))
         _save_body(response_path, "\n".join(raw_lines))
-        body_json = _responses_body_from_stream_events(events)
-        if scenario == "tool":
-            return _assert_responses_tool_call(body_json)
-        return _assert_responses_text(body_json)
+    return _responses_body_from_stream_events(events)
 
 
-def _probe_anthropic_messages(
+def _post_shape_request(
     client: httpx.Client,
     base_url: str,
     headers: dict[str, str],
-    model: str,
-    max_output_tokens: int,
-    scenario: str,
+    model: ModelProbe,
+    shape: ProbeShape,
+    body: dict[str, Any],
     request_path: Path | None,
     response_path: Path | None,
-) -> str:
-    body = _anthropic_request_body(model, max_output_tokens, scenario)
-    body_json, _ = _post_json(client, f"{base_url}/v1/messages", headers, body, request_path, response_path)
-    if scenario == "tool":
-        return _assert_anthropic_tool_call(body_json)
-    return _assert_anthropic_text(body_json)
+) -> Any:
+    url = _request_url(base_url, shape.name)
+    if shape.stream:
+        return _post_streaming_responses(client, url, headers, body, request_path, response_path)
+    body_json, _ = _post_json(client, url, headers, body, request_path, response_path)
+    return body_json
 
 
 def _probe_one(
@@ -638,39 +649,19 @@ def _probe_one(
     response_path: Path | None,
 ) -> ProbeResult:
     started = time.monotonic()
-    request_key = _request_key(
-        _request_url(base_url, shape), _planned_request_body(model, shape, scenario, max_output_tokens)
-    )
+    shape_spec = SHAPES[shape]
+    request_body = _planned_request_body(model, shape, scenario, max_output_tokens)
+    request_key = _request_key(_request_url(base_url, shape), request_body)
     try:
         if model.mode not in TEXT_MODES:
             detail = f"unsupported non-text mode for {shape}/{scenario} probe: {model.mode}"
             status = "fail" if include_unsupported else "skip"
-        elif shape == "openai-chat":
-            detail = _probe_chat(
-                client, base_url, headers, model.name, max_output_tokens, scenario, request_path, response_path
-            )
-            status = "ok"
-        elif shape == "openai-responses":
-            detail = _probe_responses(
-                client,
-                base_url,
-                headers,
-                model.name,
-                max_output_tokens,
-                scenario,
-                stream=model.mode == "responses",
-                request_path=request_path,
-                response_path=response_path,
-            )
-            status = "ok"
-        elif shape == "anthropic-messages":
-            detail = _probe_anthropic_messages(
-                client, base_url, headers, model.name, max_output_tokens, scenario, request_path, response_path
-            )
-            status = "ok"
         else:
-            detail = f"unsupported mode for {shape}/{scenario} probe: {model.mode}"
-            status = "fail" if include_unsupported else "skip"
+            response_body = _post_shape_request(
+                client, base_url, headers, model, shape_spec, request_body, request_path, response_path
+            )
+            detail = _validate_for_scenario(shape_spec, scenario, response_body)
+            status = "ok"
     except Exception as exc:
         detail = f"{type(exc).__name__}: {exc}"
         status = "fail"
@@ -849,41 +840,6 @@ def _status_counts(results: list[ProbeResult]) -> dict[str, int]:
     return counts
 
 
-_REPORT_TEMPLATE = """<!doctype html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <title>LiteLLM Probe Report</title>
-  <style>
-    body { font-family: system-ui, sans-serif; margin: 2rem; }
-    details { border: 1px solid #ccc; border-radius: 6px; margin: 0.75rem 0; padding: 0.75rem; }
-    details.ok { border-color: #7ab77a; }
-    details.fail { border-color: #d36b6b; }
-    details.skip { border-color: #bbb; }
-    summary { cursor: pointer; font-weight: 600; }
-    pre { background: #f6f6f6; border-radius: 4px; overflow-x: auto; padding: 0.75rem; white-space: pre-wrap; }
-  </style>
-</head>
-<body>
-  <h1>LiteLLM Probe Report</h1>
-  <p><strong>Response directory:</strong> {{ response_dir }}</p>
-  <p><strong>Counts:</strong> {{ counts }}</p>
-  {% for row in rows %}
-  <details class="{{ row.status }}">
-    <summary>{{ row.title }}</summary>
-    <p><strong>Backend:</strong> {{ row.backend }} &nbsp; <strong>Mode:</strong> {{ row.mode }}</p>
-    {% if row.detail %}<p><strong>Detail:</strong> {{ row.detail }}</p>{% endif %}
-    <p><strong>Request:</strong> {{ row.request_path }}</p>
-    <pre>{{ row.request_body }}</pre>
-    <p><strong>Response:</strong> {{ row.response_path }}</p>
-    <pre>{{ row.response_body }}</pre>
-  </details>
-  {% endfor %}
-</body>
-</html>
-"""
-
-
 def _write_html_report(path: Path, results: list[ProbeResult], response_dir: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     counts = _status_counts(results)
@@ -905,8 +861,11 @@ def _write_html_report(path: Path, results: list[ProbeResult], response_dir: Pat
                 "response_body": _pretty_file(result.response_path),
             }
         )
-    env = Environment(autoescape=True)
-    html_text = env.from_string(_REPORT_TEMPLATE).render(
+    template_path = get_required_path(REPORT_TEMPLATE_RUNFILE)
+    env = Environment(
+        loader=FileSystemLoader(template_path.parent), autoescape=select_autoescape(enabled_extensions=("html", "j2"))
+    )
+    html_text = env.get_template(template_path.name).render(
         counts=json.dumps(counts, sort_keys=True), response_dir=str(response_dir), rows=rows
     )
     path.write_text(html_text)
@@ -930,7 +889,7 @@ def main() -> int:
         probes = [probe for probe in all_probes if _default_selected_probe(probe)]
 
     headers = _headers(args)
-    shapes = args.shape or ["openai-chat", "openai-responses", "anthropic-messages"]
+    shapes = args.shape or list(DEFAULT_SHAPES)
     scenarios = args.scenario or ["text", "tool"]
     planned_keys = _planned_request_keys(base_url, probes, shapes, scenarios, args.max_output_tokens)
     response_dir = args.response_dir or _default_response_dir()

--- a/debug/litellm_probe/probe_models.py
+++ b/debug/litellm_probe/probe_models.py
@@ -807,10 +807,6 @@ def _load_aggregate_results(response_dirs: list[Path]) -> list[ProbeResult]:
     return results
 
 
-def _result_key(result: ProbeResult) -> str:
-    return result.request_key
-
-
 def _case_key(base_url: str, model: ModelProbe, shape: str, scenario: str, max_output_tokens: int) -> str:
     body = _planned_request_body(model, shape, scenario, max_output_tokens)
     return _request_key(_request_url(base_url, shape), body)
@@ -819,7 +815,7 @@ def _case_key(base_url: str, model: ModelProbe, shape: str, scenario: str, max_o
 def _merge_results(results: list[ProbeResult]) -> dict[str, ProbeResult]:
     merged: dict[str, ProbeResult] = {}
     for result in results:
-        merged[_result_key(result)] = result
+        merged[result.request_key] = result
     return merged
 
 
@@ -955,7 +951,7 @@ def main() -> int:
     prior_results = [
         result
         for result in _load_aggregate_results(args.aggregate_dir + args.resume_dir)
-        if _result_key(result) in planned_keys
+        if result.request_key in planned_keys
     ]
     results_by_key = _merge_results(prior_results)
     if args.report_only:

--- a/debug/litellm_probe/report.html.j2
+++ b/debug/litellm_probe/report.html.j2
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>LiteLLM Probe Report</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; }
+    details { border: 1px solid #ccc; border-radius: 6px; margin: 0.75rem 0; padding: 0.75rem; }
+    details.ok { border-color: #7ab77a; }
+    details.fail { border-color: #d36b6b; }
+    details.skip { border-color: #bbb; }
+    summary { cursor: pointer; font-weight: 600; }
+    pre { background: #f6f6f6; border-radius: 4px; overflow-x: auto; padding: 0.75rem; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <h1>LiteLLM Probe Report</h1>
+  <p><strong>Response directory:</strong> {{ response_dir }}</p>
+  <p><strong>Counts:</strong> {{ counts }}</p>
+  {% for row in rows %}
+  <details class="{{ row.status }}">
+    <summary>{{ row.title }}</summary>
+    <p><strong>Backend:</strong> {{ row.backend }} &nbsp; <strong>Mode:</strong> {{ row.mode }}</p>
+    {% if row.detail %}<p><strong>Detail:</strong> {{ row.detail }}</p>{% endif %}
+    <p><strong>Request:</strong> {{ row.request_path }}</p>
+    <pre>{{ row.request_body }}</pre>
+    <p><strong>Response:</strong> {{ row.response_path }}</p>
+    <pre>{{ row.response_body }}</pre>
+  </details>
+  {% endfor %}
+</body>
+</html>

--- a/haku/plans/local_dispatch_zone.md
+++ b/haku/plans/local_dispatch_zone.md
@@ -1,0 +1,334 @@
+# Haku local dispatch zone plan
+
+Goal: add a Haku worker zone that dispatches to local Ollama-hosted models through the
+existing two-layer LiteLLM dispatch plane, with a scheduler that prevents model-swap
+thrash by allowing at most one active local model at a time.
+
+The scheduler should be designed as an optional general feature, not a local-only
+special case. Most targets can keep today's behavior: a model allowlist with no
+parallelism throttle. Local inference needs grouping for model residency, and some
+hosted-provider model lanes may later want it for shared quota windows, accounts,
+rate-limit buckets, context caches, or other operational constraints.
+
+This plan should also stop treating "zone" as one overloaded concept. The durable model
+should separate:
+
+- **Model lane**: provider/key path/model allowlist/scheduling facts.
+- **Isolation profile**: namespace, egress, mounts, MCP servers, and other runtime
+  capabilities.
+- **Dispatch target**: an explicitly allowed pairing of one model lane and one isolation
+  profile.
+
+That split matters because the operator cares about invariants like "z.ai models should
+never get access to Google Drive." A classifier policy is not enough for that. The
+dispatcher should make the invalid pairing unrepresentable: no dispatch target combines
+an external-low model lane with a Drive/Gmail/Tana-capable isolation profile.
+
+The initial local target is analogous to the existing `zai` target, but with a different
+trust and scheduling profile:
+
+- Prompts stay on local infrastructure, so the admission policy does not need the
+  z.ai/public-by-construction restriction.
+- Workers are still low-trust. They must not get haku-state, broad cluster access, raw
+  provider keys, or an unrestricted LLM key.
+- Local inference is capacity-bound by model residency. Dispatch must avoid interleaving
+  jobs across different large models.
+
+## Config shape
+
+The eventual config should look more like this than today's flat `zones.yaml`:
+
+```yaml
+model_lanes:
+  zai:
+    provider: z.ai
+    trust_tier: external-low
+    upstream_key: haku-lane-zai
+    models:
+      glm-4.5-air-anthropic: {}
+
+  local-20b:
+    provider: local-ollama
+    trust_tier: local
+    upstream_key: haku-lane-local
+    scheduling:
+      max_active_model_groups: 1
+      max_concurrent_jobs_per_model_group: 1
+    models:
+      gpt-oss-20b-128k-openai-chat:
+        model_group: gpt-oss-20b
+
+isolation_profiles:
+  public-only:
+    namespace: haku-sandbox-zai
+    capability_tier: public-only
+    mcp_servers: []
+    egress_profile: public-web
+
+  local-default:
+    namespace: haku-sandbox-local
+    capability_tier: local-default
+    mcp_servers: []
+    egress_profile: locked-down
+
+  google-drive-readonly:
+    namespace: haku-sandbox-drive-ro
+    capability_tier: personal-data-readonly
+    mcp_servers:
+      - google-drive-ro
+    egress_profile: locked-down
+
+dispatch_targets:
+  zai-public:
+    model_lane: zai
+    isolation_profile: public-only
+
+  local-default:
+    model_lane: local-20b
+    isolation_profile: local-default
+
+  local-drive-ro:
+    model_lane: local-20b
+    isolation_profile: google-drive-readonly
+```
+
+There should be no target like `zai-drive-ro`. The dispatcher validates only configured
+targets, and tests enforce provider/capability compatibility. For v1 implementation, this
+can be a migration from today's `zones.yaml`; do not add another flat "zone means
+everything" concept.
+
+Required invariants:
+
+- `external-low` model lanes, including z.ai, may pair only with `public-only`
+  isolation profiles.
+- Profiles exposing Google Drive, Gmail, Tana, Plaid, or other personal-data MCP servers
+  must not pair with external-low model lanes.
+- Every dispatch target names exactly one model lane and one isolation profile.
+- The per-job LiteLLM key is scoped to the selected model from the model lane.
+- The worker namespace/profile, not the model lane, determines MCP server access,
+  mounted secrets, and network policy.
+
+## Initial model allowlist
+
+Only whitelist models that pass live smoke probes for the API shape the worker harness
+uses. As of the LiteLLM probe run in July 2026, the useful local route is the
+OpenAI-compatible Ollama route, not the `ollama-native` route.
+
+Seed the local zone conservatively:
+
+```text
+gpt-oss-20b-128k-openai-chat
+```
+
+Candidate additions after another explicit smoke run:
+
+```text
+gpt-oss-20b-256k-openai-chat
+gpt-oss-20b-512k-openai-chat
+gpt-oss-20b-1m-openai-chat
+gpt-oss-120b-128k-openai-chat
+gemma4-31b-it-q8_0-128k-openai-chat
+```
+
+The 20B `*-openai-chat` routes passed text and tool calls across OpenAI Chat,
+OpenAI Responses, and Anthropic Messages shapes. The 120B and Gemma routes also passed
+Anthropic-shaped text/tool probes after warmup, but they showed cold-load instability
+elsewhere, including 500/504 responses. Do not make them the default local worker model
+until the operator accepts that operational profile.
+
+Do not include `*-ollama-native` gpt-oss routes in the worker allowlist for now. They
+handled basic text but failed structured tool calls and Responses-shape validation.
+
+## Smoke-test gate
+
+The model allowlist should be an output of a repeatable probe, not a hand-maintained
+guess. The probe contract for a local worker model should include at least:
+
+- Anthropic Messages text: final text exactly `OK`.
+- Anthropic Messages tool call: a `tool_use` block named `lookup_demo_fact` with input
+  exactly `{"topic": "litellm-probe"}`.
+- Optional parity probes for OpenAI Chat and OpenAI Responses, kept for diagnostics even
+  if the worker harness uses Anthropic shape.
+
+Use the existing `//cluster/k8s/litellm/app:probe_models` target for this. Its
+`results.jsonl` records are keyed by `POST + URL + canonical JSON request body`, so
+reruns can preserve successful checks and rerun only failed or missing exchanges.
+
+Before adding or keeping a model in the local model lane, attach the probe report path in
+the PR description and update this plan if the expected model set changes.
+
+## Dispatch scheduling
+
+The local zone needs a model-residency scheduler in front of Kubernetes Job creation.
+Kubernetes cannot express "at most one distinct model label is active" by itself.
+
+Add optional model-lane scheduling config, for example:
+
+```yaml
+model_lanes:
+  local-20b:
+    provider: local-ollama
+    trust_tier: local
+    scheduling:
+      max_active_model_groups: 1
+      max_concurrent_jobs_per_model_group: 1
+    models:
+      gpt-oss-20b-128k-openai-chat:
+        model_group: gpt-oss-20b
+```
+
+Semantics:
+
+- If a model lane has no `max_active_model_groups`/`model_group` config, there is no
+  active-model-group scheduling limit; the dispatcher only enforces the model allowlist
+  and per-job key budget/TTL.
+- If no local jobs are active, the dispatcher may start the next queued local job and
+  that job's `model_group` becomes the active local model group.
+- If local jobs are active and the next job uses the same `model_group`, the dispatcher
+  may start it only if
+  `active_jobs_for_model_group < max_concurrent_jobs_per_model_group`.
+- If local jobs are active for a different `model_group`, the dispatcher must keep the
+  job queued until the active group drains.
+- Failed, succeeded, killed, and timed-out jobs release their active slot.
+
+Start with `max_concurrent_jobs_per_model_group: 1`. Raising it later is a local capacity
+decision, not an isolation-profile change.
+
+For remote-provider model lanes, the same optional schema can express different grouping
+without preventing multiple model strings. Examples:
+
+```yaml
+model_lanes:
+  zai:
+    scheduling:
+      max_active_model_groups: 2
+    models:
+      glm-4.5-air-anthropic:
+        model_group: zai-low-cost
+      glm-5.2-anthropic:
+        model_group: zai-high-capability
+
+  anthropic:
+    scheduling:
+      max_active_model_groups: 1
+    models:
+      claude-haiku-4-5:
+        model_group: haku-cloud-workspace
+      claude-sonnet-5:
+        model_group: haku-cloud-workspace
+```
+
+The grouping key is an operator-owned scheduling fact, not necessarily the literal model
+name. Local groups represent loaded model residency; hosted-provider groups can represent
+shared account quota, cost lane, rate-limit bucket, or a desired "do not mix while a
+batch is running" policy. Omit it where parallelism does not matter.
+
+## Dispatcher changes
+
+The current dispatcher stamps Jobs during `POST /jobs`. For local scheduling, split
+admission from execution:
+
+1. Accept and persist the job after auth, credential lint, classifier admission, dispatch
+   target validation, model allowlist check, model-group resolution, and per-job budget
+   validation.
+2. Mark jobs that cannot run immediately as `queued` rather than creating a Kubernetes
+   Job.
+3. Add a dispatcher-owned scheduler loop or reconciliation endpoint that claims runnable
+   jobs and stamps their Kubernetes Job + Secret.
+4. Keep idempotency semantics: retrying the same idempotency key returns the existing DB
+   row, whether queued or running.
+5. Keep per-job LiteLLM keys minted close to execution time, not indefinitely at queue
+   time, so TTL and budget windows reflect actual runtime.
+
+The active-model-group calculation should come from dispatcher DB state, not from pod
+inspection. Pod state is useful for repair, but the dispatcher owns the scheduling
+contract.
+
+## Perimeter and key chain
+
+Reuse the existing three-hop key chain:
+
+- Main LiteLLM serves the local model names.
+- A static `haku-lane-local` LiteLLM virtual key on the main LiteLLM is allowlisted only
+  to the local model lane's models and reflected into `haku-dispatch`.
+- workers-LiteLLM exposes `litellm_proxy/<local-model>` entries using that static
+  upstream key.
+- The dispatcher mints per-job virtual keys on workers-LiteLLM, scoped to the requested
+  local model, budget, and TTL.
+- Worker pods receive only the per-job key and result token.
+
+Add or update:
+
+- `tf/gitops/litellm-keys/main.tf`: `local_lane_models`,
+  `litellm_key.haku_lane_local`, reflected `litellm-key-haku-lane-local`.
+- `cluster/k8s/haku/dispatch/litellm/generate_workers_litellm.py`: local model entries
+  chained through `litellm_proxy/`.
+- `cluster/k8s/haku/dispatch/dispatcher/zones.yaml`: migrate to model lanes,
+  isolation profiles, and dispatch targets; add a local target.
+- `haku/dispatch/test_zones_config.py`: expected target set, model-lane parity, and
+  provider/capability compatibility invariants.
+
+## Namespace perimeter
+
+Create `haku-sandbox-local` as a peer to `haku-sandbox-zai`:
+
+- No haku-state mount or source credential.
+- Dispatcher can create only same-named Jobs and per-job Secrets in the namespace.
+- workers-LiteLLM CNP admits local-zone pods.
+- Local-zone pod egress should be no broader than needed for the worker harness. If local
+  jobs need public git clone access, allow that intentionally; do not inherit broad
+  `haku-sandbox` egress by accident.
+- Keep the same result submission path: worker posts output to the dispatcher with the
+  job-scoped result token.
+
+The local model provider is in-cluster, but the worker still must be treated as
+untrusted. A compromised worker should get at most its namespace, its per-job key, and
+its result token.
+
+## Classifier policy
+
+Add a classifier policy selected by dispatch target/model lane, not only by namespace.
+The `local` policy is separate from `zai`.
+
+Suggested initial stance:
+
+- Allow private/local work that would be inappropriate for z.ai, because the model stays
+  in the cluster.
+- Still reject credentials, API keys, PEM/JWT material, and instructions that ask the
+  worker to exfiltrate or persist secrets.
+- Still reject prompts that would require haku-state access unless the task explicitly
+  provides a bounded public repo or artifact to fetch.
+- Prefer narrow, task-shaped prompts. Local does not mean "full Haku privileges."
+- Reject any request whose target/profile pairing is not configured, before the
+  classifier runs.
+
+The deterministic credential lint remains provider-independent and still runs before the
+classifier.
+
+## Open decisions
+
+- Whether the local worker harness should use Claude Code CLI over Anthropic shape or a
+  smaller custom harness. Anthropic shape is already smoke-tested and preserves tool-use
+  structure on the recommended local routes.
+- Whether to migrate the public API from `zone` to `target` immediately, or accept
+  `zone` as a compatibility alias for a dispatch target during the transition.
+- Whether 120B belongs in the initial zone or remains an operator-triggered model only.
+- Whether to expose readable reasoning/thinking in worker result artifacts, redact it,
+  or keep it only in Langfuse. Local gpt-oss and Gemma routes have emitted readable
+  reasoning fields in probe responses.
+- Whether the scheduler should have a manual "pin active model" override for long
+  batches.
+
+## Build order
+
+1. Land the model-lane/isolation-profile/dispatch-target schema and tests with no new
+   live target.
+2. Add the local model list to the main LiteLLM key Terraform and workers-LiteLLM
+   generator, parity-tested.
+3. Add the `local-default` isolation profile namespace perimeter and workers-LiteLLM CNP
+   admission.
+4. Add a `local-default` dispatch target with only `gpt-oss-20b-128k-openai-chat`.
+5. Run live smoke through workers-LiteLLM using a per-job-style key.
+6. Dispatch one low-risk local job, verify result submission, budget accounting, and
+   active-model release.
+7. Only then expand the allowlist.

--- a/haku/plans/local_dispatch_zone.md
+++ b/haku/plans/local_dispatch_zone.md
@@ -150,7 +150,7 @@ guess. The probe contract for a local worker model should include at least:
 - Optional parity probes for OpenAI Chat and OpenAI Responses, kept for diagnostics even
   if the worker harness uses Anthropic shape.
 
-Use the existing `//cluster/k8s/litellm/app:probe_models` target for this. Its
+Use the existing `//debug/litellm_probe:probe_models` target for this. Its
 `results.jsonl` records are keyed by `POST + URL + canonical JSON request body`, so
 reruns can preserve successful checks and rerun only failed or missing exchanges.
 

--- a/haku/plans/multi_agent.md
+++ b/haku/plans/multi_agent.md
@@ -42,8 +42,12 @@ credential lint → Anthropic classifier → per-job key mint → k8s Job in `ha
 6. **Sensors + affordances** — changedetection.io + webhook→intake; Forgejo ducktape
    mirror automation + `haku` PR rights; base doctrine amendments. Details below.
 
-Deferred: local-GPU zone; `agent-sandbox`/gVisor isolation; grocery-order bounded-write
-MCP; PII check as a required CI status on PRs.
+Deferred: `agent-sandbox`/gVisor isolation; grocery-order bounded-write MCP; PII check
+as a required CI status on PRs.
+
+New local-inference follow-up: <local_dispatch_zone.md>. It adapts the existing zone
+perimeter to Ollama-hosted models and adds an active-model scheduler so local workers do
+not thrash model residency by running agents across multiple models at once.
 
 ## The oai zone (step 5)
 

--- a/haku/plans/multi_agent.md
+++ b/haku/plans/multi_agent.md
@@ -42,8 +42,7 @@ credential lint → Anthropic classifier → per-job key mint → k8s Job in `ha
 6. **Sensors + affordances** — changedetection.io + webhook→intake; Forgejo ducktape
    mirror automation + `haku` PR rights; base doctrine amendments. Details below.
 
-Deferred: `agent-sandbox`/gVisor isolation; grocery-order bounded-write MCP; PII check
-as a required CI status on PRs.
+Deferred: grocery-order bounded-write MCP; PII check as a required CI status on PRs.
 
 New local-inference follow-up: <local_dispatch_zone.md>. It adapts the existing zone
 perimeter to Ollama-hosted models and adds an active-model scheduler so local workers do


### PR DESCRIPTION
## Summary
- add `//debug/litellm_probe:probe_models` for probing LiteLLM models across OpenAI Chat, non-streaming OpenAI Responses, streaming OpenAI Responses, and Anthropic Messages shapes
- save request/response artifacts, resumable `results.jsonl` records, and a Jinja2 HTML report with pretty-printed JSON details
- document the Haku local dispatch target plan with model lanes, isolation profiles, dispatch targets, and optional model-group scheduling

## Notes
- ChatGPT provider probes are intentionally skipped by default for now
- default parity probes include z.ai `glm-4.5-air-anthropic` and `gemini-2.5-flash`
- local worker allowlist guidance prefers non-ollama-native Ollama routes after live smoke probes
- gVisor / `agent-sandbox` is no longer listed as planned work

## Validation
- `bazelisk build --shell_executable=/nix/store/3hgg7pr65imdrifqqh3flg3arvkc2r22-bash-5.3p3/bin/bash --action_env=PATH="$PATH" --host_action_env=PATH="$PATH" //debug/litellm_probe:probe_models`
- `bazelisk run --shell_executable=/nix/store/3hgg7pr65imdrifqqh3flg3arvkc2r22-bash-5.3p3/bin/bash --action_env=PATH="$PATH" --host_action_env=PATH="$PATH" //debug/litellm_probe:probe_models -- --report-only --response-dir /tmp/litellm-probe-report-smoke`
- live probe artifacts: `/tmp/litellm-probe-full-resumable-20260707T025233Z`
- live resume artifacts: `/tmp/litellm-probe-full-resume2-20260707T032910Z`
- gemini parity artifacts: `/tmp/litellm-probe-gemini-20260707T035152Z`
- combined no-ChatGPT report: `/tmp/litellm-probe-combined-no-chatgpt/report.html`