### PR TITLE
nix: package Claude desktop app (Linux) on rugged/iguana/wyrm2

### DIFF
--- a/nix/home/hosts/iguana.nix
+++ b/nix/home/hosts/iguana.nix
@@ -5,6 +5,7 @@
   config,
   pkgs,
   lib,
+  ducktapePackages,
   ...
 }:
 {
@@ -31,6 +32,8 @@
   programs.gnome-shell.extensions = [
     { package = pkgs.gnomeExtensions.appindicator; }
   ];
+
+  home.packages = [ ducktapePackages.claude-desktop ];
 
   home.stateVersion = "24.11";
 }

--- a/nix/home/hosts/rugged.nix
+++ b/nix/home/hosts/rugged.nix
@@ -130,6 +130,7 @@ in
   home.packages = [
     ducktapePackages.aiquota
     ducktapePackages.bebas-neue-font
+    ducktapePackages.claude-desktop
     pkgs.inkscape
     pkgs.kicad
     pkgs.openscad

--- a/nix/home/hosts/wyrm2.nix
+++ b/nix/home/hosts/wyrm2.nix
@@ -156,6 +156,7 @@
     # Options: gnomeExtensions.syncthing-indicator, gnomeExtensions.syncthing-toggle, qsyncthingtray
     ducktapePackages.aiquota
     ducktapePackages.bebas-neue-font
+    ducktapePackages.claude-desktop
     pkgs.inkscape
     pkgs.kicad
     pkgs.openscad

--- a/nix/packages/claude-desktop.nix
+++ b/nix/packages/claude-desktop.nix
@@ -1,0 +1,122 @@
+# Claude Desktop (GUI app) — Anthropic's Electron desktop client for Linux.
+# Installed from the official .deb in Anthropic's apt repo (NOT Claude Code the
+# CLI — that's a separate `programs.claude-code` module). The app ships its own
+# Chromium/Electron runtime; we only supply the system shared libs it links
+# against and patch the ELF RPATHs via autoPatchelfHook.
+#
+# To update (the apt repo is the source of truth, not a GitHub release):
+#   curl -sSL https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages \
+#     | awk 'BEGIN{RS=""} /Version:/{print}' | tail -1
+#   # then bump `version`, re-fetch the .deb, and recompute the SRI hash:
+#   nix hash to-sri --type sha256 "$(curl -sSL <deb-url> | sha256sum | cut -d' ' -f1)"
+# Install docs: https://code.claude.com/docs/en/desktop-linux
+{
+  lib,
+  pkgs,
+}:
+let
+  version = "1.18286.0";
+in
+pkgs.stdenv.mkDerivation {
+  pname = "claude-desktop";
+  inherit version;
+
+  src = pkgs.fetchurl {
+    url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_${version}_amd64.deb";
+    hash = "sha256-jzFK0agKq1JxGo6qvAaq5I+zQfCt6koNcmTbXKudBTY=";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  # Maps the .deb's Depends (libgtk-3-0, libnss3, libatspi2.0-0, libdrm2,
+  # libgbm1, libsecret-1-0, libxtst6, ...). autoPatchelf patches DT_NEEDED;
+  # the GL/X libs are also dlopen'd by Electron, so makeWrapper exposes them on
+  # LD_LIBRARY_PATH too (see tana-outliner.nix for the same shape).
+  buildInputs = with pkgs; [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    cairo
+    cups
+    dbus
+    expat
+    glib
+    gtk3
+    libdrm
+    libGL
+    libnotify
+    libsecret
+    libxkbcommon
+    mesa
+    # virtiofsd (bundled for the Cowork microVM feature) needs these.
+    libseccomp
+    libcap_ng
+    nspr
+    nss
+    pango
+    util-linux # libuuid
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXrandr
+    xorg.libXtst
+    xorg.libxcb
+  ];
+
+  runtimeDependencies = [ (lib.getLib pkgs.systemd) ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Extract .deb via bsdtar (tolerates the SUID chrome-sandbox without error).
+    ${pkgs.libarchive}/bin/bsdtar -xf $src --no-same-permissions
+    ${pkgs.libarchive}/bin/bsdtar -xf data.tar.* --no-same-permissions
+
+    mkdir -p $out/lib
+    cp -r usr/share $out/share
+    cp -r usr/lib/claude-desktop $out/lib/claude-desktop
+
+    # Wrap the real binary so dlopen'd GL/X libs resolve.
+    mkdir -p $out/bin
+    makeWrapper $out/lib/claude-desktop/claude-desktop $out/bin/claude-desktop \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath (
+          with pkgs;
+          [
+            libGL
+            libdrm
+            libxkbcommon
+            mesa
+            xorg.libX11
+            xorg.libXtst
+            xorg.libxcb
+          ]
+        )
+      }"
+
+    # Point the desktop entry's Exec lines at our wrapper. Match the three
+    # `Exec=claude-desktop <arg>` lines (main + NewChat/NewCode actions) without
+    # touching StartupWMClass/Icon, which also contain the literal name.
+    substituteInPlace $out/share/applications/claude-desktop.desktop \
+      --replace-fail "Exec=claude-desktop " "Exec=$out/bin/claude-desktop "
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Claude Desktop — Anthropic's Electron desktop app (Linux beta)";
+    homepage = "https://code.claude.com/docs/en/desktop-linux";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "claude-desktop";
+  };
+}

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -326,6 +326,9 @@ rec {
   # Anthropic CLI (`ant`): Claude API / Managed Agents control plane. Not in
   # nixpkgs; vendored static release binary. Used by haku/runtime/managed_agent/self_hosted.
   anthropic-cli = pkgs.callPackage ./anthropic-cli.nix { };
+  # Claude Desktop (GUI app): Anthropic's Electron desktop client, from the
+  # official apt repo .deb. Distinct from Claude Code (the CLI).
+  claude-desktop = pkgs.callPackage ./claude-desktop.nix { };
   # fastmcp's client CLI (`fastmcp call|list <url> --auth <bearer>`) exposed as a
   # standalone app for agent closures (flake.nix `.#agent-haku`). The library
   # is consumed by the `ducktape` wheel above via `python3Packages.fastmcp`; this


### PR DESCRIPTION
Anthropic released the **Claude desktop app** (Electron) for Linux officially, shipped as a `.deb` from their apt repo (`downloads.claude.ai`). It's not in nixpkgs yet, and it's distinct from Claude Code (the CLI).

This vendors it like `tana-outliner.nix` — the repo's existing Electron-from-`.deb` pattern:

- **`nix/packages/claude-desktop.nix`** — `fetchurl` the `.deb` (version pinned, hash from the apt repo `Packages` index) + `autoPatchelfHook`, supplying the system libs the `.deb` `Depends` on (gtk3, nss, at-spi, libdrm, libgbm, libsecret, libXtst, …). `virtiofsd` (bundled for the Cowork microVM feature) pulls in `libseccomp` + `libcap_ng`. The `.desktop` `Exec=` lines are rewritten to the store wrapper; `Icon`/`StartupWMClass` left untouched.
- **`nix/packages/default.nix`** — expose as `ducktapePackages.claude-desktop`.
- **`nix/home/hosts/{rugged,iguana,wyrm2}.nix`** — install on the three workstation hosts that already carry the other GUI apps (telegram, tana, signal, …).

## Verified
- `nix build .#claude-desktop` → succeeds; output checked (wrapper, patched `.desktop`, 5 icon sizes, RPATH patched).
- pre-commit hooks green (nixfmt, statix, enforce-bazel-tests, commit-msg trailer).

## Notes
- Install path mirrors the other desktop apps (`home.packages`), keeping it consistent rather than going system-level.
- `mainProgram = claude-desktop`; signing in uses a claude.ai subscription / SSO (no Console API key, per the [Linux docs](https://code.claude.com/docs/en/desktop-linux)).