### PR TITLE
Expose ActivityWatch through Authentik

### DIFF
--- a/cluster/docs/activitywatch.md
+++ b/cluster/docs/activitywatch.md
@@ -4,15 +4,18 @@ Personal activity tracking via [aw-server-rust](https://github.com/ActivityWatch
 The cluster is the query surface; individual devices keep local ActivityWatch capture and push
 `aw-sync` databases through Syncthing.
 
-No built-in ActivityWatch auth is enabled. Read/query access is constrained by Kubernetes
-NetworkPolicy and the read-only proxy; there is no public or Nebula route.
+No built-in ActivityWatch auth is enabled. Read/query access goes through the
+read-only proxy and, for public access, Authentik.
 
 ## Current Design
 
 - **Query server**: `aw-server-rust` in `cluster/k8s/activitywatch`, device id
   `activitywatch-cluster`, SQLite on `activitywatch-data` (`local-path-proxmox`, 10Gi).
 - **Read-only API**: nginx sidecar on Service `activitywatch-readonly`, allowing GET plus
-  POST `/api/0/query` for sandbox consumers.
+  POST `/api/0/query` for query consumers.
+- **Public query route**: `https://activitywatch.allegedly.works` routes through the
+  shared Authentik embedded proxy outpost to `activitywatch-readonly`. Human access is
+  gated by Authentik group `activitywatch-users` (currently `agentydragon`).
 - **Write API**: internal Service `activitywatch-write`, admitted only from the
   Syncthing/importer pod by CiliumNetworkPolicy.
 - **Sync receiver**: `activitywatch-syncthing` Deployment on OVH, receiving into
@@ -38,6 +41,29 @@ NetworkPolicy and the read-only proxy; there is no public or Nebula route.
   Syncthing expects.
 - **No mesh sidecar**: ActivityWatch is not joined to Nebula. Devices send data through
   Syncthing, and query access should use an explicit in-cluster or authenticated route.
+
+## Query Auth
+
+Humans browse to `https://activitywatch.allegedly.works` and authenticate through
+Authentik. The Authentik proxy provider is named `activitywatch`; it forwards only to the
+read-only nginx sidecar, not to the write-capable ActivityWatch service.
+
+Agents use separate Authentik service accounts and reflected client credentials:
+
+| Agent          | Authentik user                 | Reflected Secret                                  | Namespace        |
+| -------------- | ------------------------------ | ------------------------------------------------- | ---------------- |
+| Haku           | `activitywatch-haku`           | `activitywatch-haku-client-credentials`           | `haku-sandbox`   |
+| Claude sandbox | `activitywatch-claude-sandbox` | `activitywatch-claude-sandbox-client-credentials` | `claude-sandbox` |
+
+Each Secret contains:
+
+- `client_id`, `username`, `password`, `source_scopes`: mint a source JWT at `token_url`.
+- `proxy_client_id`, `proxy_scopes`: exchange that source JWT for an Authentik proxy
+  bearer token scoped to the ActivityWatch proxy provider.
+- `activitywatch_url`: the endpoint to query with `Authorization: Bearer <proxy-token>`.
+
+The read-only service is NetworkPolicy-admitted from the Authentik server pods only; agent
+pods should not reach it directly.
 
 ## Storage Debt
 
@@ -66,6 +92,10 @@ TODO:
 - Do not add additional ActivityWatch devices in a way that makes the local-path query DB
   the only durable copy of their data; each device should keep its own Syncthing-exported
   source folder.
+- Revisit agent credentials: current agent access reflects persistent Authentik
+  client-credential material into agent namespaces. A rotator-issued proxy JWT, or another
+  auto-rotated short-lived token handoff, would be more hygienic if agents do not need to
+  perform the OAuth exchange themselves.
 
 ## Desktop Setup
 

--- a/cluster/docs/bootstrap_dependencies.md
+++ b/cluster/docs/bootstrap_dependencies.md
@@ -234,6 +234,20 @@ and writes state to the `forgejo_agentydragon` schema.
 reconciliation. The token and webhook URL use `ignore_changes` and are stable across
 re-applies — only resource recreation changes them.
 
+### ActivityWatch Authentik Access
+
+The `agent-machine-access` tofu-controller module creates the Authentik
+`activitywatch` proxy provider/application, the `activitywatch-users` group, and
+the `activitywatch-agent-client-credentials` OAuth2 provider. It also creates
+per-agent Authentik service accounts (`activitywatch-haku`,
+`activitywatch-claude-sandbox`) and writes reflected Kubernetes Secrets in the
+`authentik` namespace for `haku-sandbox` and `claude-sandbox`.
+
+These credentials are generated from Authentik state, not SOPS files. If the
+tofu state is lost but Authentik still has the resources, import or recreate
+them consistently with the `agent_machine_access` schema before expecting agent
+ActivityWatch queries to work.
+
 ## L7: NixOS Worker Integration
 
 wyrm2 and rugged join the cluster via kubelet TLS bootstrap over Nebula mesh.

--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -555,7 +555,9 @@ hil-ovh`) and apply the same `nodePathMap` entry to any matching node.
 - [ ] Harbor proxy cache: add GHCR credentials for private repos (403 on `openclaw/openclaw`)
 - [ ] Verify ntfy.sh notifications
 - [ ] ActivityWatch: Gatus health check (`activitywatch-readonly:5600/api/0/info`)
-- [ ] ActivityWatch: public access via Authentik proxy outpost
+- [ ] ActivityWatch: replace reflected persistent agent OAuth credentials with
+      short-lived auto-rotated proxy JWTs, if agents do not need to perform the
+      Authentik exchange themselves.
 
 ## Production Cutover (`agentydragon.com`)
 

--- a/cluster/k8s/activitywatch/cilium-network-policy.yaml
+++ b/cluster/k8s/activitywatch/cilium-network-policy.yaml
@@ -1,5 +1,5 @@
 # ActivityWatch query server and Syncthing importer.
-# Ingress: kube-apiserver (health probes), sandbox namespaces (readonly proxy).
+# Ingress: kube-apiserver (health probes), Authentik proxy (readonly proxy).
 # Egress: DNS only.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -17,12 +17,12 @@ spec:
         - ports:
             - port: "5600"
               protocol: TCP
-    # Read-only proxy for sandbox namespaces (nginx on 5601).
+    # Read-only proxy through Authentik embedded outpost (nginx on 5601).
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: openclaw-sandbox
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: claude-sandbox
+            k8s:io.kubernetes.pod.namespace: authentik
+            app.kubernetes.io/name: authentik
+            app.kubernetes.io/component: server
       toPorts:
         - ports:
             - port: "5601"

--- a/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
+++ b/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
@@ -21,6 +21,7 @@ entries:
       config:
         authentik_host: "https://auth.allegedly.works"
       providers:
+        - !Find [authentik_providers_proxy.proxyprovider, [name, activitywatch]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, alloy-otlp]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, grocy-sf]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, grocy-vallejo]]

--- a/cluster/k8s/authentik/proxy-routes/activitywatch-httproute.yaml
+++ b/cluster/k8s/authentik/proxy-routes/activitywatch-httproute.yaml
@@ -1,0 +1,17 @@
+# HTTPRoute for ActivityWatch via the shared Authentik proxy outpost.
+# Traffic flows: Gateway -> outpost (browser or bearer auth) -> ActivityWatch read-only proxy.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: activitywatch
+  namespace: authentik
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "activitywatch.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          port: 80

--- a/cluster/k8s/authentik/proxy-routes/kustomization.yaml
+++ b/cluster/k8s/authentik/proxy-routes/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - activitywatch-httproute.yaml
   - hubble-httproute.yaml
   - openclaw-httproute.yaml
   - alloy-otlp-httproute.yaml

--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -636,6 +636,155 @@ data "authentik_user" "auragon" {
   username = "auragon"
 }
 
+# ============================================================================
+# ActivityWatch query access
+# ============================================================================
+
+locals {
+  activitywatch_agent_clients = {
+    haku = {
+      username         = "activitywatch-haku"
+      name             = "ActivityWatch haku query service account"
+      email            = "activitywatch-haku@allegedly.works"
+      target_namespace = "haku-sandbox"
+      secret_name      = "activitywatch-haku-client-credentials"
+      order            = 10
+    }
+    claude_sandbox = {
+      username         = "activitywatch-claude-sandbox"
+      name             = "ActivityWatch claude-sandbox query service account"
+      email            = "activitywatch-claude-sandbox@allegedly.works"
+      target_namespace = "claude-sandbox"
+      secret_name      = "activitywatch-claude-sandbox-client-credentials"
+      order            = 20
+    }
+  }
+}
+
+resource "authentik_group" "activitywatch_users" {
+  name  = "activitywatch-users"
+  users = [data.authentik_user.agentydragon.pk]
+}
+
+resource "authentik_provider_oauth2" "activitywatch_agent_credentials" {
+  name        = "activitywatch-agent-client-credentials"
+  client_id   = "activitywatch-agent-client-credentials"
+  client_type = "confidential"
+
+  authorization_flow = data.authentik_flow.implicit_consent.id
+  invalidation_flow  = data.authentik_flow.invalidation.id
+  signing_key        = data.authentik_certificate_key_pair.self_signed.id
+
+  issuer_mode                = "per_provider"
+  include_claims_in_id_token = true
+  access_token_validity      = "hours=1"
+
+  property_mappings = [
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.email.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+  ]
+}
+
+resource "authentik_application" "activitywatch_agent_credentials" {
+  name              = "ActivityWatch agent client credentials"
+  slug              = "activitywatch-agent-client-credentials"
+  protocol_provider = authentik_provider_oauth2.activitywatch_agent_credentials.id
+  meta_description  = "Machine client_credentials provider for ActivityWatch query access"
+}
+
+resource "authentik_provider_proxy" "activitywatch" {
+  name                  = "activitywatch"
+  external_host         = "https://activitywatch.allegedly.works"
+  internal_host         = "http://activitywatch-readonly.activitywatch.svc.cluster.local:5600"
+  mode                  = "proxy"
+  authentication_flow   = data.authentik_flow.authentication.id
+  authorization_flow    = data.authentik_flow.implicit_consent.id
+  invalidation_flow     = data.authentik_flow.invalidation.id
+  access_token_validity = "hours=1"
+
+  jwt_federation_providers = [authentik_provider_oauth2.activitywatch_agent_credentials.id]
+}
+
+resource "authentik_application" "activitywatch" {
+  name              = "ActivityWatch"
+  slug              = "activitywatch"
+  protocol_provider = authentik_provider_proxy.activitywatch.id
+  meta_description  = "Personal ActivityWatch query surface"
+  meta_launch_url   = "https://activitywatch.allegedly.works"
+  open_in_new_tab   = true
+}
+
+resource "authentik_policy_binding" "activitywatch_users" {
+  target = authentik_application.activitywatch.uuid
+  group  = authentik_group.activitywatch_users.id
+  order  = 0
+}
+
+resource "authentik_user" "activitywatch_agent" {
+  for_each = local.activitywatch_agent_clients
+
+  username = each.value.username
+  name     = each.value.name
+  email    = each.value.email
+  type     = "service_account"
+  path     = "goauthentik.io/service-accounts"
+}
+
+resource "authentik_token" "activitywatch_agent" {
+  for_each = local.activitywatch_agent_clients
+
+  identifier   = "${each.value.username}-client-credentials"
+  user         = authentik_user.activitywatch_agent[each.key].id
+  intent       = "app_password"
+  expiring     = false
+  retrieve_key = true
+  description  = "client_credentials app-password for ${each.value.name}"
+}
+
+resource "authentik_policy_binding" "activitywatch_agent_credentials" {
+  for_each = local.activitywatch_agent_clients
+
+  target = authentik_application.activitywatch_agent_credentials.uuid
+  user   = authentik_user.activitywatch_agent[each.key].id
+  order  = each.value.order
+}
+
+resource "authentik_policy_binding" "activitywatch_agent_proxy" {
+  for_each = local.activitywatch_agent_clients
+
+  target = authentik_application.activitywatch.uuid
+  user   = authentik_user.activitywatch_agent[each.key].id
+  order  = each.value.order
+}
+
+resource "kubernetes_secret" "activitywatch_agent_client_credentials" {
+  for_each = local.activitywatch_agent_clients
+
+  metadata {
+    name      = each.value.secret_name
+    namespace = "authentik"
+    annotations = {
+      "description"                                                   = "ActivityWatch query OAuth credentials for ${each.value.name}. Reflected into ${each.value.target_namespace}; caller mints a source JWT, exchanges it for an Authentik proxy token, then queries https://activitywatch.allegedly.works."
+      "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = each.value.target_namespace
+      "reflector.v1.k8s.emberstack.com/reflection-auto-enabled"       = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"    = each.value.target_namespace
+    }
+  }
+
+  data = {
+    activitywatch_url = "https://activitywatch.allegedly.works"
+    token_url         = "https://auth.allegedly.works/application/o/token/"
+    client_id         = authentik_provider_oauth2.activitywatch_agent_credentials.client_id
+    username          = authentik_user.activitywatch_agent[each.key].username
+    password          = authentik_token.activitywatch_agent[each.key].key
+    source_scopes     = "openid profile email"
+    proxy_client_id   = authentik_provider_proxy.activitywatch.client_id
+    proxy_scopes      = "openid profile email ak_proxy"
+  }
+}
+
 resource "authentik_group" "kubectl_sandbox_users" {
   name  = "kubectl-sandbox-users"
   users = [data.authentik_user.agentydragon.pk]


### PR DESCRIPTION
## Summary

- add an Authentik proxy application for `https://activitywatch.allegedly.works` backed by the read-only ActivityWatch proxy
- add `activitywatch-users` for human access and separate ActivityWatch service accounts for `haku` and `claude-sandbox`
- reflect per-agent client credentials into the corresponding namespaces, while leaving a TODO to revisit short-lived auto-rotated proxy JWT handoff
- route public traffic through the Authentik embedded outpost and tighten ActivityWatch NetworkPolicy so agents cannot bypass Authentik directly

## Validation

- `direnv exec . pre-commit run --files tf/gitops/agent-machine-access/main.tf cluster/k8s/activitywatch/cilium-network-policy.yaml cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml cluster/k8s/authentik/proxy-routes/kustomization.yaml cluster/k8s/authentik/proxy-routes/activitywatch-httproute.yaml cluster/docs/activitywatch.md cluster/docs/plan.md cluster/docs/bootstrap_dependencies.md`
- `bbr test //tf/gitops/agent-machine-access:format //tf/gitops/agent-machine-access:lint //tf/gitops/agent-machine-access:validate`
- `direnv exec . kustomize build cluster/k8s/activitywatch`
- `direnv exec . kustomize build cluster/k8s/authentik/proxy-routes`
- `direnv exec . kustomize build cluster/k8s/authentik/app`
- `bbr test //cluster/validation:test_k8s //cluster/validation:test_flux_build //cluster/validation:test_crd_layering //cluster/validation:test_terraform_backends`