### PR TITLE
haku-console: ship a WebSocket impl so /api/approvals/ws works

### DIFF
--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -109,6 +109,9 @@ py_library(
         "@pypi//fastapi",
         "@pypi//fastapi_csrf_protect",
         "@pypi//uvicorn",
+        # uvicorn needs a WebSocket protocol impl at runtime or every /api/approvals/ws
+        # upgrade fails ("Unsupported upgrade request") — the drawer's live channel (#2977).
+        "@pypi//websockets",
     ],
 )
 


### PR DESCRIPTION
Fixes the operator-reported browser error `WebSocket connection to 'wss://haku.allegedly.works/api/approvals/ws' failed`.

The approval drawer (#2977) connects to `WebSocket /api/approvals/ws`, and the route + tests exist — but the image's uvicorn had **no WebSocket protocol implementation**: `websockets` is in `pyproject.toml`, yet was never declared in the console's Bazel deps, so it never reached the image. Starlette's `TestClient` uses an in-process transport that doesn't need one, which is why the websocket tests pass while every real browser upgrade fails.

One-line fix: declare `@pypi//websockets` on the console app target (with a comment naming the failure mode so it doesn't get "cleaned up").

Verified root cause by inspection: no `websockets`/`wsproto` anywhere in `haku/console/BUILD.bazel` while the frontend + route + docs all reference the ws channel; REST catch-up polling is why the drawer still mostly worked.

(The other console-log noise the operator saw — `Unrecognized Content-Security-Policy directive 'webrtc'` — is the documented, intentional CSP3 future-proofing in `cluster/k8s/authentik/proxy-routes/haku-ui-httproute.yaml`; no change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG8ovuxk6GJSgb6DCyL2f8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CG8ovuxk6GJSgb6DCyL2f8)_