### PR TITLE
nix: enable ducktape.cowork on iguana and wyrm2

### DIFF
--- a/nix/nixos/hosts/iguana/default.nix
+++ b/nix/nixos/hosts/iguana/default.nix
@@ -33,11 +33,16 @@ in
     ../../modules/workstation.nix
     ../../modules/bazel
     ../../modules/system-inspection-sudo.nix
+    ../../modules/claude-desktop.nix
     ../../modules/k8s-worker.nix
   ];
 
   # Passwordless sudo for system inspection commands
   ducktape.systemInspectionSudo.enable = true;
+
+  # Claude Desktop Cowork sandboxed-microVM feature (QEMU firmware + virtiofsd
+  # at the Debian /usr paths the app probes).
+  ducktape.cowork.enable = true;
 
   # TODO: enable Attic substituter for cache.allegedly.works/{main,gaffer}.
   # Reader JWT is already auto-rotated into secrets/hosts/iguana-attic.yaml

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -23,6 +23,7 @@ in
     ../../modules/workstation.nix
     ../../modules/bazel
     ../../modules/system-inspection-sudo.nix
+    ../../modules/claude-desktop.nix
     ../../modules/k8s-worker.nix
     ../../modules/gpu-monitor.nix
     ../../modules/attic-substituter.nix
@@ -30,6 +31,10 @@ in
 
   # Passwordless sudo for system inspection commands
   ducktape.systemInspectionSudo.enable = true;
+
+  # Claude Desktop Cowork sandboxed-microVM feature (QEMU firmware + virtiofsd
+  # at the Debian /usr paths the app probes).
+  ducktape.cowork.enable = true;
 
   # Pull substituter for cache.allegedly.works/{main,gaffer}. Reader JWT is
   # auto-rotated by attic-rotate-wyrm2-reader CronJob; the SOPS file is


### PR DESCRIPTION
Follow-up to #2982 (merged): enable `ducktape.cowork` on the two remaining claude-desktop hosts so Cowork works there too.

The `ducktape.cowork` module (merged in #2982) is DE-agnostic — it only provides the OVMF firmware + bundled virtiofsd at the hardcoded `/usr` paths the app probes (plus `qemu-system-x86_64` on the wrapper `PATH` from the claude-desktop package) — so it applies under both GNOME (iguana) and sway (wyrm2). `claude-desktop` is already installed on both hosts; this just imports the module and sets `ducktape.cowork.enable = true`.

BAZEL_TEST_INVOCATIONS=none: nix-only, no Bazel targets