### PR TITLE
haku-console: fix kubectl-passthrough-mcp operator OAuth 401 on registration

### DIFF
--- a/cluster/k8s/haku/console/config.yaml
+++ b/cluster/k8s/haku/console/config.yaml
@@ -21,6 +21,15 @@ mcp:
       server_url: https://kubectl-passthrough-mcp.allegedly.works/mcp
       operator_oauth:
         client_name: Haku Console
+        # Authentik has no open Dynamic Client Registration endpoint (kubernetes-mcp-server
+        # just mirrors Authentik's own OAuth metadata, which omits registration_endpoint),
+        # so DCR would 401 against the guessed {server}/register fallback. Use the
+        # pre-registered public/PKCE client_id from the kubectl_passthrough_mcp Authentik
+        # provider instead (tf/gitops/agent-machine-access/main.tf) — it already allows
+        # multiple redirect URIs (CLI localhost, kubernetes-mcp-server's own callback, and
+        # haku-console's operator-auth callback), safe to share since PKCE plus per-request
+        # redirect_uri validation secure each caller independently.
+        static_client_id: kubectl-passthrough-mcp
     # Implemented in-process (haku/console/tools/google.py) as a real FastMCP server
     # attached via an in-memory transport, not a remote MCP server — no server_url/
     # operator_oauth. Holds the Airlock-issued haku_console_google token

--- a/haku/console/mcp_approval.py
+++ b/haku/console/mcp_approval.py
@@ -91,6 +91,14 @@ class McpOperatorOAuthConfig(BaseModel):
     enabled: bool = True
     client_name: str = "Haku Console"
     scopes: list[str] | None = None
+    # For an authorization server with no open Dynamic Client Registration (RFC 7591) —
+    # e.g. Authentik, which has no /register endpoint, so the server-metadata-declared
+    # registration_endpoint is absent and DCR would otherwise 401 against a guessed
+    # {server}/register fallback. A pre-registered public/PKCE client_id shared across
+    # every OAuth caller of that authorization server, skipping registration entirely.
+    # Safe to share: PKCE plus per-request redirect_uri validation secure each caller's
+    # auth code exchange independently even though the client_id is the same for all.
+    static_client_id: str | None = None
 
 
 class McpServerEntry(BaseModel):
@@ -836,7 +844,17 @@ async def _build_operator_oauth_flow(
                 response_types=["code"],
                 scope=scope,
             )
-            client_info = await _register_oauth_client(client, server_url, oauth_metadata, client_metadata)
+            if server.operator_oauth.static_client_id:
+                client_info = OAuthClientInformationFull(
+                    client_id=server.operator_oauth.static_client_id,
+                    redirect_uris=client_metadata.redirect_uris,
+                    grant_types=client_metadata.grant_types,
+                    response_types=client_metadata.response_types,
+                    scope=client_metadata.scope,
+                    client_name=client_metadata.client_name,
+                )
+            else:
+                client_info = await _register_oauth_client(client, server_url, oauth_metadata, client_metadata)
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"failed to start MCP OAuth flow for {server.id}: {e}") from e
 

--- a/haku/console/test_mcp_approval.py
+++ b/haku/console/test_mcp_approval.py
@@ -73,9 +73,15 @@ def _remote_mcp_url(server: FastMCP) -> Generator[str]:
 
 
 @contextmanager
-def _remote_oauth_url() -> Generator[str]:
+def _remote_oauth_url(*, static_client_id: str | None = None) -> Generator[str]:
+    """A fake OAuth server. With `static_client_id` set, the metadata omits
+    `registration_endpoint` and no `/auth/register` route is mounted at all — mirroring
+    Authentik (fronted by kubernetes-mcp-server), which has no DCR endpoint — so the test
+    fails loudly if the client under test attempts dynamic registration anyway.
+    """
     port = pick_free_port()
     base_url = f"http://127.0.0.1:{port}"
+    expected_client_id = static_client_id or "dynamic-client"
 
     async def mcp(request: Request) -> JSONResponse:
         return JSONResponse(
@@ -96,17 +102,17 @@ def _remote_oauth_url() -> Generator[str]:
         )
 
     async def oauth_metadata(request: Request) -> JSONResponse:
