### PR TITLE
haku-console: add tana-rw MCP facade behind approval gate

### DIFF
--- a/cluster/k8s/haku/console/config.yaml
+++ b/cluster/k8s/haku/console/config.yaml
@@ -5,3 +5,7 @@ mcp:
       server_url: https://grocy-mcp-sf.allegedly.works/mcp
       operator_oauth:
         client_name: Haku Console
+    - id: tana-rw
+      server_url: https://tana-mcp-facade.allegedly.works/mcp
+      operator_oauth:
+        client_name: Haku Console

--- a/haku/plans/console_mcp_approval_queue.md
+++ b/haku/plans/console_mcp_approval_queue.md
@@ -33,3 +33,24 @@ Status: open follow-ups only. Implemented behavior belongs in:
    Add more connected MCP servers as concrete use cases arrive, such as a kubectl MCP server for
    "restart stuck rollout." Server config should name reachable servers; tool schemas still come
    from live MCP reflection, not duplicated config.
+
+   Pattern (established by `grocy-sf` and `tana-rw`, added 2026-07-06): a server needs an
+   MCP-OAuth authorization-server front — the `mcp-oauth-facade` image
+   (`mcp_infra.authentik_auth`, which speaks DCR + PKCE and delegates user auth to Authentik) —
+   plus an Authentik OAuth2 provider and an access group containing the console operator
+   (`agentydragon`). Then it is a single `mcp.servers` entry in
+   `cluster/k8s/haku/console/config.yaml` with `operator_oauth`. Servers behind a plain Authentik
+   **proxy provider** (forward-auth) or a static bearer do not match the console's DCR client
+   flow and need the facade treatment first. Candidates:
+   - **google-workspace-mcp** — Gmail (send, drafts, labels — beyond the narrow `gmail-labeling`
+     always_allow path, which stays), Google Drive (organize/save files), Google Calendar
+     (add/edit events). One upstream server covers all three. Already deployed at
+     `cluster/k8s/agents/google-workspace-mcp/` (`ghcr.io/taylorwilsdon/google_workspace_mcp`,
+     does its own Google OAuth) and fronted today by an Authentik proxy provider
+     (`cluster/k8s/authentik/app/blueprints/google-workspace-mcp-sso.yaml`, "authentik Admins").
+     Blocker: it does not speak MCP OAuth/DCR — front it with `mcp-oauth-facade` (or confirm an
+     MCP-OAuth mode), then add the console entry.
+   - **habitify** — habit data store (mark habits done via `set_habit_status`, etc.). MCP server
+     code exists at `llm/mcp/habitify/` (FastMCP with write tools) but is not deployed. Needs a
+     container/Bazel image + k8s deployment + an auth front (facade or static bearer), then the
+     console entry.


### PR DESCRIPTION
Adds the read-write Tana facade (`tana-mcp-facade`) to the haku-console MCP approval queue behind `operator_oauth` (DCR + PKCE), mirroring `grocy-sf`. Also records two follow-up server candidates in the plan.

## What

- `cluster/k8s/haku/console/config.yaml`: new `tana-rw` entry → `https://tana-mcp-facade.allegedly.works/mcp` with `operator_oauth`.
- `haku/plans/console_mcp_approval_queue.md`: expand "Additional server onboarding" with the established pattern (facade + Authentik OAuth2 provider + operator access group → one config entry) and two candidates — `google-workspace-mcp` (Gmail/Drive/Calendar; needs facade treatment, currently behind an Authentik proxy provider) and `habitify` (MCP code exists at `llm/mcp/habitify/`, not yet deployed).

## Why

Haku already reaches **read-only** Tana directly via `tana-ro` (`always_allow`, static bearer, in `haku/base/agent_shared.yaml`). This adds the **read-write** path through the console approval gate — the privileged, operator-gated write channel, parallel to how `grocy-sf` sits in the console. `tana-rw` is deliberately *not* added to `agent_shared.yaml` (that would bypass the gate).

## Why it's a one-line config change

`tana-mcp-facade` is already a full MCP-OAuth authorization server (`mcp_infra/authentik_auth` → FastMCP `OIDCProxy`, DCR `/register` accepting `openid email profile offline_access`), already serving claude.ai as a DCR client. Its Authentik provider (`tf/gitops/agent-machine-access/main.tf`) is identical in shape to the working `grocy-mcp-sf` one and is gated to a one-user group containing exactly `agentydragon` — the console operator. So the console becomes a second DCR client. **No Authentik, facade, frontend, or DB-migration change**; the `(server_id, operator)` token store already handles multiple servers.

## Rollout

1. Merge → Flux applies the ConfigMap. `configMapGenerator` hashes content into the volume name, so the console pod restarts cleanly.
2. As `agentydragon`, open the console → connect the `tana-rw` account once (OAuth dance). Until then `/api/capabilities/mcp-servers` shows `tana-rw` as `degraded: "Connect your tana-rw MCP account…"`.
3. Smoke with a harmless read (`read_node`/`search_nodes`) before any real write.

BAZEL_TEST_INVOCATIONS=none: ConfigMap data + markdown plan only; no Bazel target source changed (console tests use inline fixtures, not the prod config).