### PR TITLE
haku-console: run 2 replicas with zero-downtime rolling updates

### DIFF
--- a/cluster/k8s/haku/console/csrf-secret.sops.yaml
+++ b/cluster/k8s/haku/console/csrf-secret.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: haku-console-csrf-secret
+    namespace: haku-console
+    annotations:
+        description: Signing key for the capability tier's double-submit CSRF token (fastapi-csrf-protect). Must be shared across every haku-console replica — without it, a token signed by one pod fails validation on another, so going beyond a single replica requires this (create_app falls back to a per-process ephemeral secret otherwise, which only worked by accident when there was exactly one process). Rotate by re-generating and re-`sops`-ing this file; a rotation just makes in-flight SPA sessions refetch their token, same as an ordinary restart today.
+type: Opaque
+stringData:
+    secret: ENC[AES256_GCM,data:jEqACkjbU2HIHGpyMGxAs8P2Ou9JItyZqK+06xK1Pn6v5EZOTJ934p06fDY=,iv:jEIJDLqvOsqMQpXYzR5PAN7iscsrtVIielaIa61XEk4=,tag:fHHAlPnQ+AmZH4UXTTg1tA==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBR1hGQUJZTFI5L2ZvSmNr
+            UFJYNXlRWVREVkVrbS83R2FwM0VtWWNxTGlBCk8xT2Q4K2MrM1B4THZYUThBeDNt
+            Ri9vMWkvUm9mZjZpUzlRL256NnlGWmcKLS0tIE1sNU1CNWZKem5NVWZZOGZ4c3cz
+            VVMzemx4ZXV1VmhJWjI2MU1WdEY5ckkKiLwiE8Evm8SiFrNzzMi9eC5+Gata8jI0
+            +QFf2tYgJbLZDRiH3nPrtn+3k7FnTXU4xcyg2VEApbrZc+sCmj2aUA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZVVdMeTRQUmk0dnZ5bVg4
+            VjJnaVl5b0dWcU5veG5TWjh6bEkraG5mWXdrCnQ4d1V0Nm0wWm9peUJ1c1B5Q0Zn
+            WllJc2pkeVBtKytIQndKKyt0UGFVY2sKLS0tIDZDNDFTOXZNQTlGU3ltWXk1ajd5
+            RTNZclMwNkJUcjdQUFhlL21NemgyelkKbmRdIQitbAmJ6fFevo1x9oQCP04COXIQ
+            4iGebHfEUS6xFFTE+ePhwhc5N3KiLdqeRSLpGMim8s3/t1p2rU8JoQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-08T05:44:28Z"
+    mac: ENC[AES256_GCM,data:XkCAaGoBioxOO3vrlj5Ds3/8HKWk/wjD5bGycaP4pyXHWv5vqvQp1zd97+vME/eqyuXsf15q1E/s0HGEfGCbx/SlCG+KyKG4YA3vvWB75Cirs6OMFeyqOHQgHed/dcRp824HBdzFNUzqPpAcdB/3tjZDXm75WWUdLPSY+7p6NkA=,iv:8JWHgsEp/6eoBoNE6jxrkmlXSN+J+MGU/GKp2hVsp5I=,tag:sau23nxKtuga4NbBegsZKg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -23,9 +23,15 @@ metadata:
   labels:
     app.kubernetes.io/name: haku-console
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    # maxUnavailable: 0 means the new pod must be Ready before an old one is torn
+    # down, so a deploy never drops to zero endpoints (unlike the single-replica
+    # Recreate strategy this replaces, which always had a brief full outage).
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: haku-console
@@ -108,6 +114,14 @@ spec:
                 secretKeyRef:
                   name: haku-console-agent-api
                   key: token
+            # CSRF double-submit signing key, shared across replicas (see
+            # csrf-secret.sops.yaml) — without it each pod would sign/validate with
+            # its own ephemeral secret and cross-pod requests would randomly 403.
+            - name: HAKU_CONSOLE_CSRF_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: haku-console-csrf-secret
+                  key: secret
             # In-process `google` MCP server (calendar event creation, batch Gmail thread
             # label changes, Gmail draft creation — see haku/console/tools/google.py).
             # haku-console-google-access-token (access_token + expires_at) is written

--- a/cluster/k8s/haku/console/kustomization.yaml
+++ b/cluster/k8s/haku/console/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: haku-console
 
 resources:
+  - csrf-secret.sops.yaml
   - deployment.yaml
   - routine-launch-token.sops.yaml
   - service.yaml

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import logging
 import secrets
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import FastAPI, Request, Response
@@ -49,18 +50,26 @@ def _cache_control_for_path(path: str) -> str:
 
 
 def create_app(settings: Settings) -> FastAPI:
-    app = FastAPI(title="Haku console")
+    database_url = settings.database_url.get_secret_value() if settings.database_url is not None else None
+    # Cross-replica fan-out (Postgres LISTEN/NOTIFY) when a database is configured;
+    # started/stopped by the lifespan below rather than at construction time, since
+    # starting the listen loop needs a running event loop.
+    tool_call_event_hub = mcp_approval.ToolCallEventHub(database_url)
+
+    @asynccontextmanager
+    async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+        await tool_call_event_hub.start()
+        try:
+            yield
+        finally:
+            await tool_call_event_hub.aclose()
+
+    app = FastAPI(title="Haku console", lifespan=_lifespan)
     # The capability router reads settings off app.state (see haku.console.capabilities).
     app.state.settings = settings
-    app.state.tool_call_ledger = (
-        mcp_approval.PostgresToolCallLedger(settings.database_url.get_secret_value())
-        if settings.database_url is not None
-        else None
-    )
+    app.state.tool_call_ledger = mcp_approval.PostgresToolCallLedger(database_url) if database_url is not None else None
     app.state.mcp_operator_oauth_store = (
-        mcp_approval.PostgresMcpOperatorOAuthStore(settings.database_url.get_secret_value())
-        if settings.database_url is not None
-        else None
+        mcp_approval.PostgresMcpOperatorOAuthStore(database_url) if database_url is not None else None
     )
     in_process_servers: dict[str, FastMCP] = {}
     app.state.google_gmail_client = None
@@ -68,7 +77,7 @@ def create_app(settings: Settings) -> FastAPI:
         gmail_client, calendar_client = google_tools.build_tool_clients(settings.google_token_dir)
         app.state.google_gmail_client = gmail_client
         in_process_servers[google_tools.GOOGLE_SERVER_ID] = google_tools.build_mcp(gmail_client, calendar_client)
-    app.state.tool_call_event_hub = mcp_approval.ToolCallEventHub()
+    app.state.tool_call_event_hub = tool_call_event_hub
     app.state.tool_call_executor = mcp_approval.McpToolExecutor(in_process_servers)
     app.state.tool_call_metadata_provider = mcp_approval.McpMetadataProvider(in_process_servers)
 
@@ -89,8 +98,10 @@ def create_app(settings: Settings) -> FastAPI:
 
     # CSRF for the capability tier: a header-located double-submit token (the SPA
     # echoes the token from GET /api/capabilities/csrf in X-CSRF-Token). Use the
-    # configured secret, else an ephemeral one (fine for the single-replica console
-    # — a restart just makes the SPA refetch its token).
+    # configured secret (shared across every replica — see csrf-secret.sops.yaml),
+    # else an ephemeral one; the ephemeral fallback only ever worked by accident
+    # with exactly one replica (a token from a different pod's secret would fail
+    # validation), so it's a dev/test convenience now, not a real deploy path.
     csrf_secret = settings.csrf_secret.get_secret_value() if settings.csrf_secret else secrets.token_urlsafe(32)
     CsrfProtect.load_config(lambda: [("secret_key", csrf_secret), ("token_location", "header")])
 

--- a/haku/console/database_migrate.py
+++ b/haku/console/database_migrate.py
@@ -7,13 +7,21 @@ from typing import Any
 
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
+from sqlalchemy import text
 
 from haku.console.database_schema import metadata
 
 _MIGRATIONS_DIR = Path(__file__).parent / "migrations"
 
+# Arbitrary fixed key, unique to this lock's purpose (no meaning beyond that). With more
+# than one haku-console replica, every pod runs migrations at startup — pg_advisory_xact_lock
+# serializes them onto the connection's transaction (auto-released on commit/rollback) so two
+# pods starting at once don't race to apply the same migration.
+_MIGRATION_LOCK_KEY = 0x4B41_4B55  # "KAKU" in hex, close enough to "haku" to be memorable
+
 
 def run_migrations_for_connection(conn: Any) -> None:
+    conn.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": _MIGRATION_LOCK_KEY})
     cfg = AlembicConfig()
     cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
     cfg.attributes["connection"] = conn

--- a/haku/console/mcp_approval.py
+++ b/haku/console/mcp_approval.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import datetime as dt
 import html
+import json
 import logging
 import os
 import re
@@ -21,6 +23,7 @@ from typing import Annotated, Any, Literal, Protocol, cast
 from urllib.parse import quote, urlencode, urljoin
 
 import httpx
+import psycopg
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
@@ -499,9 +502,42 @@ class PostgresMcpOperatorOAuthStore:
             return row.access_token
 
 
+def _psycopg_dsn(database_url: str) -> str:
+    # SQLAlchemy's "+psycopg" driver suffix isn't a real libpq scheme; strip it so
+    # psycopg's own AsyncConnection.connect() (used here for LISTEN/NOTIFY, outside
+    # SQLAlchemy) accepts the DSN directly.
+    return database_url.replace("postgresql+psycopg://", "postgresql://", 1)
+
+
 class ToolCallEventHub:
-    def __init__(self) -> None:
+    """WebSocket fan-out to this pod's connected clients, relayed across every
+    haku-console replica via Postgres LISTEN/NOTIFY (when a database is configured) —
+    so a client connected to one pod still gets the live nudge for an event a
+    *different* pod handled, not just events its own pod happened to process.
+    `broadcast()` always publishes (NOTIFY when DB-backed, direct local delivery
+    otherwise, e.g. in tests with no database); actual WebSocket sends happen only in
+    `_deliver_locally`, invoked either directly or from the NOTIFY listen loop — the
+    publishing pod hears its own NOTIFY back too, so there's no separate "local vs.
+    remote" delivery path to keep in sync.
+    """
+
+    _CHANNEL = "haku_console_tool_call_events"
+
+    def __init__(self, database_url: str | None = None) -> None:
         self._connections: set[WebSocket] = set()
+        self._dsn = _psycopg_dsn(database_url) if database_url else None
+        self._listen_task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        if self._dsn is not None:
+            self._listen_task = asyncio.create_task(self._listen_loop())
+
+    async def aclose(self) -> None:
+        if self._listen_task is None:
+            return
+        self._listen_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._listen_task
 
     async def connect(self, websocket: WebSocket) -> None:
         await websocket.accept()
@@ -512,7 +548,17 @@ class ToolCallEventHub:
 
     async def broadcast(self, events: Iterable[ToolCallEvent]) -> None:
         payloads = [e.model_dump(mode="json") for e in events]
-        if not payloads or not self._connections:
+        if not payloads:
+            return
+        if self._dsn is None:
+            await self._deliver_locally(payloads)
+            return
+        async with await psycopg.AsyncConnection.connect(self._dsn, autocommit=True) as conn:
+            for payload in payloads:
+                await conn.execute("SELECT pg_notify(%s, %s)", (self._CHANNEL, json.dumps(payload)))
+
+    async def _deliver_locally(self, payloads: list[dict[str, Any]]) -> None:
+        if not self._connections:
             return
         dead: list[WebSocket] = []
         for ws in self._connections:
@@ -523,6 +569,25 @@ class ToolCallEventHub:
                 dead.append(ws)
         for ws in dead:
             self.disconnect(ws)
+
+    async def _listen_loop(self) -> None:
+        assert self._dsn is not None
+        while True:
+            try:
+                async with await psycopg.AsyncConnection.connect(self._dsn, autocommit=True) as conn:
+                    await conn.execute(f"LISTEN {self._CHANNEL}")
+                    async for note in conn.notifies():
+                        try:
+                            payload = json.loads(note.payload)
+                        except ValueError:
+                            logger.exception("failed to parse tool-call event notification payload")
+                            continue
+                        await self._deliver_locally([payload])
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("tool-call event listen loop failed; reconnecting")
+                await asyncio.sleep(1)
 
 
 # A server reached over an in-process FastMCP instance instead of a remote URL (see


### PR DESCRIPTION
## Summary

Root-caused the `Error proxying to upstream server: dial tcp 10.96.12.140:8080: connect: operation not permitted` report: `haku-console` ran a single replica with `strategy: type: Recreate`, which guarantees a brief zero-endpoint window on every deploy (old pod fully killed before the new one starts) — Authentik's proxy outpost hit the Service during exactly that gap. Confirmed live (via `kubectl describe`/events) and confirmed the Service is otherwise healthy (a direct in-cluster `curl` to `/healthz` succeeded cleanly).

- Switches to `replicas: 2` + `RollingUpdate` (`maxUnavailable: 0, maxSurge: 1`), so a deploy never drops below the configured replica count.
- That surfaced (and this PR fixes) three correctness gaps that only mattered once more than one pod could run concurrently:
  - **CSRF secret** was per-process-ephemeral by default (`HAKU_CONSOLE_CSRF_SECRET` was never set) — fine with one pod, but a token signed by one replica would fail validation on another. Added a persisted, shared secret (`csrf-secret.sops.yaml`).
  - **Alembic migrations** ran unguarded at every pod's startup — two pods starting concurrently could race to apply the same migration. Wrapped the run in `pg_advisory_xact_lock` so they serialize instead of racing.
  - **`ToolCallEventHub`'s WebSocket fan-out** was in-memory per pod — a client connected to one replica would miss live nudges for events a *different* replica handled. Rebuilt it on Postgres LISTEN/NOTIFY: every pod publishes via `NOTIFY` and relays whatever it hears (including its own publishes) to its local WebSocket clients, so delivery no longer depends on which pod happened to handle the request.

## Test plan

- [x] `pre-commit` clean (ruff, kubeconform, prettier) on all six changed/new files.
- [x] mypy + ruff clean on all touched Python.
- [x] Local pytest (throwaway venv, no Bazel/Docker in this sandbox): `haku/console/test_app.py`, `haku/console/test_capabilities.py`, `haku/console/tools/` — 31 passed, unaffected by this change (no `database_url` configured in those tests, so the new NOTIFY path is inert and falls back to direct local delivery, matching prior behavior exactly).
- [x] `haku/console/test_mcp_approval.py` (the Postgres-backed suite that exercises `ToolCallEventHub` for real, including `test_websocket_receives_pending_approval_event`) still collects cleanly; verified `psycopg.AsyncConnection`'s API shape locally against the pinned `psycopg==3.3.4`. Requires Docker (a real Postgres testcontainer) to actually execute, which isn't available in this sandbox — relying on CI (BuildBuddy RBE) for that.
- [ ] Manual, post-merge: watch a real haku-console rollout to confirm zero dropped requests, and confirm the live approval WebSocket still nudges correctly with 2 replicas up.

https://claude.ai/code/session_01WRa6JHZU5xqM8r7hzFHF47


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRa6JHZU5xqM8r7hzFHF47)_