### PR TITLE
Document ActivityWatch integration as a prioritization signal

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -337,15 +337,16 @@ can do something, grep for your group and read the referenced role.
 **Credentials you have today** (all in `haku-sandbox`; all read-only except the one
 labeled write-capable below):
 
-| Purpose                              | Secret                      | Key fields                                                                |
-| ------------------------------------ | --------------------------- | ------------------------------------------------------------------------- |
-| State repo (write)                   | `haku-state-git-write`      | `username`, `password`, `repo_url`                                        |
-| Forgejo API / `tea` (write)          | `haku-forgejo-tea`          | `config.yml` for `~/.config/tea/config.yml`; raw `token` for debugging    |
-| Console tool-call API (request/read) | `haku-console-agent-api`    | `token` (request/sweep only; does not approve calls)                      |
-| Plaid Postgres (read-only)           | `plaid-mcp-db-readonly`     | `DATABASE_URL` (+ `username`/`password`/…)                                |
-| Google read-only APIs                | `google-access-token`       | `access_token` (Gmail, Calendar, Drive, Tasks, …)                         |
-| Tana (read-only MCP)                 | `haku-tana-ro-token`        | `token` (bearer for the `tana-mcp-ro` facade)                             |
-| Gmail labels (**write**, bounded)    | `haku-gmail-labeling-token` | `token` (bearer for the `gmail-labeling` MCP; confined to `haku/` labels) |
+| Purpose                              | Secret                                  | Key fields                                                                                                                                    |
+| ------------------------------------ | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| State repo (write)                   | `haku-state-git-write`                  | `username`, `password`, `repo_url`                                                                                                            |
+| Forgejo API / `tea` (write)          | `haku-forgejo-tea`                      | `config.yml` for `~/.config/tea/config.yml`; raw `token` for debugging                                                                        |
+| Console tool-call API (request/read) | `haku-console-agent-api`                | `token` (request/sweep only; does not approve calls)                                                                                          |
+| Plaid Postgres (read-only)           | `plaid-mcp-db-readonly`                 | `DATABASE_URL` (+ `username`/`password`/…)                                                                                                    |
+| Google read-only APIs                | `google-access-token`                   | `access_token` (Gmail, Calendar, Drive, Tasks, …)                                                                                             |
+| Tana (read-only MCP)                 | `haku-tana-ro-token`                    | `token` (bearer for the `tana-mcp-ro` facade)                                                                                                 |
+| ActivityWatch (read-only)            | `activitywatch-haku-client-credentials` | `activitywatch_url`, `token_url`, `client_id`, `username`, `password`, `proxy_client_id`, scopes (two-step mint — `sources/activitywatch.md`) |
+| Gmail labels (**write**, bounded)    | `haku-gmail-labeling-token`             | `token` (bearer for the `gmail-labeling` MCP; confined to `haku/` labels)                                                                     |
 
 More sources arrive the same way: a new read-only credential shows up as a
 secret in `haku-sandbox` and a row under `cluster/k8s/haku/`. Model calls go

--- a/haku/base/sources/README.md
+++ b/haku/base/sources/README.md
@@ -35,6 +35,9 @@ grows its own techniques and records them in its state `memory/`.
 - [`grocy`](grocy.md) — the operator's household stock (expiring /
   below-minimum items, shopping suggestions); reached via the grocy-sf MCP
   (`fastmcp`), read-only because the `haku` Grocy user has empty permissions.
+- [`activitywatch`](activitywatch.md) — the operator's device activity: presence
+  (at which computer, right now), focus, and per-day time-use; read-only via an
+  Authentik two-step token mint. The prioritization signal the other sources lack.
 - [`mailbox`](mailbox.md) — **your own mailbox** (`haku@allegedly.works`, a real
   mail account you manage): mail the operator sends directly to you (requests,
   context, forwards). Delivery is DMARC-gated to whitelisted senders at the server;