-        return JSONResponse(
-            {
-                "issuer": f"{base_url}/auth",
-                "authorization_endpoint": f"{base_url}/auth/authorize",
-                "token_endpoint": f"{base_url}/auth/token",
-                "registration_endpoint": f"{base_url}/auth/register",
-                "response_types_supported": ["code"],
-                "grant_types_supported": ["authorization_code", "refresh_token"],
-                "code_challenge_methods_supported": ["S256"],
-            }
-        )
+        metadata = {
+            "issuer": f"{base_url}/auth",
+            "authorization_endpoint": f"{base_url}/auth/authorize",
+            "token_endpoint": f"{base_url}/auth/token",
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+            "code_challenge_methods_supported": ["S256"],
+        }
+        if static_client_id is None:
+            metadata["registration_endpoint"] = f"{base_url}/auth/register"
+        return JSONResponse(metadata)
 
     async def register(request: Request) -> JSONResponse:
         body = await request.json()
@@ -125,7 +131,7 @@ def _remote_oauth_url() -> Generator[str]:
         form = {k: v[0] for k, v in parse_qs((await request.body()).decode()).items()}
         if form["grant_type"] == "authorization_code":
             assert form["code"] == "operator-code"
-            assert form["client_id"] == "dynamic-client"
+            assert form["client_id"] == expected_client_id
             assert form["code_verifier"]
             return JSONResponse(
                 {
@@ -147,16 +153,16 @@ def _remote_oauth_url() -> Generator[str]:
             }
         )
 
-    app = Starlette(
-        routes=[
-            Route("/mcp", mcp),
-            Route("/.well-known/oauth-protected-resource/mcp", protected_resource),
-            Route("/.well-known/oauth-protected-resource", protected_resource),
-            Route("/.well-known/oauth-authorization-server/auth", oauth_metadata),
-            Route("/auth/register", register, methods=["POST"]),
-            Route("/auth/token", token, methods=["POST"]),
-        ]
-    )
+    routes = [
+        Route("/mcp", mcp),
+        Route("/.well-known/oauth-protected-resource/mcp", protected_resource),
+        Route("/.well-known/oauth-protected-resource", protected_resource),
+        Route("/.well-known/oauth-authorization-server/auth", oauth_metadata),
+        Route("/auth/token", token, methods=["POST"]),
+    ]
+    if static_client_id is None:
+        routes.append(Route("/auth/register", register, methods=["POST"]))
+    app = Starlette(routes=routes)
     uvicorn_server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning"))
     thread = threading.Thread(target=uvicorn_server.run, daemon=True)
     thread.start()
@@ -243,6 +249,22 @@ mcp:
     - id: grocy-sf
       server_url: {oauth_base_url}/mcp
       operator_oauth: {{}}
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _operator_oauth_static_client_config_file(tmp_path: Path, oauth_base_url: str, client_id: str) -> Path:
+    path = tmp_path / "haku_console_operator_oauth_static.yaml"
+    path.write_text(
+        f"""
+mcp:
+  servers:
+    - id: grocy-sf
+      server_url: {oauth_base_url}/mcp
+      operator_oauth:
+        static_client_id: {client_id}
 """,
         encoding="utf-8",
     )
