### PR TITLE
nix/claude-desktop: fix keyring persistence + enable Cowork microVM

### DIFF
--- a/nix/nixos/hosts/rugged/default.nix
+++ b/nix/nixos/hosts/rugged/default.nix
@@ -28,6 +28,7 @@ in
     ../../modules/gui.nix
     ../../modules/workstation.nix
     ../../modules/bazel
+    ../../modules/claude-desktop.nix
     ../../modules/system-inspection-sudo.nix
     ../../modules/k8s-worker.nix
     ./ipu7-camera.nix
@@ -61,6 +62,10 @@ in
 
   # IPU7 webcam (Intel Lunar Lake, OV08X40 sensor)
   ducktape.ipu7Camera.enable = true;
+
+  # Claude Desktop Cowork sandboxed-microVM feature (QEMU firmware + virtiofsd
+  # at the Debian /usr paths the app probes).
+  ducktape.cowork.enable = true;
 
   # Local LLM inference (Arc GPU + NPU)
   ducktape.localLlm.arc.enable = true;

--- a/nix/nixos/modules/claude-desktop.nix
+++ b/nix/nixos/modules/claude-desktop.nix
@@ -1,0 +1,52 @@
+# Claude Desktop "Cowork" runs agent tools in a local QEMU microVM (smol-bin
+# image + a virtiofsd bundled inside the app). Before starting a VM it gates on
+# a presence check that probes three hard-coded Debian paths:
+#
+#   qemuPath       -> `qemu-system-x86_64` on PATH
+#   firmwarePath   -> /usr/share/OVMF/OVMF_CODE_4M.fd, then OVMF_CODE.fd
+#   virtiofsdPath  -> /usr/libexec/virtiofsd, then /usr/bin/virtiofsd
+#
+# None of those resolve on NixOS: /usr/share and /usr/libexec aren't populated
+# (only /usr/bin is, via a read-only envfs mount), nixpkgs ships no standalone
+# virtiofsd, and the detection list does NOT include the virtiofsd bundled with
+# the app. So without help Cowork reports "Virtualization isn't fully set up"
+# and refuses to start. The detection source lives in app.asar (minified): the
+# firmware probe list `ogi`, the virtiofsd list `sgi`, and a VARS-template
+# derivation `Qgi = p => p.replace("OVMF_CODE","OVMF_VARS")`.
+#
+# This module satisfies the firmware + virtiofsd checks by symlinking those
+# exact /usr paths into the nix store via tmpfiles. qemu-system-x86_64 is put on
+# PATH by the claude-desktop package wrapper (see packages/claude-desktop.nix).
+# /dev/kvm access is host-dependent; on hosts where it is 0666 (default NixOS
+# GNOME) no group setup is needed.
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  # Same callPackage the home-manager package set uses, so this resolves to the
+  # identical store path the user runs — and thus to its bundled virtiofsd.
+  claudeDesktop = pkgs.callPackage ../../packages/claude-desktop.nix { };
+  ovmf = pkgs.OVMF;
+in
+{
+  options.ducktape.cowork = {
+    enable = lib.mkEnableOption "Claude Desktop Cowork microVM support (OVMF firmware + bundled virtiofsd at the Debian /usr paths the app probes)";
+  };
+
+  config = lib.mkIf config.ducktape.cowork.enable {
+    systemd.tmpfiles.rules = [
+      "d /usr/libexec 0755 root root -"
+      "L+ /usr/libexec/virtiofsd - - - - ${claudeDesktop}/lib/claude-desktop/resources/virtiofsd"
+
+      "d /usr/share/OVMF 0755 root root -"
+      # The probe tries OVMF_CODE_4M.fd first and falls back to OVMF_CODE.fd;
+      # nixpkgs only ships the 2MB OVMF_CODE.fd, which boots the smol-bin guest.
+      "L+ /usr/share/OVMF/OVMF_CODE.fd - - - - ${ovmf.fd}/FV/OVMF_CODE.fd"
+      # Qgi derives the VARS template from the CODE path by CODE->VARS replace.
+      "L+ /usr/share/OVMF/OVMF_VARS.fd - - - - ${ovmf.fd}/FV/OVMF_VARS.fd"
+    ];
+  };
+}

