### PR TITLE
nix: awatcher for ActivityWatch window capture (all hosts)

### DIFF
--- a/debug/activitywatch_window_gnome_wayland.md
+++ b/debug/activitywatch_window_gnome_wayland.md
@@ -1,0 +1,152 @@
+# ActivityWatch window bucket empty on rugged (GNOME Wayland)
+
+Investigation/RCA — 2026-07-07. rugged = ThinkPad, GNOME Shell 49.4, Wayland-only.
+
+## TL;DR
+
+The `aw-watcher-window_rugged` bucket (local and the synced
+`aw-watcher-window_rugged-synced-from-rugged` on cluster) has **zero events**. AFK and
+Chrome-tab buckets flow fine, so presence + browser-focus are captured; the missing
+signal is "which non-browser app has focus" — the richest prioritization input.
+
+Root cause is on-device, watcher-side (not sync): the stock `aw-watcher-window` cannot
+see windows on GNOME Wayland. **A maintained, maintainer-endorsed solution exists and is
+packaged in nixpkgs**: `awatcher` (Rust binary) + the `focused-window-d-bus` GNOME Shell
+extension. Both ActivityWatch co-founders redirect GNOME-Wayland users to this combo, and
+it's verified on GNOME Shell 49.0.
+
+## Evidence (verified on rugged, 2026-07-07)
+
+Local aw-server (`127.0.0.1:5600`) bucket event counts:
+
+```text
+aw-watcher-window_rugged/events/count   → 0      ← empty
+aw-watcher-afk_rugged/events/count      → 3      ← control, working
+aw-watcher-web-chrome_localhost         → populated
+```
+
+The window bucket exists (created at aw-qt startup) but `metadata.start`/`end` are
+`null` and `events` is `null` — the watcher registered the bucket and never wrote a
+sample.
+
+Session + watcher process:
+
+```text
+XDG_SESSION_TYPE=wayland   XDG_CURRENT_DESKTOP=GNOME   ShellVersion=49.4
+aw-watcher-window-0.13.2 running as a child of aw-qt (PID via .aw-watcher-window-wrapped)
+```
+
+The watcher throws on every poll (journal, once per second):
+
+```text
+aw-qt.desktop[…]: [ERROR]: Exception thrown while trying to get active window (aw_watcher_window.main:133)
+  … aw_watcher_window/lib.py:64 get_current_window
+  … aw_watcher_window/lib.py:17 get_current_window_linux
+  … aw_watcher_window/xlib.py:85 get_window_name
+```
+
+Its only window-detection dependency is `python3.13-xlib-0.33` — no dbus/gtk/wnck
+backend. It reads `_NET_ACTIVE_WINDOW` off the X root window, which Mutter-on-Wayland
+does not maintain for native Wayland clients, so it throws and writes nothing.
+
+## Why every out-of-process method fails on GNOME 49
+
+Every method an _external_ process can use to read the focused window is closed off on
+GNOME 49 (all probed on rugged):
+
+| Method                                                                  | Result                                                                                              |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| stock `aw-watcher-window` (xlib `_NET_ACTIVE_WINDOW`)                   | throws every poll                                                                                   |
+| `aw-watcher-window-wayland` (wlroots `wlr-foreign-toplevel-management`) | Mutter does not implement the protocol → nothing                                                    |
+| `org.gnome.Shell.Eval` (JS `global.display.focus_window`)               | `(false, '')` — disabled in `Mode="user"` (gated to `unsafe-mode` since GNOME 41)                   |
+| `org.gnome.Shell.Introspect.GetWindows()`                               | `org.freedesktop.DBus.Error.AccessDenied: GetWindows is not allowed` (whitelisted since GNOME 3.32) |
+
+These closures all target _out-of-process_ introspection. The one path that works is code
+running **in-process inside `gnome-shell`** (a Shell extension), which reads
+`global.display.focus_window` directly via GJS and re-exports it on a custom session-bus
+interface that an external watcher polls.
+
+## The solution: `awatcher` + `focused-window-d-bus`
+
+- **Extension** `focused-window-d-bus` (flexagoon, e.g.o #5592,
+  <https://github.com/flexagoon/focused-window-dbus>) — runs in-process, exports
+  `org.gnome.shell.extensions.FocusedWindow.Get()` at
+  `/org/gnome/shell/extensions/FocusedWindow`, returning the focused window's
+  `{app, title}`.
+- **Watcher** `awatcher` (2e3s, Rust, <https://github.com/2e3s/awatcher>) — polls the
+  extension's D-Bus method once per second and POSTs heartbeats to aw-server at
+  `127.0.0.1:5600`. Also handles AFK via `org.gnome.Mutter.IdleMonitor` (no extension
+  needed for AFK). Default `--poll-time-window 1s`, `--host 127.0.0.1 --port 5600`.
+- Writes bucket `aw-watcher-window_<hostname>`, type `currentwindow`, data `{app, title}`
+  — **the same shape as the stock watcher** (contract below), so the existing aw-sync →
+  Syncthing → cluster pipeline populates the synced bucket with zero cluster-side changes.
+
+**Maintainer endorsements**: ErikBjare (`aw-watcher-window#46`, 2024-11-26) and
+johan-bjareholt (forum #3947, 2025-05-24) both redirect GNOME-Wayland users to
+`awatcher` + this extension. Verified working on GNOME Shell 49.0 / Wayland in
+`ActivityWatch/activitywatch#1218` (2026-03-19). The master Wayland tracking issue
+`activitywatch#92` (open since 2017-08-02) documents why no first-party watcher exists:
+the project refuses compositor-specific watchers and is waiting for a freedesktop portal
+protocol Mutter will likely never adopt.
+
+### nixpkgs packaging (verified 2026-07-07)
+
+```text
+pkgs.awatcher                              → awatcher-0.3.1          (upstream 0.3.3; minor lag)
+pkgs.gnomeExtensions.focused-window-d-bus  → …-focused-window-d-bus-9
+  metadata.json: shell-version ["49"], uuid focused-window-dbus@flexagoon.com   ← loads on GNOME 49
+```
+
+awatcher CLI (`nix run nixpkgs#awatcher -- --help`) confirms default
+`--host 127.0.0.1 --port 5600`, `--poll-time-window 1s`, window + idle, `--no-server`.
+
+## aw-server contract (reference)
+
+Confirmed from the stock watcher source (`aw_watcher_window/main.py`, `lib.py`) and a
+local throwaway-bucket round-trip; `awatcher` writes the same shape:
+
+- Bucket id: `aw-watcher-window_<hostname>` → `aw-watcher-window_rugged`
+- Bucket type: `currentwindow`, client: `aw-watcher-window`, hostname: `rugged`
+- Create (idempotent): `POST /api/0/buckets/aw-watcher-window_rugged` body
+  `{"id":"aw-watcher-window_rugged","type":"currentwindow","client":"aw-watcher-window","hostname":"rugged","data":{}}`
+- Heartbeat: `POST /api/0/buckets/aw-watcher-window_rugged/heartbeat?pulsetime=2` body
+  `{"timestamp":"<iso8601 utc>","data":{"app":"<wm_class>","title":"<title>"}}`
+- `app`/`title` fall back to `"unknown"` when unresolved.
+
+## Options
+
+1. **`awatcher` + `focused-window-d-bus` extension (recommended).** Both already in
+   nixpkgs. Wire into `nix/home/services/activitywatch.nix`:
+   - Add `pkgs.awatcher` + `pkgs.gnomeExtensions.focused-window-d-bus` to the host (rugged)
+     packages.
+   - Enable the extension (`gnome-extensions enable`, or `dconf`
+     `org.gnome.shell enabled-extensions`); needs a one-time logout/login (Wayland can't
+     restart the shell live).
+   - Run `awatcher` as a systemd-user service (it is a standalone binary, not an aw-qt
+     module) pointing at `127.0.0.1:5600`.
+   - Drop `aw-watcher-window` from `aw-qt.toml` `autostart_modules` (stops the per-second
+     journal error spam and bucket-ownership collision).
+   - AFK: `awatcher` produces AFK itself; decide whether to also drop the stock
+     `aw-watcher-afk` (verify which bucket id `awatcher` uses for AFK so the cluster-side
+     `aw-watcher-afk_rugged` sync mapping is preserved) or keep the stock AFK watcher and
+     suppress `awatcher`'s AFK (no CLI flag for that — so the clean cut is to let
+     `awatcher` own both).
+2. **Custom GNOME Shell extension, direct heartbeat.** ~100 LOC GJS reading
+   `global.display.focus_window` and POSTing to aw-server via `imports.gi.Soup`. Only
+   worth it if `awatcher` proves unsuitable — it duplicates what `awatcher` + the
+   extension already do, maintained.
+3. **Log into GNOME-on-Xorg instead of Wayland.** Zero code — stock `aw-watcher-window`
+   works. Cost: lose Wayland (fractional scaling, gestures) and run a legacy/deprecated
+   X11 session on Lunar Lake (see [[project_rugged_gnome_iris_crash]]). Bad trade.
+4. **Do nothing; keep AFK + Chrome-tab only.** Current state. Lose the non-browser-app
+   focus signal.
+
+## Next step
+
+Proceed with Option 1. Open implementation details to nail in the plan: the AFK
+bucket-id question (does `awatcher` write `aw-watcher-afk_rugged` or a different id?),
+the systemd-user service unit for `awatcher`, and the extension-enable mechanism via
+home-manager. Capture lives under `nix/home/services/activitywatch.nix`; cluster
+ingestion documented in `cluster/docs/activitywatch.md`. Other GNOME-Wayland hosts
+(`wyrm2` runs sway → `aw-watcher-window-wayland` would also work there; `iguana`, `atlas`
+if GNOME-Wayland) likely have the same empty-window-bucket issue.

--- a/nix/home/hosts/rugged.nix
+++ b/nix/home/hosts/rugged.nix
@@ -62,6 +62,8 @@ in
     };
   };
 
