### PR TITLE
activitywatch: strip Origin at read-only proxy (fix web UI 403s)

### DIFF
--- a/cluster/k8s/activitywatch/readonly-proxy.conf
+++ b/cluster/k8s/activitywatch/readonly-proxy.conf
@@ -1,6 +1,12 @@
 server {
     listen 5601;
 
+    # aw-server-rust's CORS (rocket_cors) allow-list defaults to localhost only;
+    # browser and service-worker subresource fetches carry Origin: <this host> and
+    # get 403'd. Authentik is the real auth boundary for the public route, so each
+    # location below drops Origin before proxying (nginx omits headers set to "").
+    # See aw-server src/endpoints/cors.rs and its `cors` config (left at default).
+
     # Allow all GET/HEAD requests (read-only API endpoints).
     location / {
         limit_except GET {
@@ -8,6 +14,7 @@ server {
         }
         proxy_pass http://127.0.0.1:5600;
         proxy_set_header Host $host;
+        proxy_set_header Origin "";
     }
 
     # Allow POST to query endpoint (read-only in effect, uses POST for
@@ -18,6 +25,7 @@ server {
         }
         proxy_pass http://127.0.0.1:5600;
         proxy_set_header Host $host;
+        proxy_set_header Origin "";
     }
 
     # Health check for the proxy itself.


### PR DESCRIPTION
activitywatch: strip Origin at read-only proxy to fix aw-server CORS 403

aw-server-rust's CORS (rocket_cors) allow-list defaults to localhost only
(http://127.0.0.1:<port>, http://localhost:<port>; config `cors` is empty).
The browser and the PWA service worker send Origin: https://activitywatch.allegedly.works
on SPA subresource fetches (/assets/* chunks), which rocket_cors 403s — so the web UI
loaded index.html but every chunk failed (403 on the JS, HTML-returned-for-CSS),
independently of the aw-server route gap fixed in #2986.

Drop the Origin header at the read-only nginx proxy before proxying to aw-server.
The read-only proxy (behind Authentik) is the public mediation point; aw-server's
localhost-CORS is a desktop-app concern, not the security boundary here, so stripping
Origin is appropriate. nginx omits from the upstream request any header set to "".

Verified live by patching the ConfigMap and rolling the pod: an Origin-bearing
request through nginx now reaches aw-server as 200 (was 403).

BAZEL_TEST_INVOCATIONS=none: k8s manifest (ConfigMap) change; verified via live patch + Reloader rollout
