### PR TITLE
Polish Haku approval drawer

### DIFF
--- a/haku/console/frontend/approval_state.test.ts
+++ b/haku/console/frontend/approval_state.test.ts
@@ -3,10 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   approvalDisplayFields,
   approvalQueueItems,
-  formatHideCountdown,
   geolocationApprovalQueueId,
   makeRecentToolCall,
-  nextSelectedApprovalId,
+  recentToolCallCountdown,
   toolApprovalQueueId,
   type GeolocationApproval,
 } from "./approval_state.ts";
@@ -66,14 +65,6 @@ describe("approval queue state", () => {
     ]);
   });
 
-  it("preserves a valid selection and otherwise picks the newest approval", () => {
-    const tool = pendingApproval({ tool_call_id: "tc_old", created_at: "2026-07-07T10:00:00Z" });
-    const geo = geolocationApproval({ id: "geo_new", createdAt: "2026-07-07T10:02:00Z" });
-
-    expect(nextSelectedApprovalId([tool], [geo], toolApprovalQueueId("tc_old"))).toBe(toolApprovalQueueId("tc_old"));
-    expect(nextSelectedApprovalId([tool], [geo], "missing")).toBe(geolocationApprovalQueueId("geo_new"));
-  });
-
   it("extracts structured display fields without collapsing everything into one JSON blob", () => {
     const fields = approvalDisplayFields(pendingApproval());
 
@@ -88,7 +79,22 @@ describe("approval queue state", () => {
     const recent = makeRecentToolCall(toolCallRecord(), 1_000);
 
     expect(recent?.hideAtMs).toBe(16_000);
-    expect(formatHideCountdown(16_000, 6_500)).toBe("hiding in 10s");
+    expect(recent ? recentToolCallCountdown(recent, 6_500) : null).toMatchObject({
+      label: "Auto-hides in 10s",
+      remainingSeconds: 10,
+    });
+    expect(recent ? recentToolCallCountdown(recent, 6_500).progressPercent : null).toBeCloseTo(63.33, 1);
     expect(makeRecentToolCall(toolCallRecord({ status: "pending_approval" }), 1_000)).toBeNull();
+  });
+
+  it("uses a longer countdown for errored tool calls", () => {
+    const recent = makeRecentToolCall(toolCallRecord({ status: "error" }), 1_000);
+
+    expect(recent?.hideAtMs).toBe(61_000);
+    expect(recent ? recentToolCallCountdown(recent, 70_000) : null).toMatchObject({
+      label: "Auto-hides now",
+      progressPercent: 0,
+      remainingSeconds: 0,
+    });
   });
 });

--- a/haku/console/frontend/approval_state.ts
+++ b/haku/console/frontend/approval_state.ts
@@ -29,6 +29,12 @@ export interface RecentToolCall {
   hideAtMs: number;
 }
 
+export interface RecentToolCallCountdown {
+  label: string;
+  progressPercent: number;
+  remainingSeconds: number;
+}
+
 const RECENT_OK_TTL_MS = 15_000;
 const RECENT_ERROR_TTL_MS = 60_000;
 
@@ -44,10 +50,6 @@ export function toolApprovalQueueId(toolCallId: string): string {
 
 export function geolocationApprovalQueueId(id: string): string {
   return `geolocation:${id}`;
-}
-
-export function sortApprovalsNewestFirst(approvals: readonly PendingApproval[]): PendingApproval[] {
-  return [...approvals].sort((a, b) => createdAtMs(b.created_at) - createdAtMs(a.created_at));
 }
 
 export function approvalQueueItems(
@@ -72,16 +74,6 @@ export function approvalQueueItems(
       })
     ),
   ].sort((a, b) => createdAtMs(b.createdAt) - createdAtMs(a.createdAt));
-}
-
-export function nextSelectedApprovalId(
-  toolApprovals: readonly PendingApproval[],
-  geolocationApprovals: readonly GeolocationApproval[],
-  selectedId: string | null
-): string | null {
-  const items = approvalQueueItems(toolApprovals, geolocationApprovals);
-  if (selectedId && items.some((item) => item.id === selectedId)) return selectedId;
-  return items[0]?.id ?? null;
 }
 
 export function approvalDisplayFields(approval: PendingApproval | ToolCallRecord): ApprovalDisplayFields {
@@ -118,9 +110,16 @@ export function makeRecentToolCall(record: ToolCallRecord, nowMs: number): Recen
   return ttlMs === null ? null : { record, hideAtMs: nowMs + ttlMs };
 }
 
