### PR TITLE
Add Haku approval drawer

### DIFF
--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -76,8 +76,9 @@ Core endpoints:
   datetime `since` filter on `updated_at`.
 
 Backend callers authenticate with the shared `HAKU_CONSOLE_AGENT_API_TOKEN`. Browser-origin
-approvals use the operator's Authentik session plus CSRF. The approval dialog renders in trusted
-console chrome, not inside Haku's iframe. If a server enables `operator_oauth`, approval execution
+approvals use the operator's Authentik session plus CSRF. The approval drawer renders in trusted
+console chrome, not inside Haku's iframe, and does not block the framed Haku UI. If a server enables
+`operator_oauth`, approval execution
 uses the approving operator's linked OAuth token and refuses to move the call out of
 `pending_approval` until that association exists. Static bearer credentials can remain configured
 for reflection or fallback wiring, but they are not silently substituted for operator-approved

--- a/haku/console/docs/containment.md
+++ b/haku/console/docs/containment.md
@@ -74,17 +74,18 @@ Haku could author hostile UI). Safety comes from the perimeter, not from trustin
 
 ## The shell as a thin trusted layer
 
-The iframe covers the page; the shell owns only the moment-of-decision confirm, the frame,
+The iframe covers the page; the shell owns only the moment-of-decision surfaces, the frame,
 the bridge, and the CSP. **A persistent "trust indicator" is not a security control**: a web
 page has no secure-attention channel, and an iframe can render a pixel-perfect decoy badge.
 Security rests on two things instead:
 
 1. **The capability gate makes a faked control inert.** A fake "Launch" button can only emit
    a bridge request, which the shell re-gates with its own CSRF + confirm + bearer.
-2. **The confirm is the only trustworthy surface, and only at the moment of approval.** It
-   renders as a **top-layer `<dialog>.showModal()` with a backdrop**: the iframe cannot draw
-   over it, read it, or intercept its clicks. Anti-clickjacking hygiene: explicit action
-   text, a deliberate click on a freshly-rendered button, no click-through.
+2. **The shell is the only trustworthy approval surface.** Immediate bridge escalations render as
+   a **top-layer `<dialog>.showModal()` with a backdrop**. Queueable approvals render in the
+   shell-owned non-modal drawer. In both cases the iframe cannot draw over the trusted controls,
+   read them, or intercept their clicks. Anti-clickjacking hygiene: explicit action text, a
+   deliberate click on a freshly-rendered button, no click-through.
 
 Fullscreen is withheld from the iframe (no `allow="fullscreen"`) so it can't spoof browser
 chrome.