--- a/nix/packages/claude-desktop.nix
+++ b/nix/packages/claude-desktop.nix
@@ -35,6 +35,12 @@ pkgs.stdenv.mkDerivation {
   # libgbm1, libsecret-1-0, libxtst6, ...). autoPatchelf patches DT_NEEDED;
   # the GL/X libs are also dlopen'd by Electron, so makeWrapper exposes them on
   # LD_LIBRARY_PATH too (see tana-outliner.nix for the same shape).
+  #
+  # libsecret is the non-obvious one: Electron's safeStorage/OSCrypt dlopens
+  # libsecret-1.so.0 (it is NOT a DT_NEEDED), so without it on LD_LIBRARY_PATH
+  # the dlopen fails and safeStorage.isEncryptionAvailable() returns false —
+  # Claude Desktop then refuses to persist sign-in with a misleading "install a
+  # system keyring" prompt even though gnome-keyring is running and unlocked.
   buildInputs = with pkgs; [
     alsa-lib
     at-spi2-atk
@@ -85,7 +91,11 @@ pkgs.stdenv.mkDerivation {
     cp -r usr/share $out/share
     cp -r usr/lib/claude-desktop $out/lib/claude-desktop
 
-    # Wrap the real binary so dlopen'd GL/X libs resolve.
+    # Wrap the real binary so dlopen'd GL/X libs — and libsecret (dlopen'd by
+    # Electron's OSCrypt for safeStorage; see buildInputs note above) — resolve.
+    # qemu_kvm goes on PATH so the "Cowork" sandboxed-microVM feature's presence
+    # check finds qemu-system-x86_64 (firmware + virtiofsd are handled at the
+    # system level by the ducktape.cowork NixOS module).
     mkdir -p $out/bin
     makeWrapper $out/lib/claude-desktop/claude-desktop $out/bin/claude-desktop \
       --prefix LD_LIBRARY_PATH : "${
@@ -94,6 +104,7 @@ pkgs.stdenv.mkDerivation {
           [
             libGL
             libdrm
+            libsecret
             libxkbcommon
             mesa
             xorg.libX11
@@ -101,7 +112,8 @@ pkgs.stdenv.mkDerivation {
             xorg.libxcb
           ]
         )
-      }"
+      }" \
+      --prefix PATH : "${lib.makeBinPath [ pkgs.qemu_kvm ]}"
 
     # Point the desktop entry's Exec lines at our wrapper. Match the three
     # `Exec=claude-desktop <arg>` lines (main + NewChat/NewCode actions) without


### PR DESCRIPTION
Two NixOS packaging fixes for the Claude Desktop Electron app (packaged from the apt `.deb`), each found by dissecting the bundled `app.asar`.

## 1. "Your sign-in won't be saved" (keyring)
Chromium `dlopen()`s `libsecret-1.so.0` for `safeStorage` rather than linking it, so `autoPatchelf` never adds it to `RUNPATH` and the wrapper's `LD_LIBRARY_PATH` missed it. The dlopen failed → `safeStorage.isEncryptionAvailable()` returned false → a misleading "install a system keyring" prompt, even though gnome-keyring was running and unlocked. Verified by proving the dlopen fails in the app env and succeeds with libsecret on the path.

**Fix:** add `libsecret` to the wrapper `LD_LIBRARY_PATH`.

## 2. Cowork "Virtualization isn't fully set up"
The presence check gates on three **hardcoded Debian paths**, none of which exist on NixOS (`/usr/share` and `/usr/libexec` are unpopulated; the app's bundled virtiofsd isn't in the probe list; nixpkgs ships no standalone virtiofsd):
- `qemu-system-x86_64` on `PATH`
- `/usr/share/OVMF/OVMF_CODE[_4M].fd`
- `/usr/libexec/virtiofsd`

Patching `app.asar` was rejected — it carries ASAR-integrity blocks + the fuse machinery (`validateBufferIntegrity` → `process.exit(1)`).

**Fix:**
- `qemu_kvm` on the wrapper `PATH` (ships `qemu-system-x86_64`).
- New `ducktape.cowork` NixOS module symlinks the OVMF firmware (`${pkgs.OVMF.fd}/FV/…`, probe falls through `_4M` → `OVMF_CODE.fd`; VARS via the app's `Qgi = p => p.replace("OVMF_CODE","OVMF_VARS")`) and the **bundled** virtiofsd into the probed `/usr` paths via tmpfiles. Enabled on **rugged**; iguana/wyrm2 opt in with `ducktape.cowork.enable = true`.

`/dev/kvm` is `0666` on rugged, so no group setup needed.

## Verified
- Files parse; `qemu_kvm`, `OVMF` (`outputs = [ "out" "fd" ]`), and the package all evaluate.
- Deployed on rugged: all three detection checks pass; after a full restart of Claude Desktop, Cowork reports supported and boots. (Electron tray apps survive a window close, so a cold restart — `pkill -f claude-desktop` — is required.)