@@ -344,6 +366,36 @@ def test_operator_oauth_association_drives_tool_reflection(make_client, tmp_path
     assert after["servers"][0]["status"] == "alive"
     assert metadata_provider.auth_tokens == ["operator-access-token"]
     assert "bearer_token_secret" not in str(after)
+
+
+def test_operator_oauth_static_client_id_skips_dynamic_registration(make_client, tmp_path: Path, db_url: str) -> None:
+    """Mirrors kubectl-passthrough-mcp: fronted by Authentik, which has no DCR endpoint —
+    dynamic registration would 401, so a configured static_client_id must skip it entirely.
+    """
+    with (
+        _remote_oauth_url(static_client_id="preregistered-client") as oauth_url,
+        make_client(
+            config_file=_operator_oauth_static_client_config_file(tmp_path, oauth_url, "preregistered-client"),
+            csrf_secret=SecretStr("csrf"),
+            public_base_url="https://haku.test",
+            **_test_app_overrides(db_url),
+        ) as client,
+    ):
+        started = client.post(
+            "/api/mcp/operator-auth/grocy-sf/start",
+            headers={"X-CSRF-Token": _csrf(client), "X-authentik-username": "operator@example.com"},
+        )
+        assert started.status_code == 200, started.text
+        auth_query = parse_qs(urlparse(started.json()["authorization_url"]).query)
+        assert auth_query["client_id"] == ["preregistered-client"]
+
+        callback = client.get(
+            "/api/mcp/operator-auth/callback", params={"state": auth_query["state"][0], "code": "operator-code"}
+        )
+        after = client.get("/api/mcp/operator-auth", headers={"X-authentik-username": "operator@example.com"}).json()
+
+    assert callback.status_code == 200, callback.text
+    assert after["associations"][0]["status"] == "connected"
 
 
 def test_reflection_marks_unreachable_servers_degraded(

--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -816,6 +816,12 @@ resource "authentik_provider_oauth2" "kubectl_passthrough_mcp" {
 
   # - Claude Code: http://localhost:<port>/callback
   # - kubernetes-mcp-server's built-in callback (browser testing): /oauth/callback
+  # - haku-console's operator_oauth flow (mcp_approval.py): /api/mcp/operator-auth/callback.
+  #   kubernetes-mcp-server has no DCR endpoint of its own (it just mirrors Authentik's
+  #   OAuth metadata, which has none either), so haku-console is configured with this
+  #   provider's static client_id instead of registering dynamically — safe to share
+  #   across callers since this is a public/PKCE client and redirect_uri is validated
+  #   per request.
   #
   # TODO: Consider adding https://claude.ai/api/mcp/auth_callback for Claude.ai
   # Custom Connectors. Intentionally omitted for now — using the passthrough
@@ -831,6 +837,10 @@ resource "authentik_provider_oauth2" "kubectl_passthrough_mcp" {
     {
       matching_mode = "strict"
       url           = "https://kubectl-passthrough-mcp.allegedly.works/oauth/callback"
+    },
+    {
+      matching_mode = "strict"
+      url           = "https://haku.allegedly.works/api/mcp/operator-auth/callback"
     },
   ]
 }


### PR DESCRIPTION
## Summary

- Fixes `Couldn't start MCP account link — failed to start MCP OAuth flow for kubectl-passthrough-mcp: Registration failed: 401 Unauthorized: Bearer token required` when linking the `kubectl-passthrough-mcp` MCP account from haku-console.
- Root cause (confirmed empirically against the live server): `kubernetes-mcp-server`'s own OAuth authorization-server metadata just mirrors Authentik's real metadata, which has no `registration_endpoint` (Authentik doesn't support Dynamic Client Registration). haku-console's `operator_oauth` flow then falls back to guessing `{server}/register`, but that path doesn't exist on `kubectl-passthrough-mcp` either — it just hits the server's blanket "bearer token required" auth middleware and 401s before ever reaching Authentik.
- Adds an optional `static_client_id` to `McpOperatorOAuthConfig` (`haku/console/mcp_approval.py`) that skips dynamic registration and uses a pre-registered client_id directly — for authorization servers with no open DCR support.
- Points `kubectl-passthrough-mcp`'s config entry at its existing public/PKCE Authentik `client_id` (`cluster/k8s/haku/console/config.yaml`), which was already designed to be shared across multiple callback URLs (Claude Code CLI, kubernetes-mcp-server's own browser-testing callback).
- Adds haku-console's operator-auth callback URL to that Authentik provider's `allowed_redirect_uris` (`tf/gitops/agent-machine-access/main.tf`).

## Test plan

- [x] `ruff check` / `ruff format --diff` clean on the touched Python files (Bazel/RBE unavailable in this sandbox — the `bbr test //haku/console:test_mcp_approval` run needs CI).
- [x] Added `test_operator_oauth_static_client_id_skips_dynamic_registration`, using a fake OAuth server with *no* `/register` route and no `registration_endpoint` in its metadata (mirroring Authentik/kubernetes-mcp-server), asserting the flow completes end-to-end using the configured static client_id.
- [ ] CI (`bbr test //...`) — Terraform apply for the Authentik provider redirect URI change happens via the GitOps `agent-machine-access` reconciler once merged.
- [ ] Manual: re-try the "Connect account" flow for `kubectl-passthrough-mcp` in haku-console once deployed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRa6JHZU5xqM8r7hzFHF47)_