@@ -121,7 +122,7 @@ haku-ui frontend posts to its own same-origin backend, that backend reads
 `tool_requests/<id>.yaml` from haku-state and calls haku-console's
 `POST /api/tool-calls` with the configured console agent API token. If approval is
 required, haku-console notifies its trusted frontend (`/api/approvals/ws`, with REST catch-up from
-`/api/approvals/pending`) and renders the top-layer approval dialog itself. The iframe can request a
+`/api/approvals/pending`) and renders the non-modal approval drawer itself. The iframe can request a
 tool call, but cannot approve one or forge console chrome.
 
 ### `requestGeolocation` / `startGeolocationWatch` — read the operator's location (standing grant)

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -24,6 +24,15 @@ js_library(
 )
 
 js_library(
+    name = "approval_state",
+    srcs = ["approval_state.ts"],
+    deps = [
+        ":bridge",
+        ":client",
+    ],
+)
+
+js_library(
     name = "theme",
     srcs = ["theme.ts"],
     deps = ["//:node_modules/@mantine/core"],
@@ -70,6 +79,9 @@ js_library(
     name = "console_panel",
     srcs = ["console_panel.tsx"],
     deps = [
+        ":approval_state",
+        ":client",
+        ":theme",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
     ],
@@ -79,6 +91,7 @@ js_library(
     name = "haku_ui_embed",
     srcs = ["haku_ui_embed.tsx"],
     deps = [
+        ":approval_state",
         ":bridge",
         ":client",
         ":confirm_dialog",
@@ -121,6 +134,7 @@ filegroup(
     name = "tailwind_content_srcs",
     srcs = [
         "app.tsx",
+        "approval_state.ts",
         "client.ts",
         "confirm_dialog.tsx",
         "console_panel.tsx",
@@ -192,6 +206,7 @@ tsc_bin.tsc_test(
     ],
     chdir = package_name(),
     data = [
+        "approval_state.test.ts",
         "bridge.test.ts",
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
@@ -208,10 +223,12 @@ vitest_bin.vitest_test(
     args = ["run"],
     chdir = package_name(),
     data = [
+        "approval_state.test.ts",
         "bridge.test.ts",
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
         "vitest.config.ts",
+        ":approval_state",
         ":bridge",
         ":geolocation",
         ":haku_ui_embed",

--- a/haku/console/frontend/approval_state.test.ts
+++ b/haku/console/frontend/approval_state.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  approvalDisplayFields,
+  approvalQueueItems,
+  formatHideCountdown,
+  geolocationApprovalQueueId,
+  makeRecentToolCall,
+  nextSelectedApprovalId,
+  toolApprovalQueueId,
+  type GeolocationApproval,
+} from "./approval_state.ts";
+import type { PendingApproval, ToolCallRecord } from "./client.ts";
+
+function pendingApproval(overrides: Partial<PendingApproval> = {}): PendingApproval {
+  return {
+    tool_call_id: "tc_1",
+    server_id: "grocy-sf",
+    title: "Remove bought items",
+    tool_name: "shopping_list_items_remove",
+    caller_principal: "haku-agent-api-token",
+    rationale: "already in stock",
+    arguments: { ids: [1, 2, 3] },
+    created_at: "2026-07-07T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function geolocationApproval(overrides: Partial<GeolocationApproval> = {}): GeolocationApproval {
+  return {
+    id: "geo_1",
+    mode: "geolocation",
+    createdAt: "2026-07-07T10:01:00Z",
+    ...overrides,
+  };
+}
+
+function toolCallRecord(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
+  return {
+    tool_call_id: "tc_1",
+    server_id: "grocy-sf",
+    tool_name: "shopping_list_items_remove",
+    caller_principal: "operator",
+    status: "ok",
+    created_at: "2026-07-07T10:00:00Z",
+    updated_at: "2026-07-07T10:00:10Z",
+    arguments: { ids: [1, 2, 3] },
+    rationale: "already in stock",
+    title: "Remove bought items",
+    result: { removed: 3 },
+    error: null,
+    ...overrides,
+  };
+}
+
+describe("approval queue state", () => {
+  it("orders mixed tool and geolocation approvals newest first", () => {
+    const items = approvalQueueItems(
+      [pendingApproval({ tool_call_id: "tc_old", created_at: "2026-07-07T10:00:00Z" })],
+      [geolocationApproval({ id: "geo_new", createdAt: "2026-07-07T10:02:00Z" })]
+    );
+
+    expect(items.map((item) => item.id)).toEqual([
+      geolocationApprovalQueueId("geo_new"),
+      toolApprovalQueueId("tc_old"),
+    ]);
+  });
+
+  it("preserves a valid selection and otherwise picks the newest approval", () => {
+    const tool = pendingApproval({ tool_call_id: "tc_old", created_at: "2026-07-07T10:00:00Z" });
+    const geo = geolocationApproval({ id: "geo_new", createdAt: "2026-07-07T10:02:00Z" });
+
+    expect(nextSelectedApprovalId([tool], [geo], toolApprovalQueueId("tc_old"))).toBe(toolApprovalQueueId("tc_old"));
+    expect(nextSelectedApprovalId([tool], [geo], "missing")).toBe(geolocationApprovalQueueId("geo_new"));
+  });
+
+  it("extracts structured display fields without collapsing everything into one JSON blob", () => {
+    const fields = approvalDisplayFields(pendingApproval());
+
+    expect(fields.serverId).toBe("grocy-sf");
+    expect(fields.toolName).toBe("shopping_list_items_remove");
+    expect(fields.argumentSummary).toBe("ids");
+    expect(fields.argumentsJson).toContain('"ids"');
+    expect(fields.toolCallId).toBe("tc_1");
+  });
+
+  it("keeps terminal results only as short-lived recent feedback", () => {
+    const recent = makeRecentToolCall(toolCallRecord(), 1_000);
+
+    expect(recent?.hideAtMs).toBe(16_000);
+    expect(formatHideCountdown(16_000, 6_500)).toBe("hiding in 10s");
+    expect(makeRecentToolCall(toolCallRecord({ status: "pending_approval" }), 1_000)).toBeNull();
+  });
+});

--- a/haku/console/frontend/approval_state.ts
+++ b/haku/console/frontend/approval_state.ts
@@ -1,0 +1,142 @@
+import type { PendingApproval, ToolCallRecord } from "./client.ts";
+import type { GeolocationOptions } from "./bridge.ts";
+
+export interface GeolocationApproval {
+  id: string;
+  mode: "geolocation" | "geolocationWatch";
+  options?: GeolocationOptions;
+  createdAt: string;
+}
+
+export type ApprovalQueueItem =
+  | { kind: "tool"; id: string; createdAt: string; approval: PendingApproval }
+  | { kind: "geolocation"; id: string; createdAt: string; approval: GeolocationApproval };
+
+export interface ApprovalDisplayFields {
+  title: string;
+  serverId: string;
+  toolName: string;
+  rationale: string;
+  argumentsJson: string;
+  argumentSummary: string;
+  toolCallId: string;
+  callerPrincipal: string | null;
+  createdAt: string | null;
+}
+
+export interface RecentToolCall {
+  record: ToolCallRecord;
+  hideAtMs: number;
+}
+
+const RECENT_OK_TTL_MS = 15_000;
+const RECENT_ERROR_TTL_MS = 60_000;
+
+function createdAtMs(value: string | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export function toolApprovalQueueId(toolCallId: string): string {
+  return `tool:${toolCallId}`;
+}
+
+export function geolocationApprovalQueueId(id: string): string {
+  return `geolocation:${id}`;
+}
+
+export function sortApprovalsNewestFirst(approvals: readonly PendingApproval[]): PendingApproval[] {
+  return [...approvals].sort((a, b) => createdAtMs(b.created_at) - createdAtMs(a.created_at));
+}
+
+export function approvalQueueItems(
+  toolApprovals: readonly PendingApproval[],
+  geolocationApprovals: readonly GeolocationApproval[]
+): ApprovalQueueItem[] {
+  return [
+    ...toolApprovals.map(
+      (approval): ApprovalQueueItem => ({
+        kind: "tool",
+        id: toolApprovalQueueId(approval.tool_call_id),
+        createdAt: approval.created_at,
+        approval,
+      })
+    ),
+    ...geolocationApprovals.map(
+      (approval): ApprovalQueueItem => ({
+        kind: "geolocation",
+        id: geolocationApprovalQueueId(approval.id),
+        createdAt: approval.createdAt,
+        approval,
+      })
+    ),
+  ].sort((a, b) => createdAtMs(b.createdAt) - createdAtMs(a.createdAt));
+}
+
+export function nextSelectedApprovalId(
+  toolApprovals: readonly PendingApproval[],
+  geolocationApprovals: readonly GeolocationApproval[],
+  selectedId: string | null
+): string | null {
+  const items = approvalQueueItems(toolApprovals, geolocationApprovals);
+  if (selectedId && items.some((item) => item.id === selectedId)) return selectedId;
+  return items[0]?.id ?? null;
+}
+
+export function approvalDisplayFields(approval: PendingApproval | ToolCallRecord): ApprovalDisplayFields {
+  const args = approval.arguments ?? {};
+  const toolName = approval.tool_name ?? "unknown tool";
+  return {
+    title: approval.title ?? `${approval.server_id}: ${toolName}`,
+    serverId: approval.server_id,
+    toolName,
+    rationale: approval.rationale ?? "",
+    argumentsJson: JSON.stringify(args, null, 2) ?? "null",
+    argumentSummary: summarizeArguments(args),
+    toolCallId: approval.tool_call_id,
+    callerPrincipal: approval.caller_principal ?? null,
+    createdAt: approval.created_at ?? null,
+  };
+}
+
+export function summarizeArguments(args: Record<string, unknown>): string {
+  const keys = Object.keys(args);
+  if (keys.length === 0) return "No arguments";
+  if (keys.length <= 3) return keys.join(", ");
+  return `${keys.length} fields: ${keys.slice(0, 3).join(", ")}`;
+}
+
+export function recentToolCallTtlMs(status: ToolCallRecord["status"]): number | null {
+  if (status === "ok" || status === "denied") return RECENT_OK_TTL_MS;
+  if (status === "error") return RECENT_ERROR_TTL_MS;
+  return null;
+}
+
+export function makeRecentToolCall(record: ToolCallRecord, nowMs: number): RecentToolCall | null {
+  const ttlMs = recentToolCallTtlMs(record.status);
+  return ttlMs === null ? null : { record, hideAtMs: nowMs + ttlMs };
+}
+
+export function formatHideCountdown(hideAtMs: number, nowMs: number): string {
+  const remainingSeconds = Math.max(0, Math.ceil((hideAtMs - nowMs) / 1000));
+  return remainingSeconds === 0 ? "hiding now" : `hiding in ${remainingSeconds}s`;
+}
+
+export function terminalStatusLabel(status: ToolCallRecord["status"]): string {
+  if (status === "ok") return "OK";
+  if (status === "denied") return "Denied";
+  if (status === "error") return "Error";
+  if (status === "running") return "Running";
+  return "Pending";
+}
+
+export function geolocationApprovalTitle(approval: GeolocationApproval): string {
+  return approval.mode === "geolocationWatch" ? "Allow continuous location sharing?" : "Allow location sharing?";
+}
+
+export function geolocationApprovalBody(approval: GeolocationApproval): string {
+  return approval.mode === "geolocationWatch"
+    ? "Haku is asking to continuously receive your device location until it stops the watch or you withdraw access."
+    : "Haku is asking to read your current device location once.";
+}

--- a/haku/console/frontend/confirm_dialog.tsx
+++ b/haku/console/frontend/confirm_dialog.tsx
@@ -2,8 +2,6 @@ import { Button, Group, Stack, Text } from "@mantine/core";
 import type { PointerEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 
-import type { GeolocationOptions } from "./bridge.ts";
-import type { PendingApproval } from "./client.ts";
 import { ACTION_COLOR } from "./theme.ts";
 
 // The escalation the shell is asking the operator to approve — the **actual action** the
@@ -11,12 +9,7 @@ import { ACTION_COLOR } from "./theme.ts";
 // renders its own confirm copy (no flag+optional soup). The trusted-rendered text for each
 // privileged action lives here, in one place, since this dialog is the only trustworthy
 // surface at the moment of approval.
-export type Escalation =
-  | { kind: "openLink"; url: string }
-  | { kind: "launch"; id: string; prompt: string }
-  | { kind: "geolocation"; id: string; options?: GeolocationOptions }
-  | { kind: "geolocationWatch"; id: string; options?: GeolocationOptions }
-  | { kind: "toolApproval"; approval: PendingApproval };
+export type Escalation = { kind: "openLink"; url: string } | { kind: "launch"; id: string; prompt: string };
 
 interface Rendered {
   title: string;
@@ -24,37 +17,6 @@ interface Rendered {
   // Verbatim agent-supplied text to review before approving (a URL, a launch prompt).
   preview?: { text: string; mono: boolean };
   approveLabel: string;
-}
-
-type ToolApprovalRenderer = (approval: PendingApproval) => Rendered;
-
-const toolApprovalRenderers: Record<string, ToolApprovalRenderer> = {};
-
-function defaultToolApprovalRenderer(approval: PendingApproval): Rendered {
-  return {
-    title: approval.title ?? `${approval.server_id}: ${approval.tool_name}`,
-    body: `Approve ${approval.server_id}.${approval.tool_name} for ${approval.caller_principal}?`,
-    preview: {
-      text: JSON.stringify(
-        {
-          server_id: approval.server_id,
-          tool_name: approval.tool_name,
-          rationale: approval.rationale,
-          arguments: approval.arguments,
-          tool_call_id: approval.tool_call_id,
-        },
-        null,
-        2
-      ),
-      mono: true,
-    },
-    approveLabel: "Run tool",
-  };
-}
-
-function renderToolApproval(approval: PendingApproval): Rendered {
-  const renderer = toolApprovalRenderers[`${approval.server_id}.${approval.tool_name}`] ?? defaultToolApprovalRenderer;
-  return renderer(approval);
 }
 
 function render(action: Escalation): Rendered {
@@ -68,17 +30,15 @@ function render(action: Escalation): Rendered {
         preview: action.prompt ? { text: action.prompt, mono: false } : undefined,
         approveLabel: "Launch",
       };
-    // One grant covers both a one-shot read and a continuous watch, so the copy discloses
-    // the strongest capability it unlocks — ongoing tracking.
-    case "geolocation":
-    case "geolocationWatch":
-      return {
-        title: "Allow Haku to use your location?",
-        body: "Haku's UI is asking to use your device location, including tracking it continuously. Allowing lets it read your location whenever it asks — until you withdraw from the console panel (the ⚙ button, top-right). Your browser may prompt too. Haku is assumed adversarial; only allow when you trust why it's asked.",
-        approveLabel: "Allow",
-      };
-    case "toolApproval":
-      return renderToolApproval(action.approval);
+  }
+}
+
+export function escalationIdentity(action: Escalation): string {
+  switch (action.kind) {
+    case "openLink":
+      return `openLink:${action.url}`;
+    case "launch":
+      return `launch:${action.id}`;
   }
 }
 
@@ -108,18 +68,21 @@ export function ConfirmDialog({
 }) {
   const ref = useRef<HTMLDialogElement>(null);
   const [armed, setArmed] = useState(false);
+  const actionIdentity = action ? escalationIdentity(action) : null;
 
   useEffect(() => {
     const d = ref.current;
     if (!d) return;
-    if (action && !d.open) {
+    if (!actionIdentity) {
       setArmed(false);
-      d.showModal();
-      const t = setTimeout(() => setArmed(true), ARM_DELAY_MS);
-      return () => clearTimeout(t);
+      if (d.open) d.close();
+      return;
     }
-    if (!action && d.open) d.close();
-  }, [action]);
+    setArmed(false);
+    if (!d.open) d.showModal();
+    const t = setTimeout(() => setArmed(true), ARM_DELAY_MS);
+    return () => clearTimeout(t);
+  }, [actionIdentity]);
 
   const r = action ? render(action) : null;
   return (

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -1,20 +1,40 @@
-import { Badge, Button, Divider, Drawer, Group, Stack, Text } from "@mantine/core";
+import { Badge, Button, Group, SegmentedControl, Stack, Text } from "@mantine/core";
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import type { McpOperatorAuthStatus } from "./client.ts";
+import {
+  approvalDisplayFields,
+  approvalQueueItems,
+  formatHideCountdown,
+  geolocationApprovalBody,
+  geolocationApprovalTitle,
+  type GeolocationApproval,
+  type RecentToolCall,
+  terminalStatusLabel,
+} from "./approval_state.ts";
+import type { McpOperatorAuthStatus, PendingApproval, ToolCallRecord } from "./client.ts";
+import { ACTION_COLOR } from "./theme.ts";
 
-// The shell's own operator control surface — trusted chrome the agent-owned iframe cannot
-// render into, opened by the floating escape button over the (full-page) frame. It hosts
-// shell-owned status and controls that must live outside Haku's reach. New shell config/
-// views go here as sections, rather than scattering more floating badges over the frame.
-//
-// This is NOT a consent surface (it only *reveals* state and *reduces* privilege), so it
-// needn't be a top-layer `<dialog>` like the ConfirmDialog — a portalled Drawer above the
-// iframe is enough. The one authority moment (granting location) stays in ConfirmDialog.
-export interface ConsolePanelProps {
+export type ShellDrawerTab = "approvals" | "console";
+
+export interface ShellDrawerProps {
   opened: boolean;
+  activeTab: ShellDrawerTab;
+  onOpenTab: (tab: ShellDrawerTab) => void;
   onClose: () => void;
-  // Standing location-sharing grant (geolocation_grant.ts), whether a live watch is currently
-  // streaming, and the withdraw action (revokes the grant AND stops any live watch).
+  pendingApprovals: PendingApproval[];
+  geolocationApprovals: GeolocationApproval[];
+  selectedApprovalId: string | null;
+  selectedRecentToolCallId: string | null;
+  decidingApprovalIds: readonly string[];
+  recentToolCalls: RecentToolCall[];
+  onSelectApproval: (id: string) => void;
+  onSelectRecentToolCall: (toolCallId: string) => void;
+  onApproveTool: (approval: PendingApproval) => void;
+  onDenyTool: (approval: PendingApproval) => void;
+  onApproveGeolocation: (approval: GeolocationApproval) => void;
+  onDenyGeolocation: (approval: GeolocationApproval) => void;
+  onDismissRecentToolCall: (toolCallId: string) => void;
   geoGranted: boolean;
   tracking: boolean;
   onWithdrawGeolocation: () => void;
@@ -24,17 +44,526 @@ export interface ConsolePanelProps {
   onRefreshMcp: () => void;
 }
 
-// zIndex maxed so the Drawer sits above the full-page iframe; the escape button is one below.
+export interface ShellControlsProps {
+  pendingCount: number;
+  opened: boolean;
+  activeTab: ShellDrawerTab;
+  geoGranted: boolean;
+  tracking: boolean;
+  onOpenTab: (tab: ShellDrawerTab) => void;
+}
+
+// zIndex maxed so shell chrome sits above the full-page iframe; controls are one below.
 export const PANEL_Z = 2147483647;
+const ARM_DELAY_MS = 400;
+
+function useArmed(identity: string | null): boolean {
+  const [armed, setArmed] = useState(false);
+  useEffect(() => {
+    if (!identity) {
+      setArmed(false);
+      return;
+    }
+    setArmed(false);
+    const t = window.setTimeout(() => setArmed(true), ARM_DELAY_MS);
+    return () => window.clearTimeout(t);
+  }, [identity]);
+  return armed;
+}
 
 function shortDate(value: string | null | undefined): string | null {
   if (!value) return null;
   return new Date(value).toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
 }
 
-export function ConsolePanel({
+function statusColor(status: ToolCallRecord["status"]): string {
+  if (status === "ok") return "teal";
+  if (status === "error") return "red";
+  if (status === "denied") return "gray";
+  return "blue";
+}
+
+export function ShellControls({
+  pendingCount,
   opened,
-  onClose,
+  activeTab,
+  geoGranted,
+  tracking,
+  onOpenTab,
+}: ShellControlsProps) {
+  return (
+    <Group className="haku-shell-controls" gap="xs" style={{ zIndex: PANEL_Z - 1 }}>
+      <Button
+        size="xs"
+        variant={opened && activeTab === "approvals" ? "filled" : "default"}
+        color={ACTION_COLOR}
+        onClick={() => onOpenTab("approvals")}
+        rightSection={
+          pendingCount > 0 ? (
+            <Badge size="xs" color="red" variant="filled">
+              {pendingCount}
+            </Badge>
+          ) : null
+        }
+      >
+        Approvals
+      </Button>
+      <Button
+        size="xs"
+        variant={opened && activeTab === "console" ? "filled" : "default"}
+        color={tracking ? "teal" : geoGranted ? "blue" : "gray"}
+        onClick={() => onOpenTab("console")}
+      >
+        Console
+      </Button>
+    </Group>
+  );
+}
+
+function Field({ label, children, mono = false }: { label: string; children: ReactNode; mono?: boolean }) {
+  return (
+    <div className="haku-shell-field">
+      <dt>{label}</dt>
+      <dd className={mono ? "haku-shell-mono" : ""}>{children}</dd>
+    </div>
+  );
+}
+
+function ToolApprovalDetail({
+  approval,
+  deciding,
+  onApprove,
+  onDeny,
+}: {
+  approval: PendingApproval;
+  deciding: boolean;
+  onApprove: () => void;
+  onDeny: () => void;
+}) {
+  const fields = approvalDisplayFields(approval);
+  const armed = useArmed(`detail:${approval.tool_call_id}`);
+  return (
+    <section className="haku-shell-card haku-shell-card-selected">
+      <Stack gap="sm">
+        <Group justify="space-between" align="flex-start" gap="sm">
+          <Stack gap={3}>
+            <Text fw={700}>{fields.title}</Text>
+            <Text size="xs" c="dimmed">
+              Tool call approval
+            </Text>
+          </Stack>
+          <Badge color={deciding ? "blue" : "yellow"} variant="light">
+            {deciding ? "Running" : "Pending"}
+          </Badge>
+        </Group>
+        <dl className="haku-shell-fields">
+          <div className="haku-shell-field-grid">
+            <Field label="Server id" mono>
+              {fields.serverId}
+            </Field>
+            <Field label="Tool name" mono>
+              {fields.toolName}
+            </Field>
+          </div>
+          <Field label="Rationale">{fields.rationale || "No rationale provided."}</Field>
+          <Field label="Arguments">
+            <pre className="haku-shell-json">{fields.argumentsJson}</pre>
+          </Field>
+          {(fields.callerPrincipal || fields.createdAt) && (
+            <Field label="Requested">
+              {[fields.callerPrincipal, shortDate(fields.createdAt)].filter(Boolean).join(" · ")}
+            </Field>
+          )}
+          <details className="haku-shell-disclosure">
+            <summary>Tool call id</summary>
+            <code>{fields.toolCallId}</code>
+          </details>
+        </dl>
+        <Group justify="space-between">
+          <Button size="sm" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
+            Deny
+          </Button>
+          <Button size="sm" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
+            Approve
+          </Button>
+        </Group>
+      </Stack>
+    </section>
+  );
+}
+
+function GeolocationApprovalDetail({
+  approval,
+  deciding,
+  onApprove,
+  onDeny,
+}: {
+  approval: GeolocationApproval;
+  deciding: boolean;
+  onApprove: () => void;
+  onDeny: () => void;
+}) {
+  const armed = useArmed(`geo-detail:${approval.id}`);
+  return (
+    <section className="haku-shell-card haku-shell-card-selected">
+      <Stack gap="sm">
+        <Group justify="space-between" align="flex-start" gap="sm">
+          <Stack gap={3}>
+            <Text fw={700}>{geolocationApprovalTitle(approval)}</Text>
+            <Text size="xs" c="dimmed">
+              Browser location approval
+            </Text>
+          </Stack>
+          <Badge color={deciding ? "blue" : "yellow"} variant="light">
+            {deciding ? "Applying" : "Pending"}
+          </Badge>
+        </Group>
+        <Text size="sm">{geolocationApprovalBody(approval)}</Text>
+        <dl className="haku-shell-fields">
+          <Field label="Mode">{approval.mode === "geolocationWatch" ? "Continuous watch" : "One-shot read"}</Field>
+          <Field label="Requested">{shortDate(approval.createdAt)}</Field>
+          {approval.options && (
+            <Field label="Options">
+              <pre className="haku-shell-json">{JSON.stringify(approval.options, null, 2)}</pre>
+            </Field>
+          )}
+          <details className="haku-shell-disclosure">
+            <summary>Bridge request id</summary>
+            <code>{approval.id}</code>
+          </details>
+        </dl>
+        <Group justify="space-between">
+          <Button size="sm" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
+            Deny
+          </Button>
+          <Button size="sm" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
+            Approve
+          </Button>
+        </Group>
+      </Stack>
+    </section>
+  );
+}
+
+function ToolApprovalCard({
+  approval,
+  selected,
+  deciding,
+  onSelect,
+  onApprove,
+  onDeny,
+}: {
+  approval: PendingApproval;
+  selected: boolean;
+  deciding: boolean;
+  onSelect: () => void;
+  onApprove: () => void;
+  onDeny: () => void;
+}) {
+  const fields = approvalDisplayFields(approval);
+  const armed = useArmed(`card:${approval.tool_call_id}`);
+  return (
+    <section className={`haku-shell-card haku-shell-approval-card ${selected ? "haku-shell-card-active" : ""}`}>
+      <Group justify="space-between" align="flex-start" gap="sm">
+        <Stack gap={2}>
+          <Text fw={600} size="sm">
+            {fields.title}
+          </Text>
+          <Text size="xs" c="dimmed">
+            {fields.serverId}.{fields.toolName}
+          </Text>
+          <Text size="xs">{fields.rationale || fields.argumentSummary}</Text>
+        </Stack>
+        <Badge color={deciding ? "blue" : "yellow"} variant="light">
+          {deciding ? "Running" : "Pending"}
+        </Badge>
+      </Group>
+      <Group justify="flex-end" gap="xs" mt="xs">
+        <Button size="compact-xs" variant="subtle" onClick={onSelect}>
+          Details
+        </Button>
+        <Button size="compact-xs" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
+          Deny
+        </Button>
+        <Button size="compact-xs" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
+          Approve
+        </Button>
+      </Group>
+    </section>
+  );
+}
+
+function GeolocationApprovalCard({
+  approval,
+  selected,
+  deciding,
+  onSelect,
+  onApprove,
+  onDeny,
+}: {
+  approval: GeolocationApproval;
+  selected: boolean;
+  deciding: boolean;
+  onSelect: () => void;
+  onApprove: () => void;
+  onDeny: () => void;
+}) {
+  const armed = useArmed(`geo-card:${approval.id}`);
+  return (
+    <section className={`haku-shell-card haku-shell-approval-card ${selected ? "haku-shell-card-active" : ""}`}>
+      <Group justify="space-between" align="flex-start" gap="sm">
+        <Stack gap={2}>
+          <Text fw={600} size="sm">
+            {geolocationApprovalTitle(approval)}
+          </Text>
+          <Text size="xs" c="dimmed">
+            {approval.mode === "geolocationWatch" ? "Continuous location watch" : "Current location read"}
+          </Text>
+          <Text size="xs">{geolocationApprovalBody(approval)}</Text>
+        </Stack>
+        <Badge color={deciding ? "blue" : "yellow"} variant="light">
+          {deciding ? "Applying" : "Pending"}
+        </Badge>
+      </Group>
+      <Group justify="flex-end" gap="xs" mt="xs">
+        <Button size="compact-xs" variant="subtle" onClick={onSelect}>
+          Details
+        </Button>
+        <Button size="compact-xs" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
+          Deny
+        </Button>
+        <Button size="compact-xs" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
+          Approve
+        </Button>
+      </Group>
+    </section>
+  );
+}
+
+function RecentToolCallCard({
+  recent,
+  selected,
+  nowMs,
+  onSelect,
+  onDismiss,
+}: {
+  recent: RecentToolCall;
+  selected: boolean;
+  nowMs: number;
+  onSelect: () => void;
+  onDismiss: () => void;
+}) {
+  const fields = approvalDisplayFields(recent.record);
+  return (
+    <section className={`haku-shell-card haku-shell-approval-card ${selected ? "haku-shell-card-active" : ""}`}>
+      <Group justify="space-between" align="flex-start" gap="sm">
+        <Stack gap={2}>
+          <Text fw={600} size="sm">
+            {fields.title}
+          </Text>
+          <Text size="xs" c="dimmed">
+            {fields.serverId}.{fields.toolName} · {formatHideCountdown(recent.hideAtMs, nowMs)}
+          </Text>
+          {recent.record.error && (
+            <Text size="xs" c="red">
+              {recent.record.error}
+            </Text>
+          )}
+        </Stack>
+        <Badge color={statusColor(recent.record.status)} variant="light">
+          {terminalStatusLabel(recent.record.status)}
+        </Badge>
+      </Group>
+      <Group justify="flex-end" gap="xs" mt="xs">
+        <Button size="compact-xs" variant="subtle" onClick={onSelect}>
+          Details
+        </Button>
+        <Button size="compact-xs" variant="subtle" color="gray" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </Group>
+    </section>
+  );
+}
+
+function RecentToolCallDetail({ record }: { record: ToolCallRecord }) {
+  const fields = approvalDisplayFields(record);
+  return (
+    <section className="haku-shell-card haku-shell-card-selected">
+      <Stack gap="sm">
+        <Group justify="space-between" align="flex-start" gap="sm">
+          <Stack gap={3}>
+            <Text fw={700}>{fields.title}</Text>
+            <Text size="xs" c="dimmed">
+              Tool call result
+            </Text>
+          </Stack>
+          <Badge color={statusColor(record.status)} variant="light">
+            {terminalStatusLabel(record.status)}
+          </Badge>
+        </Group>
+        {record.error && (
+          <Text size="sm" c="red">
+            {record.error}
+          </Text>
+        )}
+        <dl className="haku-shell-fields">
+          <div className="haku-shell-field-grid">
+            <Field label="Server id" mono>
+              {fields.serverId}
+            </Field>
+            <Field label="Tool name" mono>
+              {fields.toolName}
+            </Field>
+          </div>
+          <Field label="Arguments">
+            <pre className="haku-shell-json">{fields.argumentsJson}</pre>
+          </Field>
+          {record.result && (
+            <Field label="Result">
+              <pre className="haku-shell-json">{JSON.stringify(record.result, null, 2)}</pre>
+            </Field>
+          )}
+          <details className="haku-shell-disclosure">
+            <summary>Tool call id</summary>
+            <code>{fields.toolCallId}</code>
+          </details>
+        </dl>
+      </Stack>
+    </section>
+  );
+}
+
+function ApprovalsTab({
+  pendingApprovals,
+  geolocationApprovals,
+  selectedApprovalId,
+  selectedRecentToolCallId,
+  decidingApprovalIds,
+  recentToolCalls,
+  onSelectApproval,
+  onSelectRecentToolCall,
+  onApproveTool,
+  onDenyTool,
+  onApproveGeolocation,
+  onDenyGeolocation,
+  onDismissRecentToolCall,
+}: Pick<
+  ShellDrawerProps,
+  | "pendingApprovals"
+  | "geolocationApprovals"
+  | "selectedApprovalId"
+  | "selectedRecentToolCallId"
+  | "decidingApprovalIds"
+  | "recentToolCalls"
+  | "onSelectApproval"
+  | "onSelectRecentToolCall"
+  | "onApproveTool"
+  | "onDenyTool"
+  | "onApproveGeolocation"
+  | "onDenyGeolocation"
+  | "onDismissRecentToolCall"
+>) {
+  const items = useMemo(
+    () => approvalQueueItems(pendingApprovals, geolocationApprovals),
+    [geolocationApprovals, pendingApprovals]
+  );
+  const selectedItem = items.find((item) => item.id === selectedApprovalId) ?? null;
+  const selectedRecent =
+    selectedItem === null
+      ? recentToolCalls.find((recent) => recent.record.tool_call_id === selectedRecentToolCallId)
+      : null;
+  const deciding = new Set(decidingApprovalIds);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (recentToolCalls.length === 0) return;
+    const t = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(t);
+  }, [recentToolCalls.length]);
+
+  return (
+    <Stack gap="md">
+      {selectedItem?.kind === "tool" && (
+        <ToolApprovalDetail
+          approval={selectedItem.approval}
+          deciding={deciding.has(selectedItem.id)}
+          onApprove={() => onApproveTool(selectedItem.approval)}
+          onDeny={() => onDenyTool(selectedItem.approval)}
+        />
+      )}
+      {selectedItem?.kind === "geolocation" && (
+        <GeolocationApprovalDetail
+          approval={selectedItem.approval}
+          deciding={deciding.has(selectedItem.id)}
+          onApprove={() => onApproveGeolocation(selectedItem.approval)}
+          onDeny={() => onDenyGeolocation(selectedItem.approval)}
+        />
+      )}
+      {selectedRecent && <RecentToolCallDetail record={selectedRecent.record} />}
+      {!selectedItem && !selectedRecent && (
+        <section className="haku-shell-card">
+          <Text size="sm" c="dimmed">
+            No pending approvals.
+          </Text>
+        </section>
+      )}
+      <Stack gap="xs">
+        <Text fw={600} size="sm">
+          Pending
+        </Text>
+        {items.length === 0 ? (
+          <Text size="sm" c="dimmed">
+            Nothing needs a decision.
+          </Text>
+        ) : (
+          items.map((item) =>
+            item.kind === "tool" ? (
+              <ToolApprovalCard
+                key={item.id}
+                approval={item.approval}
+                selected={item.id === selectedApprovalId}
+                deciding={deciding.has(item.id)}
+                onSelect={() => onSelectApproval(item.id)}
+                onApprove={() => onApproveTool(item.approval)}
+                onDeny={() => onDenyTool(item.approval)}
+              />
+            ) : (
+              <GeolocationApprovalCard
+                key={item.id}
+                approval={item.approval}
+                selected={item.id === selectedApprovalId}
+                deciding={deciding.has(item.id)}
+                onSelect={() => onSelectApproval(item.id)}
+                onApprove={() => onApproveGeolocation(item.approval)}
+                onDeny={() => onDenyGeolocation(item.approval)}
+              />
+            )
+          )
+        )}
+      </Stack>
+      {recentToolCalls.length > 0 && (
+        <Stack gap="xs">
+          <Text fw={600} size="sm">
+            Recent
+          </Text>
+          {recentToolCalls.map((recent) => (
+            <RecentToolCallCard
+              key={recent.record.tool_call_id}
+              recent={recent}
+              selected={recent.record.tool_call_id === selectedRecentToolCallId}
+              nowMs={nowMs}
+              onSelect={() => onSelectRecentToolCall(recent.record.tool_call_id)}
+              onDismiss={() => onDismissRecentToolCall(recent.record.tool_call_id)}
+            />
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  );
+}
+
+function ConsoleTab({
   geoGranted,
   tracking,
   onWithdrawGeolocation,
@@ -42,52 +571,61 @@ export function ConsolePanel({
   onConnectMcp,
   onDisconnectMcp,
   onRefreshMcp,
-}: ConsolePanelProps) {
+}: Pick<
+  ShellDrawerProps,
+  | "geoGranted"
+  | "tracking"
+  | "onWithdrawGeolocation"
+  | "mcpAuthStatuses"
+  | "onConnectMcp"
+  | "onDisconnectMcp"
+  | "onRefreshMcp"
+>) {
   return (
-    <Drawer opened={opened} onClose={onClose} position="right" size="sm" title="Console" zIndex={PANEL_Z}>
-      <Stack gap="lg">
-        <Stack gap={6}>
-          <Text fw={600} size="sm">
-            Location sharing
-          </Text>
-          {geoGranted ? (
-            <Group justify="space-between">
-              {tracking ? (
-                <Badge color="teal" variant="filled" leftSection="📍">
-                  Tracking — live
-                </Badge>
-              ) : (
-                <Badge color="blue" variant="light" leftSection="📍">
-                  Allowed — idle
-                </Badge>
-              )}
-              <Button size="xs" variant="light" color="red" onClick={onWithdrawGeolocation}>
-                {tracking ? "Stop & withdraw" : "Withdraw"}
-              </Button>
-            </Group>
-          ) : (
-            <Text size="sm" c="dimmed">
-              Not shared — Haku will ask when it needs your location.
-            </Text>
-          )}
-        </Stack>
-        <Divider />
-        <Stack gap="sm">
-          <Group justify="space-between">
+    <Stack gap="md">
+      <section className="haku-shell-card">
+        <Group justify="space-between" align="flex-start" gap="sm">
+          <Stack gap={4}>
             <Text fw={600} size="sm">
-              MCP accounts
+              Location sharing
             </Text>
-            <Button size="compact-xs" variant="subtle" onClick={onRefreshMcp}>
-              Refresh
+            <Text size="sm" c="dimmed">
+              {geoGranted
+                ? tracking
+                  ? "Haku is receiving live location updates."
+                  : "Haku may request your location without another approval until withdrawn."
+                : "Not shared. Haku will request approval when it needs your location."}
+            </Text>
+          </Stack>
+          <Badge color={tracking ? "teal" : geoGranted ? "blue" : "gray"} variant="light">
+            {tracking ? "Live" : geoGranted ? "Allowed" : "Off"}
+          </Badge>
+        </Group>
+        {geoGranted && (
+          <Group justify="flex-end" mt="sm">
+            <Button size="xs" variant="light" color="red" onClick={onWithdrawGeolocation}>
+              {tracking ? "Stop & withdraw" : "Withdraw"}
             </Button>
           </Group>
+        )}
+      </section>
+      <section className="haku-shell-card">
+        <Group justify="space-between" align="center">
+          <Text fw={600} size="sm">
+            MCP accounts
+          </Text>
+          <Button size="compact-xs" variant="subtle" onClick={onRefreshMcp}>
+            Refresh
+          </Button>
+        </Group>
+        <Stack gap="sm" mt="sm">
           {mcpAuthStatuses.length === 0 ? (
             <Text size="sm" c="dimmed">
               No operator-linked MCP servers are configured.
             </Text>
           ) : (
             mcpAuthStatuses.map((status) => (
-              <Stack key={status.server_id} gap={5}>
+              <div key={status.server_id} className="haku-shell-subcard">
                 <Group justify="space-between" align="flex-start" gap="xs">
                   <Stack gap={2}>
                     <Text size="sm" fw={500}>
@@ -101,37 +639,86 @@ export function ConsolePanel({
                         : `Not linked for ${status.operator_principal}`}
                     </Text>
                   </Stack>
-                  {status.status === "connected" ? (
-                    <Badge color="teal" variant="light">
-                      Connected
-                    </Badge>
-                  ) : (
-                    <Badge color="gray" variant="light">
-                      Unconnected
-                    </Badge>
-                  )}
+                  <Badge color={status.status === "connected" ? "teal" : "gray"} variant="light">
+                    {status.status === "connected" ? "Connected" : "Unconnected"}
+                  </Badge>
                 </Group>
-                <Group justify="flex-end" gap="xs">
+                <Group justify="flex-end" gap="xs" mt="xs">
                   {status.status === "connected" ? (
                     <>
-                      <Button size="xs" variant="light" onClick={() => onConnectMcp(status.server_id)}>
+                      <Button size="compact-xs" variant="light" onClick={() => onConnectMcp(status.server_id)}>
                         Reconnect
                       </Button>
-                      <Button size="xs" variant="subtle" color="red" onClick={() => onDisconnectMcp(status.server_id)}>
+                      <Button
+                        size="compact-xs"
+                        variant="subtle"
+                        color="red"
+                        onClick={() => onDisconnectMcp(status.server_id)}
+                      >
                         Disconnect
                       </Button>
                     </>
                   ) : (
-                    <Button size="xs" variant="light" onClick={() => onConnectMcp(status.server_id)}>
+                    <Button size="compact-xs" variant="light" onClick={() => onConnectMcp(status.server_id)}>
                       Connect
                     </Button>
                   )}
                 </Group>
-              </Stack>
+              </div>
             ))
           )}
         </Stack>
-      </Stack>
-    </Drawer>
+      </section>
+    </Stack>
+  );
+}
+
+export function ShellDrawer(props: ShellDrawerProps) {
+  return (
+    <div className="haku-shell-overlay" style={{ zIndex: PANEL_Z }} aria-hidden={!props.opened}>
+      {props.opened && (
+        <aside className="haku-shell-drawer" aria-label="Haku console controls">
+          <Group justify="space-between" align="center" className="haku-shell-header">
+            <Stack gap={1}>
+              <Text fw={700}>Haku console</Text>
+              <Text size="xs" c="dimmed">
+                Trusted shell controls
+              </Text>
+            </Stack>
+            <Button size="compact-xs" variant="subtle" onClick={props.onClose}>
+              Close
+            </Button>
+          </Group>
+          <SegmentedControl
+            fullWidth
+            size="xs"
+            value={props.activeTab}
+            onChange={(value) => props.onOpenTab(value as ShellDrawerTab)}
+            data={[
+              {
+                value: "approvals",
+                label: `Approvals (${props.pendingApprovals.length + props.geolocationApprovals.length})`,
+              },
+              { value: "console", label: "Console" },
+            ]}
+          />
+          <div className="haku-shell-scroll">
+            {props.activeTab === "approvals" ? (
+              <ApprovalsTab {...props} />
+            ) : (
+              <ConsoleTab
+                geoGranted={props.geoGranted}
+                tracking={props.tracking}
+                onWithdrawGeolocation={props.onWithdrawGeolocation}
+                mcpAuthStatuses={props.mcpAuthStatuses}
+                onConnectMcp={props.onConnectMcp}
+                onDisconnectMcp={props.onDisconnectMcp}
+                onRefreshMcp={props.onRefreshMcp}
+              />
+            )}
+          </div>
+        </aside>
+      )}
+    </div>
   );
 }

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -1,6 +1,15 @@
-import { ActionIcon, Anchor, Indicator } from "@mantine/core";
+import { Anchor } from "@mantine/core";
 import { useEffect, useRef, useState } from "react";
 
+import {
+  geolocationApprovalQueueId,
+  makeRecentToolCall,
+  nextSelectedApprovalId,
+  sortApprovalsNewestFirst,
+  toolApprovalQueueId,
+  type GeolocationApproval,
+  type RecentToolCall,
+} from "./approval_state.ts";
 import { type GeolocationOptions, isRoutePath, type Outbound, parseInbound, vetOpenLink } from "./bridge.ts";
 import {
   approveToolCall,
@@ -11,10 +20,11 @@ import {
   launchRoutine,
   type McpOperatorAuthStatus,
   type PendingApproval,
+  type ToolCallRecord,
   startMcpOperatorAuth,
 } from "./client.ts";
 import { ConfirmDialog, type Escalation } from "./confirm_dialog.tsx";
-import { ConsolePanel, PANEL_Z } from "./console_panel.tsx";
+import { ShellControls, ShellDrawer, type ShellDrawerTab } from "./console_panel.tsx";
 import { GEO_PERMISSION_DENIED, GeolocationWatcher, getGeolocation } from "./geolocation.ts";
 import { hasGeolocationGrant, setGeolocationGrant } from "./geolocation_grant.ts";
 import { toastError, toastSuccess } from "./toast.ts";
@@ -76,15 +86,24 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
   // to launch). One typed action, dispatched on its `kind` — see ConfirmDialog's Escalation.
   const [pending, setPending] = useState<Escalation | null>(null);
   const [toolApprovals, setToolApprovals] = useState<PendingApproval[]>([]);
+  const toolApprovalsRef = useRef<PendingApproval[]>([]);
+  const knownToolApprovalIdsRef = useRef<Set<string> | null>(null);
+  const [geolocationApprovals, setGeolocationApprovals] = useState<GeolocationApproval[]>([]);
+  const geolocationApprovalsRef = useRef<GeolocationApproval[]>([]);
   const [mcpAuthStatuses, setMcpAuthStatuses] = useState<McpOperatorAuthStatus[]>([]);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerTab, setDrawerTab] = useState<ShellDrawerTab>("approvals");
+  const [selectedApprovalId, setSelectedApprovalId] = useState<string | null>(null);
+  const [selectedRecentToolCallId, setSelectedRecentToolCallId] = useState<string | null>(null);
+  const [decidingApprovalIds, setDecidingApprovalIds] = useState<string[]>([]);
+  const [recentToolCalls, setRecentToolCalls] = useState<RecentToolCall[]>([]);
   // Computed once: later routeChanged mirroring must not rewrite `src` (that would
   // reload the frame); the iframe navigates itself, the console only reflects.
   const [frameSrc] = useState(() => initialFrameSrc(uiUrl, window.location.hash));
   const origin = new URL(uiUrl).origin;
   const toolApprovalChannelRef = useRef<BroadcastChannel | null>(null);
   const mcpAuthChannelRef = useRef<BroadcastChannel | null>(null);
-  const activeAction: Escalation | null =
-    pending ?? (toolApprovals[0] ? { kind: "toolApproval", approval: toolApprovals[0] } : null);
+  const activeAction: Escalation | null = pending;
 
   function reply(msg: Outbound) {
     iframeRef.current?.contentWindow?.postMessage(msg, origin);
@@ -114,7 +133,6 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
   // closure; these mirrors only drive rendering.
   const [geoGranted, setGeoGranted] = useState(() => hasGeolocationGrant());
   const [tracking, setTracking] = useState(false);
-  const [panelOpen, setPanelOpen] = useState(false);
 
   // The shell (never the iframe) holds every live watchPosition stream; each fix is relayed
   // to the iframe as a geolocationResult tagged with its watch id. Created once.
@@ -150,14 +168,88 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
     setGeoGranted(false);
   }
 
-  function removeToolApproval(toolCallId: string) {
-    setToolApprovals((approvals) => approvals.filter((a) => a.tool_call_id !== toolCallId));
+  function openDrawerTab(tab: ShellDrawerTab) {
+    setDrawerTab(tab);
+    setDrawerOpen(true);
+  }
+
+  function openApproval(id: string) {
+    setSelectedApprovalId(id);
+    setSelectedRecentToolCallId(null);
+    openDrawerTab("approvals");
+  }
+
+  function setDeciding(id: string, deciding: boolean) {
+    setDecidingApprovalIds((ids) =>
+      deciding ? (ids.includes(id) ? ids : [...ids, id]) : ids.filter((existing) => existing !== id)
+    );
+  }
+
+  function applyToolApprovals(approvals: PendingApproval[]) {
+    const incomingIds = new Set(approvals.map((approval) => approval.tool_call_id));
+    const previousIds = knownToolApprovalIdsRef.current;
+    const newApprovals =
+      previousIds === null ? approvals : approvals.filter((approval) => !previousIds.has(approval.tool_call_id));
+    knownToolApprovalIdsRef.current = incomingIds;
+    toolApprovalsRef.current = approvals;
+    setToolApprovals(approvals);
+    if (newApprovals.length > 0) {
+      openApproval(toolApprovalQueueId(sortApprovalsNewestFirst(newApprovals)[0].tool_call_id));
+    }
+  }
+
+  function removeToolApproval(toolCallId: string): PendingApproval[] {
+    const remaining = toolApprovalsRef.current.filter((approval) => approval.tool_call_id !== toolCallId);
+    toolApprovalsRef.current = remaining;
+    knownToolApprovalIdsRef.current = new Set(remaining.map((approval) => approval.tool_call_id));
+    setToolApprovals(remaining);
+    return remaining;
+  }
+
+  function addRecentToolCall(record: ToolCallRecord) {
+    const recent = makeRecentToolCall(record, Date.now());
+    if (!recent) return;
+    setRecentToolCalls((records) => [
+      recent,
+      ...records.filter((existing) => existing.record.tool_call_id !== record.tool_call_id),
+    ]);
+  }
+
+  function finishToolDecision(record: ToolCallRecord) {
+    const remaining = removeToolApproval(record.tool_call_id);
+    addRecentToolCall(record);
+    setDeciding(toolApprovalQueueId(record.tool_call_id), false);
+    const nextApprovalId = nextSelectedApprovalId(remaining, geolocationApprovalsRef.current, null);
+    setSelectedApprovalId(nextApprovalId);
+    setSelectedRecentToolCallId(nextApprovalId ? null : record.tool_call_id);
+  }
+
+  function addGeolocationApproval(mode: GeolocationApproval["mode"], id: string, options?: GeolocationOptions) {
+    const approval: GeolocationApproval = { id, mode, options, createdAt: new Date().toISOString() };
+    const remaining = [approval, ...geolocationApprovalsRef.current.filter((existing) => existing.id !== id)];
+    geolocationApprovalsRef.current = remaining;
+    setGeolocationApprovals(remaining);
+    openApproval(geolocationApprovalQueueId(id));
+  }
+
+  function removeGeolocationApproval(id: string): GeolocationApproval[] {
+    const remaining = geolocationApprovalsRef.current.filter((approval) => approval.id !== id);
+    geolocationApprovalsRef.current = remaining;
+    setGeolocationApprovals(remaining);
+    return remaining;
+  }
+
+  function advanceAfterGeolocation(id: string) {
+    const remaining = removeGeolocationApproval(id);
+    const nextApprovalId = nextSelectedApprovalId(toolApprovalsRef.current, remaining, null);
+    setSelectedApprovalId(nextApprovalId);
+    if (!nextApprovalId) setSelectedRecentToolCallId(null);
   }
 
   function refreshToolApprovals(notifyPeers = false) {
     if (notifyPeers) toolApprovalChannelRef.current?.postMessage({ type: "toolApprovalsChanged" });
     void fetchPendingApprovals().then(
-      (approvals) => setToolApprovals(approvals),
+      (approvals) => applyToolApprovals(approvals),
       (e: unknown) => toastError("Couldn't load tool approvals", e)
     );
   }
@@ -256,17 +348,17 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
       }
       if (msg.type === "requestGeolocation") {
         // The iframe can only ask; the shell owns the standing grant. With consent already
-        // given ("allow until withdrawn"), serve directly; otherwise pop the top-layer
-        // consent confirm, which — once approved — records the grant so later reads skip it.
+        // given ("allow until withdrawn"), serve directly; otherwise queue a trusted shell
+        // approval in the non-modal drawer so Haku's UI remains usable.
         if (hasGeolocationGrant()) geolocateAndReply(msg.id, msg.options);
-        else setPending({ kind: "geolocation", id: msg.id, options: msg.options });
+        else addGeolocationApproval("geolocation", msg.id, msg.options);
         return;
       }
       if (msg.type === "startGeolocationWatch") {
         // A continuous stream: same grant gate as a one-shot read, but the shell keeps the
         // watch (so the iframe can't start one silently or keep one the operator stopped).
         if (hasGeolocationGrant()) startWatch(msg.id, msg.options);
-        else setPending({ kind: "geolocationWatch", id: msg.id, options: msg.options });
+        else addGeolocationApproval("geolocationWatch", msg.id, msg.options);
         return;
       }
       if (msg.type === "stopGeolocationWatch") {
@@ -295,6 +387,40 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
     return () => window.removeEventListener("message", onMessage);
   }, [origin, launchAvailable]);
 
+  useEffect(() => {
+    toolApprovalsRef.current = toolApprovals;
+  }, [toolApprovals]);
+
+  useEffect(() => {
+    geolocationApprovalsRef.current = geolocationApprovals;
+  }, [geolocationApprovals]);
+
+  useEffect(() => {
+    setSelectedApprovalId((selected) => nextSelectedApprovalId(toolApprovals, geolocationApprovals, selected));
+  }, [geolocationApprovals, toolApprovals]);
+
+  useEffect(() => {
+    if (recentToolCalls.length === 0) return;
+    const nextHideAtMs = Math.min(...recentToolCalls.map((recent) => recent.hideAtMs));
+    const t = window.setTimeout(
+      () => {
+        const now = Date.now();
+        setRecentToolCalls((records) => records.filter((recent) => recent.hideAtMs > now));
+      },
+      Math.max(0, nextHideAtMs - Date.now()) + 50
+    );
+    return () => window.clearTimeout(t);
+  }, [recentToolCalls]);
+
+  useEffect(() => {
+    if (
+      selectedRecentToolCallId &&
+      !recentToolCalls.some((recent) => recent.record.tool_call_id === selectedRecentToolCallId)
+    ) {
+      setSelectedRecentToolCallId(null);
+    }
+  }, [recentToolCalls, selectedRecentToolCallId]);
+
   // The operator approved against trusted-rendered chrome — now actually perform the action
   // (open the link / fire the capability) and report the outcome back over the bridge.
   function onApprove() {
@@ -303,29 +429,6 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
     if (!action) return;
     if (action.kind === "openLink") {
       openAndReply(action.url);
-      return;
-    }
-    if (action.kind === "geolocation" || action.kind === "geolocationWatch") {
-      // Consent given on trusted chrome — record the standing grant so subsequent reads are
-      // served without re-confirming, until the operator withdraws (the console panel below).
-      setGeolocationGrant(true);
-      setGeoGranted(true);
-      if (action.kind === "geolocationWatch") startWatch(action.id, action.options);
-      else geolocateAndReply(action.id, action.options);
-      return;
-    }
-    if (action.kind === "toolApproval") {
-      const toolCallId = action.approval.tool_call_id;
-      removeToolApproval(toolCallId);
-      void approveToolCall(toolCallId)
-        .then((record) => {
-          toastSuccess("Tool call finished", `${record.server_id}.${record.tool_name}: ${record.status}`);
-          refreshToolApprovals(true);
-        })
-        .catch((e: unknown) => {
-          toastError("Tool call failed", e);
-          refreshToolApprovals(true);
-        });
       return;
     }
     void launchRoutine(action.prompt || undefined)
@@ -350,30 +453,66 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
     if (!action) return;
     if (action.kind === "openLink") {
       reply({ type: "openLinkResult", url: action.url, opened: false, reason: "cancelled" });
-    } else if (action.kind === "geolocation" || action.kind === "geolocationWatch") {
-      // Declined on trusted chrome → mirror a browser PERMISSION_DENIED so the iframe treats
-      // it exactly like a native geolocation denial (for a watch, no stream ever starts). No
-      // grant is recorded.
-      reply({ type: "geolocationResult", id: action.id, ok: false, code: GEO_PERMISSION_DENIED, reason: "declined" });
-    } else if (action.kind === "toolApproval") {
-      const toolCallId = action.approval.tool_call_id;
-      removeToolApproval(toolCallId);
-      void denyToolCall(toolCallId, "cancelled from console").then(
-        () => {
-          toastSuccess(
-            "Tool call denied",
-            action.approval.title ?? `${action.approval.server_id}: ${action.approval.tool_name}`
-          );
-          refreshToolApprovals(true);
-        },
-        (e: unknown) => {
-          toastError("Couldn't deny tool call", e);
-          refreshToolApprovals(true);
-        }
-      );
     } else {
       reply({ type: "launchResult", id: action.id, ok: false, reason: "cancelled" });
     }
+  }
+
+  function approveToolApproval(approval: PendingApproval) {
+    const approvalId = toolApprovalQueueId(approval.tool_call_id);
+    setDeciding(approvalId, true);
+    void approveToolCall(approval.tool_call_id)
+      .then((record) => {
+        finishToolDecision(record);
+        toastSuccess("Tool call finished", `${record.server_id}.${record.tool_name}: ${record.status}`);
+        refreshToolApprovals(true);
+      })
+      .catch((e: unknown) => {
+        setDeciding(approvalId, false);
+        toastError("Tool call failed", e);
+        refreshToolApprovals(true);
+      });
+  }
+
+  function denyToolApproval(approval: PendingApproval) {
+    const approvalId = toolApprovalQueueId(approval.tool_call_id);
+    setDeciding(approvalId, true);
+    void denyToolCall(approval.tool_call_id, "denied from console").then(
+      (record) => {
+        finishToolDecision(record);
+        toastSuccess("Tool call denied", approval.title ?? `${approval.server_id}: ${approval.tool_name}`);
+        refreshToolApprovals(true);
+      },
+      (e: unknown) => {
+        setDeciding(approvalId, false);
+        toastError("Couldn't deny tool call", e);
+        refreshToolApprovals(true);
+      }
+    );
+  }
+
+  function approveGeolocationApproval(approval: GeolocationApproval) {
+    const approvalId = geolocationApprovalQueueId(approval.id);
+    setDeciding(approvalId, true);
+    setGeolocationGrant(true);
+    setGeoGranted(true);
+    if (approval.mode === "geolocationWatch") startWatch(approval.id, approval.options);
+    else geolocateAndReply(approval.id, approval.options);
+    setDeciding(approvalId, false);
+    advanceAfterGeolocation(approval.id);
+  }
+
+  function denyGeolocationApproval(approval: GeolocationApproval) {
+    const approvalId = geolocationApprovalQueueId(approval.id);
+    setDeciding(approvalId, true);
+    reply({ type: "geolocationResult", id: approval.id, ok: false, code: GEO_PERMISSION_DENIED, reason: "declined" });
+    setDeciding(approvalId, false);
+    advanceAfterGeolocation(approval.id);
+  }
+
+  function dismissRecentToolCall(toolCallId: string) {
+    setRecentToolCalls((records) => records.filter((recent) => recent.record.tool_call_id !== toolCallId));
+    if (selectedRecentToolCallId === toolCallId) setSelectedRecentToolCallId(null);
   }
 
   return (
@@ -385,26 +524,40 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
         sandbox="allow-scripts allow-same-origin allow-forms"
         style={{ display: "block", width: "100vw", height: "100vh", border: 0 }}
       />
-      {/* Persistent escape hatch into the shell's own controls (config, grants, views),
-          rendered by the SHELL above the full-page iframe. The dot marks a standing location
-          grant, and pulses (green) while a live watch is streaming, so the operator has
-          at-a-glance awareness that tracking is on even before opening the panel. It only ever
-          opens trusted shell chrome / *reduces* privilege, so — unlike the consent moment — it
-          needn't be a top-layer surface; the browser's own site-settings revoke is the
-          tamper-proof backstop (docs/containment.md). */}
-      <Indicator
-        color={tracking ? "teal" : "blue"}
-        processing={tracking}
-        disabled={!geoGranted}
-        style={{ position: "fixed", top: 8, right: 8, zIndex: PANEL_Z - 1 }}
-      >
-        <ActionIcon variant="default" size="lg" aria-label="Open console controls" onClick={() => setPanelOpen(true)}>
-          ⚙
-        </ActionIcon>
-      </Indicator>
-      <ConsolePanel
-        opened={panelOpen}
-        onClose={() => setPanelOpen(false)}
+      <ShellControls
+        pendingCount={toolApprovals.length + geolocationApprovals.length}
+        opened={drawerOpen}
+        activeTab={drawerTab}
+        geoGranted={geoGranted}
+        tracking={tracking}
+        onOpenTab={openDrawerTab}
+      />
+      <ShellDrawer
+        opened={drawerOpen}
+        activeTab={drawerTab}
+        onOpenTab={openDrawerTab}
+        onClose={() => setDrawerOpen(false)}
+        pendingApprovals={toolApprovals}
+        geolocationApprovals={geolocationApprovals}
+        selectedApprovalId={selectedApprovalId}
+        selectedRecentToolCallId={selectedRecentToolCallId}
+        decidingApprovalIds={decidingApprovalIds}
+        recentToolCalls={recentToolCalls}
+        onSelectApproval={(id) => {
+          setSelectedApprovalId(id);
+          setSelectedRecentToolCallId(null);
+          openDrawerTab("approvals");
+        }}
+        onSelectRecentToolCall={(toolCallId) => {
+          setSelectedRecentToolCallId(toolCallId);
+          setSelectedApprovalId(null);
+          openDrawerTab("approvals");
+        }}
+        onApproveTool={approveToolApproval}
+        onDenyTool={denyToolApproval}
+        onApproveGeolocation={approveGeolocationApproval}
+        onDenyGeolocation={denyGeolocationApproval}
+        onDismissRecentToolCall={dismissRecentToolCall}
         geoGranted={geoGranted}
         tracking={tracking}
         onWithdrawGeolocation={withdrawGeolocation}

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -15,6 +15,9 @@
     --haku-code-bg: #eaf6f2;
     --haku-code-fg: #202728;
     --haku-backdrop: rgb(21 74 70 / 55%);
+    --haku-shell-shadow: rgb(36 31 43 / 20%);
+    --haku-shell-muted-bg: #f4f0f7;
+    --haku-shell-active-bg: #e7f4ef;
   }
   :root[data-mantine-color-scheme="dark"] {
     --haku-page-bg: #0f1f1d;
@@ -23,6 +26,9 @@
     --haku-code-bg: #172f2b;
     --haku-code-fg: #e8f4f0;
     --haku-backdrop: rgb(0 0 0 / 68%);
+    --haku-shell-shadow: rgb(0 0 0 / 45%);
+    --haku-shell-muted-bg: #1b2f2c;
+    --haku-shell-active-bg: #203d38;
   }
   body {
     margin: 0;
@@ -83,4 +89,143 @@
   border: 1px solid var(--haku-border);
   background: var(--haku-code-bg);
   color: var(--haku-code-fg);
+}
+
+.haku-shell-controls {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+}
+
+.haku-shell-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+  pointer-events: none;
+}
+
+.haku-shell-drawer {
+  width: min(32rem, calc(100vw - 0.75rem));
+  height: calc(100dvh - 1rem);
+  margin: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  pointer-events: auto;
+  border: 1px solid var(--haku-border);
+  border-radius: 8px;
+  background: var(--haku-panel-bg);
+  color: var(--mantine-color-text);
+  box-shadow: 0 18px 50px var(--haku-shell-shadow);
+  padding: 0.85rem;
+}
+
+.haku-shell-header {
+  flex: 0 0 auto;
+}
+
+.haku-shell-scroll {
+  min-height: 0;
+  overflow: auto;
+  padding-right: 0.1rem;
+}
+
+.haku-shell-card,
+.haku-shell-subcard {
+  border: 1px solid var(--haku-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--haku-panel-bg) 88%, var(--haku-shell-muted-bg));
+  padding: 0.75rem;
+}
+
+.haku-shell-subcard {
+  background: var(--haku-shell-muted-bg);
+}
+
+.haku-shell-approval-card {
+  display: block;
+  width: 100%;
+  color: inherit;
+  text-align: left;
+}
+
+.haku-shell-card-active,
+.haku-shell-card-selected {
+  border-color: var(--mantine-color-teal-5);
+  background: var(--haku-shell-active-bg);
+}
+
+.haku-shell-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.haku-shell-field-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0.65rem;
+}
+
+.haku-shell-field {
+  min-width: 0;
+}
+
+.haku-shell-field dt {
+  margin: 0 0 0.18rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--mantine-color-dimmed);
+  text-transform: uppercase;
+}
+
+.haku-shell-field dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.haku-shell-mono,
+.haku-shell-disclosure code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.82rem;
+}
+
+.haku-shell-json {
+  max-height: 14rem;
+  margin: 0;
+  overflow: auto;
+  border: 1px solid var(--haku-border);
+  border-radius: 6px;
+  background: var(--haku-code-bg);
+  color: var(--haku-code-fg);
+  padding: 0.55rem;
+  font-size: 0.82rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.haku-shell-disclosure {
+  border-top: 1px solid var(--haku-border);
+  padding-top: 0.55rem;
+}
+
+.haku-shell-disclosure summary {
+  cursor: pointer;
+  color: var(--mantine-color-dimmed);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+@media (max-width: 520px) {
+  .haku-shell-drawer {
+    width: calc(100vw - 0.5rem);
+    height: calc(100dvh - 0.5rem);
+    margin: 0.25rem;
+  }
+
+  .haku-shell-field-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/haku/docs/security.md
+++ b/haku/docs/security.md
@@ -75,12 +75,11 @@ live source reads). Channels out, and what fences each:
 3. The console renders **no** Haku-authored content and holds no haku-state credential; the
    litmus test for console code: _does it hold a secret, perform a privileged action, or
    define the trust boundary?_ If not, it belongs to Haku.
-4. Consent moments happen on trusted top-level/top-layer surfaces only (the capability
-   confirm, the MCP tool-call approval confirm, the `openLink` off-whitelist confirm,
-   the `requestGeolocation` grant confirm).
-   Never move a confirm into agent-embeddable chrome; a persistent "trust badge" is not a
-   control — and the console panel that withdraws a grant is not one either (it only reduces
-   privilege).
+4. Consent moments happen on trusted top-level/top-layer shell surfaces only (the capability
+   confirm, the approval drawer for MCP tool calls and geolocation grants, and the `openLink`
+   off-whitelist confirm). Never move a confirm into agent-embeddable chrome; a persistent "trust
+   badge" is not a control — and the console panel that withdraws a grant is not one either (it only
+   reduces privilege).
 5. The `openLink` host whitelist lives in the shell (ducktape), never in haku-state.
 6. **The console stays the outer window.** Do not make haku-ui top-level: exfiltration
    containment (navigation channel above) depends on the embedding. Evaluated and rejected

--- a/haku/state_template/ui/frontend/src/client.test.ts
+++ b/haku/state_template/ui/frontend/src/client.test.ts
@@ -136,7 +136,7 @@ arguments:
 
   it("loads the authored request and posts its exact body to the backend proxy", async () => {
     const fetchMock = stubToolRequestFetch();
-    const record = await callToolRequest("2026-07-thrive.box", 500);
+    const record = await callToolRequest("2026-07-thrive.box");
     const toolCall = fetchMock.mock.calls.find((c) => c[0] === "/api/tool-calls");
     expect(toolCall).toBeTruthy();
     const init = toolCall![1] as RequestInit;
@@ -147,7 +147,7 @@ arguments:
       title: "Add Thrive box to Grocy",
       rationale: "box present",
       arguments: { items: [{ product_id: 123, amount: 1 }] },
-      wait_for_ms: 500,
+      wait_for_ms: 0,
     });
     expect(record.status).toBe("pending_approval");
   });

--- a/haku/state_template/ui/frontend/src/client.ts
+++ b/haku/state_template/ui/frontend/src/client.ts
@@ -79,7 +79,7 @@ export async function loadToolRequest(stateRequestId: string): Promise<ToolReque
   return parsed;
 }
 
-export async function callToolRequest(stateRequestId: string, waitForMs = 10_000): Promise<ToolCallRecord> {
+export async function callToolRequest(stateRequestId: string, waitForMs = 0): Promise<ToolCallRecord> {
   const request = await loadToolRequest(stateRequestId);
   const res = await fetch("/api/tool-calls", {
     method: "POST",


### PR DESCRIPTION
## Summary

- replace queued tool-call approval modals with a non-modal right-side approval drawer
- render approval details as structured fields for server id, tool name, rationale, arguments, and disclosed tool call id
- route geolocation confirmations through the same approval queue as a separate approval kind
- move existing MCP/location console controls into the same drawer styling and keep recent tool-call outcomes briefly visible with countdown feedback
- update haku-ui tool-call requests to submit without waiting for synchronous approval results

## Validation

- `pre-commit run --files haku/console/README.md haku/console/docs/containment.md haku/console/frontend/BUILD.bazel haku/console/frontend/approval_state.ts haku/console/frontend/approval_state.test.ts haku/console/frontend/confirm_dialog.tsx haku/console/frontend/console_panel.tsx haku/console/frontend/haku_ui_embed.tsx haku/console/frontend/styles.src.css haku/docs/security.md haku/state_template/ui/frontend/src/client.ts haku/state_template/ui/frontend/src/client.test.ts`
- `bbr test //haku/console/frontend:tsc_test //haku/console/frontend:bridge_test //haku/console:test_mcp_approval`
- `git diff --check origin/devel...HEAD`

## Notes

`//haku/state_template/ui/frontend:*` could not be run directly because Bazel reports that package as deleted via `--deleted_packages`.