### PR TITLE
cluster/monitoring: enable Tempo metrics-generator for TraceQL metrics

### DIFF
--- a/cluster/k8s/monitoring/tempo/helmrelease.yaml
+++ b/cluster/k8s/monitoring/tempo/helmrelease.yaml
@@ -32,6 +32,27 @@ spec:
             bucket: tempo
             insecure: true
 
+      # Metrics-generator: powers TraceQL metrics queries (rate(), count_over_time(), etc.)
+      # in Grafana's Explore Traces app. Without this, queries over "recent" (not yet
+      # flushed to object storage) data fail with:
+      #   error finding generators in Querier.queryRangeRecent: error finding generators: empty ring
+      # because there are no metrics-generator instances registered in the ring.
+      metricsGenerator:
+        enabled: true
+        remoteWriteUrl: "http://mimir-gateway.monitoring.svc.cluster.local/api/v1/push"
+        processor:
+          local_blocks: {}
+          service_graphs: {}
+          span_metrics: {}
+
+      overrides:
+        defaults:
+          metrics_generator:
+            processors:
+              - local-blocks
+              - service-graphs
+              - span-metrics
+
       extraEnvFrom:
         - secretRef:
             name: tempo-s3-credentials


### PR DESCRIPTION
Explore Traces / TraceQL rate() and count_over_time() queries over recent (unflushed) data were failing with:

  error finding generators in Querier.queryRangeRecent: error finding
  generators: empty ring

The metrics-generator component was never enabled in the tempo HelmRelease, so the ring it's queried through had zero members. Enables local_blocks (recent-data TraceQL metrics), service_graphs, and span_metrics processors, and remote-writes to the in-cluster Mimir gateway (used elsewhere by Alloy).