+  ducktape.activitywatch.watcher = "awatcher";
+
   ducktape.activitywatch.sync = {
     enable = true;
     syncthing = {
@@ -144,6 +146,9 @@ in
   programs.gnome-shell.extensions = [
     { package = pkgs.gnomeExtensions.appindicator; }
     { package = ducktapePackages.aiquota; }
+    # GNOME Wayland has no out-of-process active-window API; awatcher reads focus via
+    # this in-shell extension. See debug/activitywatch_window_gnome_wayland.md.
+    { package = pkgs.gnomeExtensions.focused-window-d-bus; }
   ];
 
   # Enable GNOME fractional scaling (125/150/175%). GNOME gates these steps

--- a/nix/home/hosts/rugged.nix
+++ b/nix/home/hosts/rugged.nix
@@ -62,8 +62,6 @@ in
     };
   };
 
-  ducktape.activitywatch.watcher = "awatcher";
-
   ducktape.activitywatch.sync = {
     enable = true;
     syncthing = {
@@ -146,9 +144,6 @@ in
   programs.gnome-shell.extensions = [
     { package = pkgs.gnomeExtensions.appindicator; }
     { package = ducktapePackages.aiquota; }
-    # GNOME Wayland has no out-of-process active-window API; awatcher reads focus via
-    # this in-shell extension. See debug/activitywatch_window_gnome_wayland.md.
-    { package = pkgs.gnomeExtensions.focused-window-d-bus; }
   ];
 
   # Enable GNOME fractional scaling (125/150/175%). GNOME gates these steps

--- a/nix/home/services/activitywatch.nix
+++ b/nix/home/services/activitywatch.nix
@@ -138,9 +138,11 @@ in
           };
           Service = {
             ExecStart = "${pkgs.awatcher}/bin/awatcher";
-            # aw-server is started by aw-qt (xdg.autostart) at graphical-session time;
-            # retry briefly if awatcher starts before aw-server is listening.
-            Restart = "on-failure";
+            # awatcher exits 0 (not a failure) when the focused-window-d-bus extension
+            # isn't loaded yet (e.g. shell started before the install), and may also
+            # start before aw-qt has aw-server listening. Restart=always retries until
+            # both are up; it runs indefinitely once wired.
+            Restart = "always";
             RestartSec = 5;
           };
           Install = {

--- a/nix/home/services/activitywatch.nix
+++ b/nix/home/services/activitywatch.nix
@@ -7,6 +7,7 @@
 }:
 let
   cfg = config.ducktape.activitywatch;
+  useAwatcher = cfg.watcher == "awatcher";
   toTOML = (pkgs.formats.toml { }).generate;
   syncRoot = cfg.sync.root;
   syncthingCfg = cfg.sync.syncthing;
@@ -32,6 +33,24 @@ let
 in
 {
   options.ducktape.activitywatch = {
+    watcher = lib.mkOption {
+      type = lib.types.enum [
+        "stock"
+        "awatcher"
+      ];
+      default = "stock";
+      description = ''
+        Active-window watcher backend.
+        - `stock`: the xlib `aw-watcher-window` shipped with aw-qt. Produces no events
+          on GNOME/Wayland (Mutter does not maintain `_NET_ACTIVE_WINDOW`).
+        - `awatcher`: the standalone `awatcher` binary — GNOME Wayland via the
+          `focused-window-d-bus` extension, also wlroots/X11. Writes the same
+          `aw-watcher-window_<host>`/`aw-watcher-afk_<host>` buckets as the stock
+          watchers, so aw-sync is unaffected. On a GNOME host you must also add
+          `pkgs.gnomeExtensions.focused-window-d-bus` to `programs.gnome-shell.extensions`.
+      '';
+    };
+
     sync = {
       enable = lib.mkEnableOption "local ActivityWatch capture with aw-sync push into a Syncthing folder";
 
@@ -87,23 +106,48 @@ in
         # Install ActivityWatch from nixpkgs.
         home.packages = [ pkgs.activitywatch ];
 
-        xdg.configFile."activitywatch/aw-watcher-afk/aw-watcher-afk.toml".source =
-          toTOML "aw-watcher-afk.toml"
-            {
-              # Available options: timeout (default 180), poll_time (default 5)
-              aw-watcher-afk = { };
-              # Available options: timeout (default 20), poll_time (default 1)
-              aw-watcher-afk-testing = { };
-            };
+        xdg.configFile."activitywatch/aw-watcher-afk/aw-watcher-afk.toml" = lib.mkIf (!useAwatcher) {
+          source = toTOML "aw-watcher-afk.toml" {
+            # Available options: timeout (default 180), poll_time (default 5)
+            aw-watcher-afk = { };
+            # Available options: timeout (default 20), poll_time (default 1)
+            aw-watcher-afk-testing = { };
+          };
+        };
 
-        xdg.configFile."activitywatch/aw-watcher-window/aw-watcher-window.toml".source =
-          toTOML "aw-watcher-window.toml"
-            {
-              # Available options: poll_time (default 1.0), exclude_title (default false),
-              # exclude_titles (default [])
-              aw-watcher-window = { };
-            };
+        xdg.configFile."activitywatch/aw-watcher-window/aw-watcher-window.toml" = lib.mkIf (!useAwatcher) {
+          source = toTOML "aw-watcher-window.toml" {
+            # Available options: poll_time (default 1.0), exclude_title (default false),
+            # exclude_titles (default [])
+            aw-watcher-window = { };
+          };
+        };
       }
+
+      (lib.mkIf useAwatcher {
+        # Standalone watcher (GNOME Wayland via the focused-window-d-bus extension).
+        # Replaces both stock aw-watcher-window and aw-watcher-afk; writes the same
+        # bucket ids, so aw-sync and cluster ingestion are unchanged.
+        home.packages = [ pkgs.awatcher ];
+
+        systemd.user.services.awatcher = {
+          Unit = {
+            Description = "awatcher — ActivityWatch window/AFK watcher";
+            After = [ "graphical-session.target" ];
+            PartOf = [ "graphical-session.target" ];
+          };
+          Service = {
+            ExecStart = "${pkgs.awatcher}/bin/awatcher";
+            # aw-server is started by aw-qt (xdg.autostart) at graphical-session time;
+            # retry briefly if awatcher starts before aw-server is listening.
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+          Install = {
+            WantedBy = [ "graphical-session.target" ];
+          };
+        };
+      })
 
       (lib.mkIf cfg.sync.enable {
         assertions = [
@@ -121,11 +165,16 @@ in
         };
 
         xdg.configFile."activitywatch/aw-qt/aw-qt.toml".source = toTOML "aw-qt.toml" {
-          aw-qt.autostart_modules = [
-            "aw-server"
-            "aw-watcher-afk"
-            "aw-watcher-window"
-          ];
+          # awatcher owns the window+afk buckets itself; only start aw-server via aw-qt.
+          aw-qt.autostart_modules =
+            if useAwatcher then
+              [ "aw-server" ]
+            else
+              [
+                "aw-server"
+                "aw-watcher-afk"
+                "aw-watcher-window"
+              ];
         };
 
         xdg.autostart = {

--- a/nix/home/services/activitywatch.nix
+++ b/nix/home/services/activitywatch.nix
@@ -7,7 +7,6 @@
 }:
 let
   cfg = config.ducktape.activitywatch;
-  useAwatcher = cfg.watcher == "awatcher";
   toTOML = (pkgs.formats.toml { }).generate;
   syncRoot = cfg.sync.root;
   syncthingCfg = cfg.sync.syncthing;
@@ -33,24 +32,6 @@ let
 in
 {
   options.ducktape.activitywatch = {
-    watcher = lib.mkOption {
-      type = lib.types.enum [
-        "stock"
-        "awatcher"
-      ];
-      default = "stock";
-      description = ''
-        Active-window watcher backend.
-        - `stock`: the xlib `aw-watcher-window` shipped with aw-qt. Produces no events
-          on GNOME/Wayland (Mutter does not maintain `_NET_ACTIVE_WINDOW`).
-        - `awatcher`: the standalone `awatcher` binary — GNOME Wayland via the
-          `focused-window-d-bus` extension, also wlroots/X11. Writes the same
-          `aw-watcher-window_<host>`/`aw-watcher-afk_<host>` buckets as the stock
-          watchers, so aw-sync is unaffected. On a GNOME host you must also add
-          `pkgs.gnomeExtensions.focused-window-d-bus` to `programs.gnome-shell.extensions`.
-      '';
-    };
-
     sync = {
       enable = lib.mkEnableOption "local ActivityWatch capture with aw-sync push into a Syncthing folder";
 
@@ -103,32 +84,29 @@ in
   config = lib.mkIf enableGui (
     lib.mkMerge [
       {
-        # Install ActivityWatch from nixpkgs.
+        # aw-server, aw-qt (tray), aw-sync. aw-qt only starts aw-server (below);
+        # awatcher owns window+AFK capture.
         home.packages = [ pkgs.activitywatch ];
-
-        xdg.configFile."activitywatch/aw-watcher-afk/aw-watcher-afk.toml" = lib.mkIf (!useAwatcher) {
-          source = toTOML "aw-watcher-afk.toml" {
-            # Available options: timeout (default 180), poll_time (default 5)
-            aw-watcher-afk = { };
-            # Available options: timeout (default 20), poll_time (default 1)
-            aw-watcher-afk-testing = { };
-          };
-        };
-
-        xdg.configFile."activitywatch/aw-watcher-window/aw-watcher-window.toml" = lib.mkIf (!useAwatcher) {
-          source = toTOML "aw-watcher-window.toml" {
-            # Available options: poll_time (default 1.0), exclude_title (default false),
-            # exclude_titles (default [])
-            aw-watcher-window = { };
-          };
-        };
       }
 
-      (lib.mkIf useAwatcher {
-        # Standalone watcher (GNOME Wayland via the focused-window-d-bus extension).
-        # Replaces both stock aw-watcher-window and aw-watcher-afk; writes the same
-        # bucket ids, so aw-sync and cluster ingestion are unchanged.
+      (lib.mkIf cfg.sync.enable {
+        # Window/AFK capture: awatcher (https://github.com/2e3s/awatcher) instead of
+        # the stock aw-watcher-window/afk. The stock xlib watcher can't see windows on
+        # GNOME/Wayland — Mutter doesn't maintain _NET_ACTIVE_WINDOW, and every other
+        # out-of-process path is closed there (wlr-foreign-toplevel, Shell.Eval,
+        # Introspect.GetWindows). awatcher reads focus via the focused-window-d-bus
+        # GNOME Shell extension on GNOME, wlr-foreign-toplevel on wlroots, or xlib on
+        # X11. It writes the same aw-watcher-window_<host>/aw-watcher-afk_<host>
+        # buckets the stock watchers did, so aw-sync → Syncthing → cluster ingestion
+        # is unchanged. See debug/activitywatch_window_gnome_wayland.md.
         home.packages = [ pkgs.awatcher ];
+
+        # GNOME hosts need the in-shell extension that exports focus on the session
+        # bus (awatcher polls it). Inert on wlroots/X11 hosts, where awatcher uses
+        # the native protocol. Auto-added wherever gnome-shell is enabled.
+        programs.gnome-shell.extensions = lib.optional config.programs.gnome-shell.enable {
+          package = pkgs.gnomeExtensions.focused-window-d-bus;
+        };
 
         systemd.user.services.awatcher = {
           Unit = {
@@ -149,9 +127,7 @@ in
             WantedBy = [ "graphical-session.target" ];
           };
         };
-      })
 
-      (lib.mkIf cfg.sync.enable {
         assertions = [
           {
             assertion = (syncthingCfg.certFile == null) == (syncthingCfg.keySopsFile == null);
@@ -166,17 +142,9 @@ in
           };
         };
 
+        # aw-qt starts only aw-server; awatcher owns the window+afk buckets.
         xdg.configFile."activitywatch/aw-qt/aw-qt.toml".source = toTOML "aw-qt.toml" {
-          # awatcher owns the window+afk buckets itself; only start aw-server via aw-qt.
-          aw-qt.autostart_modules =
-            if useAwatcher then
-              [ "aw-server" ]
-            else
-              [
-                "aw-server"
-                "aw-watcher-afk"
-                "aw-watcher-window"
-              ];
+          aw-qt.autostart_modules = [ "aw-server" ];
         };
 
         xdg.autostart = {


### PR DESCRIPTION
Switch all ActivityWatch hosts (rugged, wyrm2, iguana, atlas) from the stock `aw-watcher-window`/`aw-watcher-afk` to `awatcher` (https://github.com/2e3s/awatcher) + the `focused-window-d-bus` GNOME Shell extension, and drop the stock watcher path entirely.

## Why
The stock xlib `aw-watcher-window` produces **zero** window events on GNOME/Wayland — Mutter doesn't maintain `_NET_ACTIVE_WINDOW`, and every other out-of-process focus path is closed there (wlr-foreign-toplevel, `Shell.Eval`, `Introspect.GetWindows`). The `aw-watcher-window_rugged` bucket was empty. awatcher reads focus in-process via the `focused-window-d-bus` extension (GNOME), wlr-foreign-toplevel (wlroots), or xlib (X11). RCA: `debug/activitywatch_window_gnome_wayland.md`.

awatcher writes the **same** `aw-watcher-{window,afk}_<host>` buckets the stock watchers did, so aw-sync → Syncthing → cluster ingestion is unchanged.

## Changes
- `nix/home/services/activitywatch.nix`: awatcher is the only backend — the `watcher` option and the stock `aw-watcher-{afk,window}.toml` writes are gone. `aw-qt` starts only `aw-server`; awatcher is a `graphical-session.target` systemd user service with `Restart=always` (it exits **0**, not failure, when the extension isn't loaded yet, so `on-failure` would leave it dead). The module auto-adds `pkgs.gnomeExtensions.focused-window-d-bus` to `programs.gnome-shell.extensions` wherever gnome-shell is enabled — loads on GNOME hosts, inert on sway (where awatcher uses wlr-foreign-toplevel).
- `nix/home/hosts/rugged.nix`: drop the redundant `watcher=` line and manual extension entry (module handles both now).
- wyrm2 / iguana / atlas: **no host-file changes** — the module flip covers them.

## Verification
- `nix eval` on all 4 hosts: awatcher `ExecStart` resolves to the real binary; `focused-window-d-bus` is in each host's `programs.gnome-shell.extensions` list (rugged, wyrm2, iguana, atlas).
- End-to-end on rugged via a devkit `gnome-shell --devkit` shell (which loaded the post-switch extension): `awatcher` polled `FocusedWindow.Get` → heartbeated aw-server → first event landed in `aw-watcher-window_rugged` with the correct `{app,title}` shape. (Test event cleaned up.)
- Full build deferred to `nixos-rebuild switch` — user-level build is blocked by the unrelated gaffer cache (401 on `cache.allegedly.works/gaffer`); the system nix config used by `switch` builds it fine today.

## Activation
Each host: `sudo nixos-rebuild switch --flake .#<host>` (atlas: `home-manager switch --impure --flake .#atlas`), then **log out/in once** so the real gnome-shell loads the extension at startup (Wayland can't restart the shell live). awatcher starts via `graphical-session.target`.

## Commits
1. `26d1d0abe` — awatcher + extension on rugged
2. `38eae29d6` — `Restart=always`
3. `42a527044` — flip all hosts to awatcher, drop stock path