--- a/haku/base/sources/activitywatch.md
+++ b/haku/base/sources/activitywatch.md
@@ -1,0 +1,39 @@
+# ActivityWatch — operator presence, focus, and time-use
+
+**What it tells Haku:** whether the operator is at a computer right now (and which one),
+what has focus (app/window/browser tab), and how today's time was actually spent. This is
+the prioritization signal the other sources lack: rank against what he's doing _now_,
+notice "3h in X today → that project is hot," and stop nudging things he's clearly on.
+
+**Infrastructure + design:** <../../../cluster/docs/activitywatch.md> (query server,
+Syncthing sync topology, the read-only nginx proxy, the Authentik route, per-agent
+service accounts). The cluster serves a **read-only** surface: GET plus
+`POST /api/0/query/` only — the write API is not reachable from agents, by construction.
+
+## How to read it
+
+Credential: the `activitywatch-haku-client-credentials` secret in `haku-sandbox`
+(fields: `activitywatch_url`, `token_url`, `client_id`, `username`, `password`,
+`source_scopes`, `proxy_client_id`, `proxy_scopes`).
+
+Auth is a two-step Authentik mint (verified 2026-07-07):
+
+1. **Source JWT** — `POST $token_url` with `grant_type=client_credentials`,
+   `client_id=$client_id`, `username=$username`, `password=$password`,
+   `scope=$source_scopes` → `access_token` (1h expiry).
+2. **Proxy bearer** — `POST $token_url` with `grant_type=client_credentials`,
+   `client_id=$proxy_client_id`, `scope=$proxy_scopes`,
+   `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`,
+   `client_assertion=<source JWT>` → the token that `$activitywatch_url` accepts as
+   `Authorization: Bearer`.
+
+Gotchas: `POST /api/0/query` requires the **trailing slash** (`/api/0/query/` — nginx
+301s otherwise and the redirected POST degrades to GET); transient TLS connection resets
+occur (~1/20 calls) — retry once; bucket `last_updated` is always `null` on this server —
+get recency from each bucket's newest event.
+
+Haku's maintained helper (token caching, canned presence/time-use queries, all gotchas
+baked in) lives in its state: `tools/aw.py` + `procedures/operator_status.md`.
+
+**Privacy contract:** window titles and URLs are as sensitive as mail bodies — reference
+(app, domain, duration), never dump raw event lists into anything surfaced or committed.


### PR DESCRIPTION
Adds comprehensive documentation for the ActivityWatch source integration, establishing it as Haku's primary prioritization signal for operator presence, focus, and time-use data.

## Summary

ActivityWatch provides real-time context about what the operator is actively doing—which computer they're at, what has focus, and how time is being spent. This is the missing piece that allows Haku to rank suggestions against actual current activity rather than static priority alone.

## Changes

- **New source documentation** (`haku/base/sources/activitywatch.md`):
  - Explains what ActivityWatch tells Haku and why it matters (prioritization signal)
  - Documents the two-step Authentik token mint flow (source JWT → proxy bearer)
  - Lists critical gotchas: trailing slash requirement on `/api/0/query/`, transient TLS resets, `last_updated` always null
  - References the maintained helper in `tools/aw.py` and `procedures/operator_status.md`
  - Establishes privacy contract: reference only (app, domain, duration), never dump raw events

- **Updated credentials table** (`haku/base/instructions.md`):
  - Adds ActivityWatch row with secret name and key fields
  - Links to the new source documentation for auth flow details
  - Maintains read-only designation

- **Updated sources index** (`haku/base/sources/README.md`):
  - Adds ActivityWatch entry describing it as the prioritization signal
  - Notes the Authentik two-step token mint and read-only access model

## Implementation Details

The integration uses a two-step OAuth2 client credentials flow:
1. Mint a source JWT with user credentials
2. Exchange that JWT for a proxy bearer token via client assertion

The cluster infrastructure (query server, Syncthing sync, read-only nginx proxy, Authentik route) is documented separately in `cluster/docs/activitywatch.md`. Haku's agent-side code handles token caching and common queries.

https://claude.ai/code/session_01CG8ovuxk6GJSgb6DCyL2f8