### PR TITLE
aw-server-rust: serve modern (Vite) aw-webui output layout

### DIFF
--- a/third_party/activitywatch/MODULE.bazel
+++ b/third_party/activitywatch/MODULE.bazel
@@ -151,7 +151,13 @@ http_archive(
     name = "aw_server_rust",
     build_file = "//:aw-server-rust.BUILD.bazel",
     patch_args = ["-p1"],
-    patches = ["//patches:aw-server-rust-rustls.patch"],
+    patches = [
+        "//patches:aw-server-rust-rustls.patch",
+        # Serve the modern aw-webui (Vite + vite-plugin-pwa) output: /assets/,
+        # /manifest.webmanifest, /registerSW.js, /sw.js. Upstream's routes only
+        # cover the webpack-era /css, /js, /static, /manifest.json layout.
+        "//patches:aw-server-rust-vite-assets-routes.patch",
+    ],
     sha256 = "7e4e0d61f3eecd272f4f7a2985f9204327e554d126d721f4db70e8e20a106474",
     strip_prefix = "aw-server-rust-" + _AW_SERVER_RUST_COMMIT,
     urls = ["https://github.com/ActivityWatch/aw-server-rust/archive/" + _AW_SERVER_RUST_COMMIT + ".tar.gz"],

--- a/third_party/activitywatch/patches/BUILD.bazel
+++ b/third_party/activitywatch/patches/BUILD.bazel
@@ -1,4 +1,5 @@
 exports_files([
     "aw-server-rust-rustls.patch",
+    "aw-server-rust-vite-assets-routes.patch",
     "vue-demi-has-injection-context.patch",
 ])

--- a/third_party/activitywatch/patches/aw-server-rust-vite-assets-routes.patch
+++ b/third_party/activitywatch/patches/aw-server-rust-vite-assets-routes.patch
@@ -1,0 +1,46 @@
+--- a/aw-server/src/endpoints/mod.rs
++++ b/aw-server/src/endpoints/mod.rs
+@@ -101,6 +101,29 @@
+     get_file("manifest.json".into(), state)
+ }
+ 
++// Modern aw-webui is a Vite + vite-plugin-pwa build: JS/CSS land under /assets,
++// and the PWA plugin emits /manifest.webmanifest, /registerSW.js and /sw.js.
++// The webpack-era /css, /js, /static routes above do not cover any of those.
++#[get("/assets/<file..>")]
++fn root_assets(file: PathBuf, state: &State<ServerState>) -> Option<(ContentType, Vec<u8>)> {
++    get_file(Path::new("assets").join(file), state)
++}
++
++#[get("/manifest.webmanifest")]
++fn root_manifest_webmanifest(state: &State<ServerState>) -> Option<(ContentType, Vec<u8>)> {
++    get_file("manifest.webmanifest".into(), state)
++}
++
++#[get("/registerSW.js")]
++fn root_register_sw(state: &State<ServerState>) -> Option<(ContentType, Vec<u8>)> {
++    get_file("registerSW.js".into(), state)
++}
++
++#[get("/sw.js")]
++fn root_sw(state: &State<ServerState>) -> Option<(ContentType, Vec<u8>)> {
++    get_file("sw.js".into(), state)
++}
++
+ #[get("/")]
+ fn server_info(config: &State<AWConfig>, state: &State<ServerState>) -> Json<Info> {
+     #[allow(clippy::or_fun_call)]
+@@ -154,7 +177,12 @@
+                 // custom static files
+                 root_dark,
+                 root_logo,
+-                root_manifest
++                root_manifest,
++                // Vite + vite-plugin-pwa build output (modern aw-webui)
++                root_assets,
++                root_manifest_webmanifest,
++                root_register_sw,
++                root_sw
+             ],
+         )
+         .mount("/api/0/info", routes![server_info])


### PR DESCRIPTION
## Problem

The ActivityWatch web UI at `https://activitywatch.allegedly.works` loaded only `index.html` — every static asset 404'd (and the manifest redirected cross-origin to Authentik, tripping a CSP error), so the SPA never rendered.

## Root cause

`aw-webui` is built with **Vite** (+ `vite-plugin-pwa`), so its output lands under `/assets/` (`index-<hash>.js`, `index-<hash>.css`) and the PWA plugin emits `/manifest.webmanifest`, `/registerSW.js`, `/sw.js`. But `aw-server-rust`'s static routes (`aw-server/src/endpoints/mod.rs`) only cover the **webpack-era** layout (`/css/`, `/js/`, `/static/`, `/manifest.json`). The Vite assets are embedded in the binary via `rust-embed` but unreachable by route.

Upstream's own `npm run build` is webpack (whose output the routes match), and they ship no Docker/server-container image that exercises this path, so the gap is latent upstream. Our Bazel build uses Vite, so we hit it.

## Fix

Add four routes served from the same `EmbeddedAssets` the other routes use:

- `GET /assets/<file..>` — JS/CSS bundles
- `GET /manifest.webmanifest` — PWA manifest
- `GET /registerSW.js`, `GET /sw.js` — service worker

Carried as a patch against the pinned `aw-server-rust@9a8802a` (`aw-server-rust-vite-assets-routes.patch`). Forward-looking: upstream will need the same routes once they finish their webpack→Vite migration.

## Why not switch to webpack?

Considered driving the Bazel build with `vue-cli-service` (webpack) to match upstream's routes. Under rules_js strict pnpm linking, aw-webui's many phantom deps (`yargs`, `autoprefixer`, `d3-shape`, …) each need a separate hoist + rebuild cycle — an open-ended whack-a-mole. Vite already builds cleanly; patching four routes is far smaller and lower-risk.

## Verification

Image builds green (BuildBuddy: https://app.buildbuddy.io/invocation/16958853-1614-4782-b162-93a0934fdfbf). Ran the image locally in Docker and probed the previously-404 paths:

```text
GET /assets/index-*.js     -> 200 text/javascript
GET /assets/index-*.css    -> 200 text/css
GET /manifest.webmanifest  -> 200
GET /registerSW.js         -> 200 text/javascript
GET /sw.js                 -> 200 text/javascript
GET /api/0/info            -> 200 application/json
```

Known cosmetic nit: `/manifest.webmanifest` is served as `application/octet-stream` (rocket's `ContentType::from_extension` doesn't recognise `.webmanifest`). Functionally fine — the original CSP error was the manifest redirecting cross-origin because it 404'd; it's now a same-origin 200, so `default-src 'self'` is satisfied and browsers parse it as JSON regardless. Happy to special-case the MIME in a follow-up.

## Deploy

Merge → `push-images.yml` builds/pushes the new `aw-server` image to GHCR → Flux `ImageRepository` updates the tag → pod redeploys → the live UI loads.
