### PR TITLE
[codex] Autostart ActivityWatch applet on synced desktops

### DIFF
--- a/cluster/docs/activitywatch.md
+++ b/cluster/docs/activitywatch.md
@@ -73,6 +73,7 @@ Current synced desktops are `rugged`, `wyrm2`, `iguana`, and `atlas`.
 
 - Local capture is managed by the graphical ActivityWatch applet (`aw-qt`), which starts
   `aw-server`, `aw-watcher-afk`, and `aw-watcher-window`.
+- Synced desktops get an XDG autostart entry for `aw-qt` from Home Manager.
 - `aw-qt` does not manage this Syncthing/`aw-sync` transport; Home Manager owns sync.
 - `nix/home/services/activitywatch.nix` configures local clients to use
   `127.0.0.1:5600` when `ducktape.activitywatch.sync.enable = true`.

--- a/nix/home/services/activitywatch.nix
+++ b/nix/home/services/activitywatch.nix
@@ -128,6 +128,22 @@ in
           ];
         };
 
+        xdg.autostart = {
+          enable = true;
+          entries = [
+            (pkgs.writeText "activitywatch.desktop" ''
+              [Desktop Entry]
+              Type=Application
+              Name=ActivityWatch
+              Exec=${pkgs.activitywatch}/bin/aw-qt
+              Icon=activitywatch
+              Terminal=false
+              Categories=Utility;
+              X-GNOME-Autostart-enabled=true
+            '')
+          ];
+        };
+
         home.activation.activitywatchSyncDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           mkdir -p '${syncRoot}'
         '';


### PR DESCRIPTION
## Summary
- add an XDG autostart entry for ActivityWatch aw-qt when ActivityWatch sync is enabled
- document that Home Manager now autostarts aw-qt on synced desktops

## Compatibility / validation
- pre-commit run --files nix/home/services/activitywatch.nix cluster/docs/activitywatch.md
- nix eval --impure --json .#nixosConfigurations.rugged.config.home-manager.users.agentydragon.xdg.autostart.entries
- nix eval --impure --json .#nixosConfigurations.wyrm2.config.home-manager.users.agentydragon.xdg.autostart.entries
- nix eval --impure --json .#nixosConfigurations.iguana.config.home-manager.users.agentydragon.xdg.autostart.entries
- nix eval --impure --json .#homeConfigurations.atlas.config.xdg.autostart.entries

## Live rollout evidence
- rugged activitywatch-sync-push.service succeeded after aw-qt came up
- cluster Syncthing inbox contains rugged test.db under device ID 15c10090-44ad-4ed6-963f-9b66e35d2055
- cluster read-only ActivityWatch API returns rugged synced buckets