-export function formatHideCountdown(hideAtMs: number, nowMs: number): string {
-  const remainingSeconds = Math.max(0, Math.ceil((hideAtMs - nowMs) / 1000));
-  return remainingSeconds === 0 ? "hiding now" : `hiding in ${remainingSeconds}s`;
+export function recentToolCallCountdown(recent: RecentToolCall, nowMs: number): RecentToolCallCountdown {
+  const ttlMs = recentToolCallTtlMs(recent.record.status) ?? 0;
+  const remainingMs = Math.max(0, recent.hideAtMs - nowMs);
+  const remainingSeconds = Math.ceil(remainingMs / 1000);
+  const progressPercent = ttlMs === 0 ? 0 : Math.max(0, Math.min(100, (remainingMs / ttlMs) * 100));
+  return {
+    label: remainingSeconds === 0 ? "Auto-hides now" : `Auto-hides in ${remainingSeconds}s`,
+    progressPercent,
+    remainingSeconds,
+  };
 }
 
 export function terminalStatusLabel(status: ToolCallRecord["status"]): string {

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -1,13 +1,13 @@
 import { Badge, Button, Group, SegmentedControl, Stack, Text } from "@mantine/core";
-import type { ReactNode } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 
 import {
   approvalDisplayFields,
   approvalQueueItems,
-  formatHideCountdown,
   geolocationApprovalBody,
   geolocationApprovalTitle,
+  recentToolCallCountdown,
   type GeolocationApproval,
   type RecentToolCall,
   terminalStatusLabel,
@@ -15,7 +15,7 @@ import {
 import type { McpOperatorAuthStatus, PendingApproval, ToolCallRecord } from "./client.ts";
 import { ACTION_COLOR } from "./theme.ts";
 
-export type ShellDrawerTab = "approvals" | "console";
+export type ShellDrawerTab = "approvals" | "access";
 
 export interface ShellDrawerProps {
   opened: boolean;
@@ -48,8 +48,6 @@ export interface ShellControlsProps {
   pendingCount: number;
   opened: boolean;
   activeTab: ShellDrawerTab;
-  geoGranted: boolean;
-  tracking: boolean;
   onOpenTab: (tab: ShellDrawerTab) => void;
 }
 
@@ -83,14 +81,27 @@ function statusColor(status: ToolCallRecord["status"]): string {
   return "blue";
 }
 
-export function ShellControls({
-  pendingCount,
-  opened,
-  activeTab,
-  geoGranted,
-  tracking,
-  onOpenTab,
-}: ShellControlsProps) {
+function openOnCardKeyDown(e: KeyboardEvent<HTMLElement>, onOpen: () => void) {
+  if (e.key !== "Enter" && e.key !== " ") return;
+  e.preventDefault();
+  onOpen();
+}
+
+function RecentCountdown({ recent, nowMs }: { recent: RecentToolCall; nowMs: number }) {
+  const countdown = recentToolCallCountdown(recent, nowMs);
+  return (
+    <div className="haku-shell-countdown" aria-label={countdown.label}>
+      <Text size="xs" c="dimmed">
+        {countdown.label}
+      </Text>
+      <div className="haku-shell-countdown-track" aria-hidden="true">
+        <div className="haku-shell-countdown-fill" style={{ width: `${countdown.progressPercent}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function ShellControls({ pendingCount, opened, activeTab, onOpenTab }: ShellControlsProps) {
   return (
     <Group className="haku-shell-controls" gap="xs" style={{ zIndex: PANEL_Z - 1 }}>
       <Button
@@ -107,14 +118,6 @@ export function ShellControls({
         }
       >
         Approvals
-      </Button>
-      <Button
-        size="xs"
-        variant={opened && activeTab === "console" ? "filled" : "default"}
-        color={tracking ? "teal" : geoGranted ? "blue" : "gray"}
-        onClick={() => onOpenTab("console")}
-      >
-        Console
       </Button>
     </Group>
   );
@@ -263,25 +266,42 @@ function ToolApprovalCard({
   const fields = approvalDisplayFields(approval);
   const armed = useArmed(`card:${approval.tool_call_id}`);
   return (
-    <section className={`haku-shell-card haku-shell-approval-card ${selected ? "haku-shell-card-active" : ""}`}>
-      <Group justify="space-between" align="flex-start" gap="sm">
-        <Stack gap={2}>
-          <Text fw={600} size="sm">
-            {fields.title}
-          </Text>
-          <Text size="xs" c="dimmed">
-            {fields.serverId}.{fields.toolName}
-          </Text>
-          <Text size="xs">{fields.rationale || fields.argumentSummary}</Text>
-        </Stack>
-        <Badge color={deciding ? "blue" : "yellow"} variant="light">
-          {deciding ? "Running" : "Pending"}
-        </Badge>
-      </Group>
-      <Group justify="flex-end" gap="xs" mt="xs">
-        <Button size="compact-xs" variant="subtle" onClick={onSelect}>
-          Details
-        </Button>
+    <section
+      className={`haku-shell-card haku-shell-approval-card ${selected ? "haku-shell-card-active" : ""}`}
+      onClick={onSelect}
+    >
+      <div
+        className="haku-shell-card-click-target"
+        role="button"
+        tabIndex={0}
+        onClick={(e) => {
+          e.stopPropagation();
+          onSelect();
+        }}
+        onKeyDown={(e) => openOnCardKeyDown(e, onSelect)}
+      >
+        <Group justify="space-between" align="flex-start" gap="sm">
+          <Stack gap={2}>
+            <Text fw={600} size="sm">
+              {fields.title}
+            </Text>
+            <Text size="xs" c="dimmed">
+              {fields.serverId}.{fields.toolName}
+            </Text>
+            <Text size="xs">{fields.rationale || fields.argumentSummary}</Text>
+          </Stack>
+          <Badge color={deciding ? "blue" : "yellow"} variant="light">
+            {deciding ? "Running" : "Pending"}
+          </Badge>
+        </Group>
+      </div>
+      <Group
+        justify="flex-end"
+        gap="xs"
+        mt="xs"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
         <Button size="compact-xs" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
           Deny
         </Button>
@@ -310,25 +330,42 @@ function GeolocationApprovalCard({
 }) {
   const armed = useArmed(`geo-card:${approval.id}`);
   return (
-    <section className={`haku-shell-card haku-shell-approval-card ${selected ? "haku-shell-card-active" : ""}`}>
-      <Group justify="space-between" align="flex-start" gap="sm">
-        <Stack gap={2}>
-          <Text fw={600} size="sm">
-            {geolocationApprovalTitle(approval)}
-          </Text>
-          <Text size="xs" c="dimmed">
-            {approval.mode === "geolocationWatch" ? "Continuous location watch" : "Current location read"}
-          </Text>
-          <Text size="xs">{geolocationApprovalBody(approval)}</Text>
-        </Stack>
-        <Badge color={deciding ? "blue" : "yellow"} variant="light">
-          {deciding ? "Applying" : "Pending"}
-        </Badge>
-      </Group>
-      <Group justify="flex-end" gap="xs" mt="xs">
-        <Button size="compact-xs" variant="subtle" onClick={onSelect}>
-          Details
-        </Button>
+    <section
+      className={`haku-shell-card haku-shell-approval-card ${selected ? "haku-shell-card-active" : ""}`}
+      onClick={onSelect}
+    >
+      <div
+        className="haku-shell-card-click-target"
+        role="button"
+        tabIndex={0}
+        onClick={(e) => {
+          e.stopPropagation();
+          onSelect();
+        }}
+        onKeyDown={(e) => openOnCardKeyDown(e, onSelect)}
+      >
+        <Group justify="space-between" align="flex-start" gap="sm">
+          <Stack gap={2}>
+            <Text fw={600} size="sm">
+              {geolocationApprovalTitle(approval)}
+            </Text>
+            <Text size="xs" c="dimmed">
+              {approval.mode === "geolocationWatch" ? "Continuous location watch" : "Current location read"}
+            </Text>
+            <Text size="xs">{geolocationApprovalBody(approval)}</Text>
+          </Stack>
+          <Badge color={deciding ? "blue" : "yellow"} variant="light">
+            {deciding ? "Applying" : "Pending"}
+          </Badge>
+        </Group>
+      </div>
+      <Group
+        justify="flex-end"
+        gap="xs"
+        mt="xs"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
         <Button size="compact-xs" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
           Deny
         </Button>
@@ -355,29 +392,47 @@ function RecentToolCallCard({
 }) {
   const fields = approvalDisplayFields(recent.record);
   return (
-    <section className={`haku-shell-card haku-shell-approval-card ${selected ? "haku-shell-card-active" : ""}`}>
-      <Group justify="space-between" align="flex-start" gap="sm">
-        <Stack gap={2}>
-          <Text fw={600} size="sm">
-            {fields.title}
-          </Text>
-          <Text size="xs" c="dimmed">
-            {fields.serverId}.{fields.toolName} · {formatHideCountdown(recent.hideAtMs, nowMs)}
-          </Text>
-          {recent.record.error && (
-            <Text size="xs" c="red">
-              {recent.record.error}
+    <section
+      className={`haku-shell-card haku-shell-approval-card ${selected ? "haku-shell-card-active" : ""}`}
+      onClick={onSelect}
+    >
+      <div
+        className="haku-shell-card-click-target"
+        role="button"
+        tabIndex={0}
+        onClick={(e) => {
+          e.stopPropagation();
+          onSelect();
+        }}
+        onKeyDown={(e) => openOnCardKeyDown(e, onSelect)}
+      >
+        <Group justify="space-between" align="flex-start" gap="sm">
+          <Stack gap={2}>
+            <Text fw={600} size="sm">
+              {fields.title}
             </Text>
-          )}
-        </Stack>
-        <Badge color={statusColor(recent.record.status)} variant="light">
-          {terminalStatusLabel(recent.record.status)}
-        </Badge>
-      </Group>
-      <Group justify="flex-end" gap="xs" mt="xs">
-        <Button size="compact-xs" variant="subtle" onClick={onSelect}>
-          Details
-        </Button>
+            <Text size="xs" c="dimmed">
+              {fields.serverId}.{fields.toolName}
+            </Text>
+            {recent.record.error && (
+              <Text size="xs" c="red">
+                {recent.record.error}
+              </Text>
+            )}
+          </Stack>
+          <Badge color={statusColor(recent.record.status)} variant="light">
+            {terminalStatusLabel(recent.record.status)}
+          </Badge>
+        </Group>
+        <RecentCountdown recent={recent} nowMs={nowMs} />
+      </div>
+      <Group
+        justify="flex-end"
+        gap="xs"
+        mt="xs"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
         <Button size="compact-xs" variant="subtle" color="gray" onClick={onDismiss}>
           Dismiss
         </Button>
@@ -386,7 +441,8 @@ function RecentToolCallCard({
   );
 }
 
-function RecentToolCallDetail({ record }: { record: ToolCallRecord }) {
+function RecentToolCallDetail({ recent, nowMs }: { recent: RecentToolCall; nowMs: number }) {
+  const record = recent.record;
   const fields = approvalDisplayFields(record);
   return (
     <section className="haku-shell-card haku-shell-card-selected">
@@ -402,6 +458,7 @@ function RecentToolCallDetail({ record }: { record: ToolCallRecord }) {
             {terminalStatusLabel(record.status)}
           </Badge>
         </Group>
+        <RecentCountdown recent={recent} nowMs={nowMs} />
         {record.error && (
           <Text size="sm" c="red">
             {record.error}
@@ -474,6 +531,8 @@ function ApprovalsTab({
       ? recentToolCalls.find((recent) => recent.record.tool_call_id === selectedRecentToolCallId)
       : null;
   const deciding = new Set(decidingApprovalIds);
+  const hasPending = items.length > 0;
+  const hasRecent = recentToolCalls.length > 0;
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
@@ -500,24 +559,20 @@ function ApprovalsTab({
           onDeny={() => onDenyGeolocation(selectedItem.approval)}
         />
       )}
-      {selectedRecent && <RecentToolCallDetail record={selectedRecent.record} />}
-      {!selectedItem && !selectedRecent && (
+      {selectedRecent && <RecentToolCallDetail recent={selectedRecent} nowMs={nowMs} />}
+      {!selectedItem && !selectedRecent && !hasPending && !hasRecent && (
         <section className="haku-shell-card">
           <Text size="sm" c="dimmed">
-            No pending approvals.
+            No approvals pending.
           </Text>
         </section>
       )}
-      <Stack gap="xs">
-        <Text fw={600} size="sm">
-          Pending
-        </Text>
-        {items.length === 0 ? (
-          <Text size="sm" c="dimmed">
-            Nothing needs a decision.
+      {hasPending && (
+        <Stack gap="xs">
+          <Text fw={600} size="sm">
+            Pending
           </Text>
-        ) : (
-          items.map((item) =>
+          {items.map((item) =>
             item.kind === "tool" ? (
               <ToolApprovalCard
                 key={item.id}
@@ -539,10 +594,10 @@ function ApprovalsTab({
                 onDeny={() => onDenyGeolocation(item.approval)}
               />
             )
-          )
-        )}
-      </Stack>
-      {recentToolCalls.length > 0 && (
+          )}
+        </Stack>
+      )}
+      {hasRecent && (
         <Stack gap="xs">
           <Text fw={600} size="sm">
             Recent
@@ -563,7 +618,7 @@ function ApprovalsTab({
   );
 }
 
-function ConsoleTab({
+function AccessTab({
   geoGranted,
   tracking,
   onWithdrawGeolocation,
@@ -584,30 +639,21 @@ function ConsoleTab({
   return (
     <Stack gap="md">
       <section className="haku-shell-card">
-        <Group justify="space-between" align="flex-start" gap="sm">
-          <Stack gap={4}>
-            <Text fw={600} size="sm">
-              Location sharing
-            </Text>
-            <Text size="sm" c="dimmed">
-              {geoGranted
-                ? tracking
-                  ? "Haku is receiving live location updates."
-                  : "Haku may request your location without another approval until withdrawn."
-                : "Not shared. Haku will request approval when it needs your location."}
-            </Text>
-          </Stack>
-          <Badge color={tracking ? "teal" : geoGranted ? "blue" : "gray"} variant="light">
-            {tracking ? "Live" : geoGranted ? "Allowed" : "Off"}
-          </Badge>
-        </Group>
-        {geoGranted && (
-          <Group justify="flex-end" mt="sm">
-            <Button size="xs" variant="light" color="red" onClick={onWithdrawGeolocation}>
-              {tracking ? "Stop & withdraw" : "Withdraw"}
-            </Button>
+        <Group justify="space-between" align="center" gap="sm" wrap="nowrap">
+          <Text fw={600} size="sm">
+            Location sharing
+          </Text>
+          <Group gap="xs" justify="flex-end" wrap="nowrap">
+            <Badge color={tracking ? "teal" : geoGranted ? "blue" : "gray"} variant="light">
+              {tracking ? "Live" : geoGranted ? "Allowed" : "Off"}
+            </Badge>
+            {geoGranted && (
+              <Button size="compact-xs" variant="light" color="red" onClick={onWithdrawGeolocation}>
+                {tracking ? "Stop & withdraw" : "Withdraw"}
+              </Button>
+            )}
           </Group>
-        )}
+        </Group>
       </section>
       <section className="haku-shell-card">
         <Group justify="space-between" align="center">
@@ -678,35 +724,32 @@ export function ShellDrawer(props: ShellDrawerProps) {
     <div className="haku-shell-overlay" style={{ zIndex: PANEL_Z }} aria-hidden={!props.opened}>
       {props.opened && (
         <aside className="haku-shell-drawer" aria-label="Haku console controls">
-          <Group justify="space-between" align="center" className="haku-shell-header">
-            <Stack gap={1}>
+          <section className="haku-shell-card haku-shell-drawer-nav">
+            <Group justify="space-between" align="center" className="haku-shell-header">
               <Text fw={700}>Haku console</Text>
-              <Text size="xs" c="dimmed">
-                Trusted shell controls
-              </Text>
-            </Stack>
-            <Button size="compact-xs" variant="subtle" onClick={props.onClose}>
-              Close
-            </Button>
-          </Group>
-          <SegmentedControl
-            fullWidth
-            size="xs"
-            value={props.activeTab}
-            onChange={(value) => props.onOpenTab(value as ShellDrawerTab)}
-            data={[
-              {
-                value: "approvals",
-                label: `Approvals (${props.pendingApprovals.length + props.geolocationApprovals.length})`,
-              },
-              { value: "console", label: "Console" },
-            ]}
-          />
+              <Button size="compact-xs" variant="subtle" onClick={props.onClose}>
+                Close
+              </Button>
+            </Group>
+            <SegmentedControl
+              fullWidth
+              size="xs"
+              value={props.activeTab}
+              onChange={(value) => props.onOpenTab(value as ShellDrawerTab)}
+              data={[
+                {
+                  value: "approvals",
+                  label: `Approvals (${props.pendingApprovals.length + props.geolocationApprovals.length})`,
+                },
+                { value: "access", label: "Access" },
+              ]}
+            />
+          </section>
           <div className="haku-shell-scroll">
             {props.activeTab === "approvals" ? (
               <ApprovalsTab {...props} />
             ) : (
-              <ConsoleTab
+              <AccessTab
                 geoGranted={props.geoGranted}
                 tracking={props.tracking}
                 onWithdrawGeolocation={props.onWithdrawGeolocation}

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -2,10 +2,9 @@ import { Anchor } from "@mantine/core";
 import { useEffect, useRef, useState } from "react";
 
 import {
+  approvalQueueItems,
   geolocationApprovalQueueId,
   makeRecentToolCall,
-  nextSelectedApprovalId,
-  sortApprovalsNewestFirst,
   toolApprovalQueueId,
   type GeolocationApproval,
   type RecentToolCall,
@@ -173,8 +172,8 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
     setDrawerOpen(true);
   }
 
-  function openApproval(id: string) {
-    setSelectedApprovalId(id);
+  function openApprovalQueueCompact() {
+    setSelectedApprovalId(null);
     setSelectedRecentToolCallId(null);
     openDrawerTab("approvals");
   }
@@ -194,7 +193,7 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
     toolApprovalsRef.current = approvals;
     setToolApprovals(approvals);
     if (newApprovals.length > 0) {
-      openApproval(toolApprovalQueueId(sortApprovalsNewestFirst(newApprovals)[0].tool_call_id));
+      openApprovalQueueCompact();
     }
   }
 
@@ -216,12 +215,11 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
   }
 
   function finishToolDecision(record: ToolCallRecord) {
-    const remaining = removeToolApproval(record.tool_call_id);
+    removeToolApproval(record.tool_call_id);
     addRecentToolCall(record);
     setDeciding(toolApprovalQueueId(record.tool_call_id), false);
-    const nextApprovalId = nextSelectedApprovalId(remaining, geolocationApprovalsRef.current, null);
-    setSelectedApprovalId(nextApprovalId);
-    setSelectedRecentToolCallId(nextApprovalId ? null : record.tool_call_id);
+    setSelectedApprovalId(null);
+    setSelectedRecentToolCallId(null);
   }
 
   function addGeolocationApproval(mode: GeolocationApproval["mode"], id: string, options?: GeolocationOptions) {
@@ -229,7 +227,7 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
     const remaining = [approval, ...geolocationApprovalsRef.current.filter((existing) => existing.id !== id)];
     geolocationApprovalsRef.current = remaining;
     setGeolocationApprovals(remaining);
-    openApproval(geolocationApprovalQueueId(id));
+    openApprovalQueueCompact();
   }
 
   function removeGeolocationApproval(id: string): GeolocationApproval[] {
@@ -240,10 +238,9 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
   }
 
   function advanceAfterGeolocation(id: string) {
-    const remaining = removeGeolocationApproval(id);
-    const nextApprovalId = nextSelectedApprovalId(toolApprovalsRef.current, remaining, null);
-    setSelectedApprovalId(nextApprovalId);
-    if (!nextApprovalId) setSelectedRecentToolCallId(null);
+    removeGeolocationApproval(id);
+    setSelectedApprovalId(null);
+    setSelectedRecentToolCallId(null);
   }
 
   function refreshToolApprovals(notifyPeers = false) {
@@ -396,7 +393,8 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
   }, [geolocationApprovals]);
 
   useEffect(() => {
-    setSelectedApprovalId((selected) => nextSelectedApprovalId(toolApprovals, geolocationApprovals, selected));
+    const activeApprovalIds = new Set(approvalQueueItems(toolApprovals, geolocationApprovals).map((item) => item.id));
+    setSelectedApprovalId((selected) => (selected && activeApprovalIds.has(selected) ? selected : null));
   }, [geolocationApprovals, toolApprovals]);
 
   useEffect(() => {
@@ -528,8 +526,6 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
         pendingCount={toolApprovals.length + geolocationApprovals.length}
         opened={drawerOpen}
         activeTab={drawerTab}
-        geoGranted={geoGranted}
-        tracking={tracking}
         onOpenTab={openDrawerTab}
       />
       <ShellDrawer

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -113,22 +113,24 @@
   flex-direction: column;
   gap: 0.75rem;
   pointer-events: auto;
-  border: 1px solid var(--haku-border);
-  border-radius: 8px;
-  background: var(--haku-panel-bg);
   color: var(--mantine-color-text);
-  box-shadow: 0 18px 50px var(--haku-shell-shadow);
-  padding: 0.85rem;
 }
 
 .haku-shell-header {
   flex: 0 0 auto;
 }
 
+.haku-shell-drawer-nav {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
 .haku-shell-scroll {
   min-height: 0;
   overflow: auto;
-  padding-right: 0.1rem;
+  padding: 0.1rem 0.15rem 0.75rem 0.1rem;
 }
 
 .haku-shell-card,
@@ -136,24 +138,63 @@
   border: 1px solid var(--haku-border);
   border-radius: 8px;
   background: color-mix(in srgb, var(--haku-panel-bg) 88%, var(--haku-shell-muted-bg));
+  box-shadow: 0 10px 32px var(--haku-shell-shadow);
   padding: 0.75rem;
 }
 
 .haku-shell-subcard {
   background: var(--haku-shell-muted-bg);
+  box-shadow: none;
 }
 
 .haku-shell-approval-card {
   display: block;
   width: 100%;
   color: inherit;
+  cursor: pointer;
   text-align: left;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.haku-shell-card-click-target {
+  cursor: pointer;
+}
+
+.haku-shell-card-click-target:focus-visible {
+  outline: 2px solid var(--mantine-color-teal-5);
+  outline-offset: 2px;
 }
 
 .haku-shell-card-active,
 .haku-shell-card-selected {
   border-color: var(--mantine-color-teal-5);
-  background: var(--haku-shell-active-bg);
+  background: color-mix(in srgb, var(--haku-panel-bg) 92%, var(--haku-shell-muted-bg));
+  box-shadow:
+    0 0 0 1px var(--mantine-color-teal-5),
+    0 10px 32px var(--haku-shell-shadow);
+}
+
+.haku-shell-countdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.45rem;
+}
+
+.haku-shell-countdown-track {
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--mantine-color-dimmed) 24%, transparent);
+}
+
+.haku-shell-countdown-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--mantine-color-teal-5);
+  transition: width 200ms linear;
 }
 
 .haku-shell-fields {


### PR DESCRIPTION
## Summary
- make the approval drawer a transparent right-side overlay of floating cards
- keep pending tool and geolocation approvals compact by default, with click-to-expand details
- show recent OK/denied/error feedback with auto-hide countdown labels and slim progress bars
- remove the separate top-right Console summon button and relabel the secondary tab as Access

## Tests
- direnv exec . pre-commit run --files haku/console/frontend/approval_state.ts haku/console/frontend/approval_state.test.ts haku/console/frontend/console_panel.tsx haku/console/frontend/haku_ui_embed.tsx haku/console/frontend/styles.src.css
- direnv exec . bbr test //haku/console/frontend:tsc_test //haku/console/frontend:bridge_test
- direnv exec . bbr build //haku/console/frontend:bundle