### PR TITLE
haku-console: grocy-sf tool previews; budget/fava: 2 replicas

### DIFF
--- a/cluster/k8s/budget/app/deployment.yaml
+++ b/cluster/k8s/budget/app/deployment.yaml
@@ -3,6 +3,12 @@
 # working tree (see sync/sync.sh for why in-place rather than git-sync); Fava reads
 # /ledger/main.beancount and auto-reloads when the file changes. Access is gated by
 # authentik (agentydragon-only) via the proxy outpost -- Fava has no native auth.
+#
+# 2 replicas + RollingUpdate: safe because /ledger is a per-pod emptyDir and
+# sync.sh only ever reads (fetch + reset --hard, never push) — each replica is an
+# independent read-only mirror with no shared state, so there's no write hazard to
+# coordinate across pods. Replicas can be briefly out of sync with each other by up
+# to SYNC_PERIOD (300s); self-heals on the next sync tick.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -11,9 +17,12 @@ metadata:
   labels:
     app.kubernetes.io/name: fava
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: fava

--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -107,6 +107,7 @@ py_library(
         ":mcp_approval",
         ":models",
         "//haku/console/tools:google",
+        "//haku/console/tools:grocy",
         "@pypi//fastapi",
         "@pypi//fastapi_csrf_protect",
         "@pypi//fastmcp",

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -27,7 +27,7 @@ from fastmcp import FastMCP
 from haku.console import capabilities, mcp_approval
 from haku.console.config import Settings
 from haku.console.models import ConfigResponse
-from haku.console.tools import google as google_tools
+from haku.console.tools import google as google_tools, grocy as grocy_tools
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +122,7 @@ def create_app(settings: Settings) -> FastAPI:
     app.include_router(capabilities.router)
     app.include_router(mcp_approval.router)
     app.include_router(google_tools.router)
+    app.include_router(grocy_tools.router)
 
     # Optional direct local/dev fallback. Production serves the SPA from the
     # haku-console-static nginx image and leaves static_dir unset on this process.

--- a/haku/console/database_schema.py
+++ b/haku/console/database_schema.py
@@ -35,6 +35,7 @@ class McpToolCall(Base):
     title: Mapped[str | None] = mapped_column(Text, nullable=True)
     result_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    denial_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     @classmethod
     def from_record(cls, record: ToolCallRecord) -> McpToolCall:
@@ -51,6 +52,7 @@ class McpToolCall(Base):
             title=record.title,
             result_json=record.result,
             error=record.error,
+            denial_reason=record.denial_reason,
         )
 
     def to_record(self) -> ToolCallRecord:
@@ -67,6 +69,7 @@ class McpToolCall(Base):
             title=self.title,
             result=self.result_json,
             error=self.error,
+            denial_reason=self.denial_reason,
         )
 
 

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -118,10 +118,22 @@ js_library(
 )
 
 js_library(
+    name = "grocy_tool_previews",
+    srcs = ["grocy_tool_previews.tsx"],
+    deps = [
+        ":field",
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+        "//:node_modules/zod",
+    ],
+)
+
+js_library(
     name = "tool_previews",
     srcs = ["tool_previews.tsx"],
     deps = [
         ":google_tool_previews",
+        ":grocy_tool_previews",
         ":kubectl_tool_previews",
         "//:node_modules/react",
     ],
@@ -194,6 +206,7 @@ filegroup(
         "console_panel.tsx",
         "field.tsx",
         "google_tool_previews.tsx",
+        "grocy_tool_previews.tsx",
         "haku_ui_embed.tsx",
         "index.html",
         "kubectl_tool_previews.tsx",

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -121,6 +121,7 @@ js_library(
     name = "grocy_tool_previews",
     srcs = ["grocy_tool_previews.tsx"],
     deps = [
+        ":client",
         ":field",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",

--- a/haku/console/frontend/approval_state.ts
+++ b/haku/console/frontend/approval_state.ts
@@ -22,6 +22,7 @@ export interface ApprovalDisplayFields {
   toolCallId: string;
   callerPrincipal: string | null;
   createdAt: string | null;
+  denialReason: string | null;
 }
 
 export interface RecentToolCall {
@@ -89,6 +90,7 @@ export function approvalDisplayFields(approval: PendingApproval | ToolCallRecord
     toolCallId: approval.tool_call_id,
     callerPrincipal: approval.caller_principal ?? null,
     createdAt: approval.created_at ?? null,
+    denialReason: "denial_reason" in approval ? (approval.denial_reason ?? null) : null,
   };
 }
 

--- a/haku/console/frontend/client.ts
+++ b/haku/console/frontend/client.ts
@@ -125,3 +125,14 @@ export async function fetchGmailThreadPreviews(threadIds: string[]): Promise<Rec
   if (error || !data) throw new Error(errorDetail(error, "Failed to load Gmail thread previews"));
   return data.threads;
 }
+
+export type GrocyReferenceResponse = components["schemas"]["GrocyReferenceResponse"];
+
+// Live product/location/quantity-unit `{id, name}` lookup for rendering pending grocy-sf
+// stock_add/stock_consume/products_create approvals — their arguments accept either a name
+// or a numeric ID, and only names render nicely on their own.
+export async function fetchGrocyReference(): Promise<GrocyReferenceResponse> {
+  const { data, error } = await api.GET("/api/grocy-sf/reference");
+  if (error || !data) throw new Error(errorDetail(error, "Failed to load grocy-sf reference data"));
+  return data;
+}

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Group, SegmentedControl, Stack, Text } from "@mantine/core";
+import { Badge, Button, Group, SegmentedControl, Stack, Text, Textarea } from "@mantine/core";
 import type { KeyboardEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 
@@ -33,7 +33,7 @@ export interface ShellDrawerProps {
   onSelectApproval: (id: string) => void;
   onSelectRecentToolCall: (toolCallId: string) => void;
   onApproveTool: (approval: PendingApproval) => void;
-  onDenyTool: (approval: PendingApproval) => void;
+  onDenyTool: (approval: PendingApproval, reason?: string) => void;
   onApproveGeolocation: (approval: GeolocationApproval) => void;
   onDenyGeolocation: (approval: GeolocationApproval) => void;
   onDismissRecentToolCall: (toolCallId: string) => void;
@@ -151,10 +151,14 @@ function ToolApprovalDetail({
   approval: PendingApproval;
   deciding: boolean;
   onApprove: () => void;
-  onDeny: () => void;
+  onDeny: (reason?: string) => void;
 }) {
   const fields = approvalDisplayFields(approval);
   const armed = useArmed(`detail:${approval.tool_call_id}`);
+  const [denyReason, setDenyReason] = useState("");
+  useEffect(() => {
+    setDenyReason("");
+  }, [approval.tool_call_id]);
   return (
     <section className="haku-shell-card haku-shell-card-selected">
       <Stack gap="sm">
@@ -195,8 +199,25 @@ function ToolApprovalDetail({
             <code>{fields.toolCallId}</code>
           </details>
         </dl>
+        <Textarea
+          size="xs"
+          label="Denial reason (optional)"
+          placeholder="Why are you denying this?"
+          autosize
+          minRows={1}
+          maxRows={4}
+          disabled={deciding}
+          value={denyReason}
+          onChange={(e) => setDenyReason(e.currentTarget.value)}
+        />
         <Group justify="space-between">
-          <Button size="sm" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
+          <Button
+            size="sm"
+            variant="light"
+            color="red"
+            disabled={deciding || !armed}
+            onClick={() => onDeny(denyReason.trim() || undefined)}
+          >
             Deny
           </Button>
           <Button size="sm" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
@@ -432,6 +453,11 @@ function RecentToolCallCard({
                 {recent.record.error}
               </Text>
             )}
+            {fields.denialReason && (
+              <Text size="xs" c="dimmed">
+                Denied: {fields.denialReason}
+              </Text>
+            )}
           </Stack>
           <Badge color={statusColor(recent.record.status)} variant="light">
             {terminalStatusLabel(recent.record.status)}
@@ -486,6 +512,7 @@ function RecentToolCallDetail({ recent, nowMs }: { recent: RecentToolCall; nowMs
               {fields.toolName}
             </Field>
           </div>
+          {fields.denialReason && <Field label="Denial reason">{fields.denialReason}</Field>}
           <ToolArgumentsField
             serverId={fields.serverId}
             toolName={fields.toolName}
@@ -564,7 +591,7 @@ function ApprovalsTab({
           approval={selectedItem.approval}
           deciding={deciding.has(selectedItem.id)}
           onApprove={() => onApproveTool(selectedItem.approval)}
-          onDeny={() => onDenyTool(selectedItem.approval)}
+          onDeny={(reason) => onDenyTool(selectedItem.approval, reason)}
         />
       )}
       {selectedItem?.kind === "geolocation" && (

--- a/haku/console/frontend/grocy_tool_previews.tsx
+++ b/haku/console/frontend/grocy_tool_previews.tsx
@@ -1,0 +1,198 @@
+// Per-tool-type rendering for the remote `grocy-sf` MCP server (see
+// grocy_mcp/README.md and grocy_mcp/batch_tools.py). Falls back to the generic raw-JSON
+// view for anything that isn't shaped as expected — same caveat as kubectl_tool_previews.tsx:
+// arguments are only validated by the tool's own schema at execution time, not at submission.
+//
+// grocy-sf's tool surface is generated from Grocy's own OpenAPI spec plus custom batch
+// tools (grocy_mcp/batch_tools.py) — there's no backend Pydantic model haku-console owns to
+// generate Zod schemas from (unlike google_tool_previews.tsx's :schema_zod), so these are
+// hand-authored once, here, against grocy_mcp/mcp_types.py's `AddItem` / `ConsumeItem` /
+// `CreateProductItem`. Every tool call runs as the approving operator's own linked Grocy
+// account (operator_oauth) once approved.
+
+import { Badge, Group, Stack, Text } from "@mantine/core";
+import type { ReactNode } from "react";
+import { z } from "zod";
+
+import { Field } from "./field.tsx";
+
+const GROCY_SERVER_ID = "grocy-sf";
+
+// `int | str` on the Python side (name or ID) — render whichever the caller passed.
+const zNameOrId = z.union([z.string(), z.number()]);
+
+const zAddItem = z.object({
+  product: zNameOrId,
+  amount: z.number(),
+  qu: zNameOrId,
+  location: zNameOrId,
+  best_before_date: z.string().nullish(),
+  price: z.number().nullish(),
+  note: z.string().nullish(),
+});
+
+const zConsumeItem = z.object({
+  product: zNameOrId,
+  amount: z.number(),
+  qu: zNameOrId,
+  location: zNameOrId,
+  spoiled: z.boolean().optional(),
+  allow_subproduct_substitution: z.boolean().optional(),
+});
+
+const zCreateProductItem = z.object({
+  name: z.string(),
+  stock_qu: zNameOrId,
+  location: zNameOrId,
+  purchase_qu: zNameOrId.nullish(),
+  min_stock_amount: z.number().optional(),
+  consume_qu: zNameOrId.nullish(),
+  default_best_before_days: z.number(),
+  due_type: z.union([z.literal(1), z.literal(2)]).optional(),
+  parent_product: zNameOrId.nullish(),
+  product_group: zNameOrId.nullish(),
+  description: z.string().nullish(),
+});
+
+const zStockAddArgs = z.object({ items: z.array(zAddItem) });
+const zStockConsumeArgs = z.object({ items: z.array(zConsumeItem) });
+const zProductsCreateArgs = z.object({ items: z.array(zCreateProductItem) });
+
+type AddItem = z.infer<typeof zAddItem>;
+type ConsumeItem = z.infer<typeof zConsumeItem>;
+type CreateProductItem = z.infer<typeof zCreateProductItem>;
+type StockAddArgs = z.infer<typeof zStockAddArgs>;
+type StockConsumeArgs = z.infer<typeof zStockConsumeArgs>;
+type ProductsCreateArgs = z.infer<typeof zProductsCreateArgs>;
+
+function ProductAmount({ product, amount, qu }: { product: string | number; amount: number; qu: string | number }) {
+  return (
+    <Group gap={4}>
+      <Text span fw={600}>
+        {product}
+      </Text>
+      <Text span c="dimmed">
+        ×
+      </Text>
+      <Text span>
+        {amount} {qu}
+      </Text>
+    </Group>
+  );
+}
+
+function StockAddRow({ item }: { item: AddItem }) {
+  return (
+    <Group gap={6}>
+      <ProductAmount product={item.product} amount={item.amount} qu={item.qu} />
+      <Text span c="dimmed">
+        → {item.location}
+      </Text>
+      {item.best_before_date && (
+        <Badge size="sm" variant="outline">
+          best before {item.best_before_date}
+        </Badge>
+      )}
+    </Group>
+  );
+}
+
+function StockAddPreview({ args }: { args: StockAddArgs }) {
+  return (
+    <Stack gap="xs">
+      <Field label="Action">
+        <Badge color="green" variant="light">
+          Add stock
+        </Badge>
+      </Field>
+      <Stack gap={4}>
+        {args.items.map((item, i) => (
+          <StockAddRow key={i} item={item} />
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+function StockConsumeRow({ item }: { item: ConsumeItem }) {
+  return (
+    <Group gap={6}>
+      <ProductAmount product={item.product} amount={item.amount} qu={item.qu} />
+      <Text span c="dimmed">
+        from {item.location}
+      </Text>
+      {item.spoiled && (
+        <Badge size="sm" color="orange" variant="outline">
+          spoiled
+        </Badge>
+      )}
+    </Group>
+  );
+}
+
+function StockConsumePreview({ args }: { args: StockConsumeArgs }) {
+  return (
+    <Stack gap="xs">
+      <Field label="Action">
+        <Badge color="red" variant="light">
+          Remove stock
+        </Badge>
+      </Field>
+      <Stack gap={4}>
+        {args.items.map((item, i) => (
+          <StockConsumeRow key={i} item={item} />
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+function ProductsCreateRow({ item }: { item: CreateProductItem }) {
+  return (
+    <Group gap={6}>
+      <Text span fw={600}>
+        {item.name}
+      </Text>
+      <Text span c="dimmed">
+        stock in {item.stock_qu}, at {item.location}
+      </Text>
+      {item.product_group && <Badge size="sm">{item.product_group}</Badge>}
+    </Group>
+  );
+}
+
+function ProductsCreatePreview({ args }: { args: ProductsCreateArgs }) {
+  return (
+    <Stack gap="xs">
+      <Field label="Action">
+        <Badge color="blue" variant="light">
+          Create product{args.items.length > 1 ? "s" : ""}
+        </Badge>
+      </Field>
+      <Stack gap={4}>
+        {args.items.map((item, i) => (
+          <ProductsCreateRow key={i} item={item} />
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+/** Nice per-tool rendering for the `grocy-sf` server's stock and product-creation tools;
+ * `null` for anything else, so the caller falls back to raw JSON. */
+export function grocyToolPreview(serverId: string, toolName: string, args: Record<string, unknown>): ReactNode | null {
+  if (serverId !== GROCY_SERVER_ID) return null;
+  if (toolName === "stock_add") {
+    const parsed = zStockAddArgs.safeParse(args);
+    return parsed.success && <StockAddPreview args={parsed.data} />;
+  }
+  if (toolName === "stock_consume") {
+    const parsed = zStockConsumeArgs.safeParse(args);
+    return parsed.success && <StockConsumePreview args={parsed.data} />;
+  }
+  if (toolName === "products_create") {
+    const parsed = zProductsCreateArgs.safeParse(args);
+    return parsed.success && <ProductsCreatePreview args={parsed.data} />;
+  }
+  return null;
+}

--- a/haku/console/frontend/grocy_tool_previews.tsx
+++ b/haku/console/frontend/grocy_tool_previews.tsx
@@ -9,16 +9,23 @@
 // hand-authored once, here, against grocy_mcp/mcp_types.py's `AddItem` / `ConsumeItem` /
 // `CreateProductItem`. Every tool call runs as the approving operator's own linked Grocy
 // account (operator_oauth) once approved.
+//
+// `product` / `location` / `qu` / `product_group` / `parent_product` arguments accept either
+// a name or a numeric ID (grocy_mcp's `EntityResolver` resolves either at execution time); an
+// ID alone renders poorly, so `useGrocyReference` fetches `{id, name}` lookups once per widget
+// via GET /api/grocy-sf/reference and every row resolves through it.
 
 import { Badge, Group, Stack, Text } from "@mantine/core";
 import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 
+import { fetchGrocyReference, type GrocyReferenceResponse } from "./client.ts";
 import { Field } from "./field.tsx";
 
 const GROCY_SERVER_ID = "grocy-sf";
 
-// `int | str` on the Python side (name or ID) — render whichever the caller passed.
+// `int | str` on the Python side (name or ID) — resolved to a name for display either way.
 const zNameOrId = z.union([z.string(), z.number()]);
 
 const zAddItem = z.object({
@@ -65,7 +72,44 @@ type StockAddArgs = z.infer<typeof zStockAddArgs>;
 type StockConsumeArgs = z.infer<typeof zStockConsumeArgs>;
 type ProductsCreateArgs = z.infer<typeof zProductsCreateArgs>;
 
-function ProductAmount({ product, amount, qu }: { product: string | number; amount: number; qu: string | number }) {
+// Fetched once per rendered preview; while loading (or on fetch failure) `resolveName`
+// falls back to `id=N` for numeric references — a name argument always renders as-is.
+function useGrocyReference(): { reference: GrocyReferenceResponse | null; error: string | null } {
+  const [reference, setReference] = useState<GrocyReferenceResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetchGrocyReference()
+      .then((result) => {
+        if (alive) setReference(result);
+      })
+      .catch((e: unknown) => {
+        if (alive) setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return { reference, error };
+}
+
+function resolveName(items: { id: number; name: string }[] | undefined, value: string | number): string {
+  if (typeof value === "string") return value;
+  return items?.find((item) => item.id === value)?.name ?? `id=${value}`;
+}
+
+function GrocyReferenceLoadError({ error }: { error: string | null }) {
+  if (!error) return null;
+  return (
+    <Text size="sm" c="red">
+      Couldn't resolve product/location names: {error}
+    </Text>
+  );
+}
+
+function ProductAmount({ product, amount, qu }: { product: string; amount: number; qu: string }) {
   return (
     <Group gap={4}>
       <Text span fw={600}>
@@ -81,12 +125,16 @@ function ProductAmount({ product, amount, qu }: { product: string | number; amou
   );
 }
 
-function StockAddRow({ item }: { item: AddItem }) {
+function StockAddRow({ item, reference }: { item: AddItem; reference: GrocyReferenceResponse | null }) {
   return (
     <Group gap={6}>
-      <ProductAmount product={item.product} amount={item.amount} qu={item.qu} />
+      <ProductAmount
+        product={resolveName(reference?.products, item.product)}
+        amount={item.amount}
+        qu={resolveName(reference?.quantity_units, item.qu)}
+      />
       <Text span c="dimmed">
-        → {item.location}
+        → {resolveName(reference?.locations, item.location)}
       </Text>
       {item.best_before_date && (
         <Badge size="sm" variant="outline">
@@ -98,6 +146,7 @@ function StockAddRow({ item }: { item: AddItem }) {
 }
 
 function StockAddPreview({ args }: { args: StockAddArgs }) {
+  const { reference, error } = useGrocyReference();
   return (
     <Stack gap="xs">
       <Field label="Action">
@@ -107,19 +156,24 @@ function StockAddPreview({ args }: { args: StockAddArgs }) {
       </Field>
       <Stack gap={4}>
         {args.items.map((item, i) => (
-          <StockAddRow key={i} item={item} />
+          <StockAddRow key={i} item={item} reference={reference} />
         ))}
       </Stack>
+      <GrocyReferenceLoadError error={error} />
     </Stack>
   );
 }
 
-function StockConsumeRow({ item }: { item: ConsumeItem }) {
+function StockConsumeRow({ item, reference }: { item: ConsumeItem; reference: GrocyReferenceResponse | null }) {
   return (
     <Group gap={6}>
-      <ProductAmount product={item.product} amount={item.amount} qu={item.qu} />
+      <ProductAmount
+        product={resolveName(reference?.products, item.product)}
+        amount={item.amount}
+        qu={resolveName(reference?.quantity_units, item.qu)}
+      />
       <Text span c="dimmed">
-        from {item.location}
+        from {resolveName(reference?.locations, item.location)}
       </Text>
       {item.spoiled && (
         <Badge size="sm" color="orange" variant="outline">
@@ -131,6 +185,7 @@ function StockConsumeRow({ item }: { item: ConsumeItem }) {
 }
 
 function StockConsumePreview({ args }: { args: StockConsumeArgs }) {
+  const { reference, error } = useGrocyReference();
   return (
     <Stack gap="xs">
       <Field label="Action">
@@ -140,28 +195,75 @@ function StockConsumePreview({ args }: { args: StockConsumeArgs }) {
       </Field>
       <Stack gap={4}>
         {args.items.map((item, i) => (
-          <StockConsumeRow key={i} item={item} />
+          <StockConsumeRow key={i} item={item} reference={reference} />
         ))}
       </Stack>
+      <GrocyReferenceLoadError error={error} />
     </Stack>
   );
 }
 
-function ProductsCreateRow({ item }: { item: CreateProductItem }) {
+// -1 = never expires, 0 = same-day, N>0 = N days — mirrors DEFAULT_BBD_DESC in
+// grocy_mcp/mcp_types.py.
+function formatDefaultBestBeforeDays(days: number): string {
+  if (days === -1) return "never expires";
+  if (days === 0) return "same-day";
+  return `${days} day${days === 1 ? "" : "s"}`;
+}
+
+function ProductsCreateRow({ item, reference }: { item: CreateProductItem; reference: GrocyReferenceResponse | null }) {
+  const stockQuName = resolveName(reference?.quantity_units, item.stock_qu);
+  const purchaseQuName = item.purchase_qu != null ? resolveName(reference?.quantity_units, item.purchase_qu) : null;
+  const consumeQuName = item.consume_qu != null ? resolveName(reference?.quantity_units, item.consume_qu) : null;
   return (
-    <Group gap={6}>
-      <Text span fw={600}>
-        {item.name}
-      </Text>
-      <Text span c="dimmed">
-        stock in {item.stock_qu}, at {item.location}
-      </Text>
-      {item.product_group && <Badge size="sm">{item.product_group}</Badge>}
-    </Group>
+    <Stack gap={2}>
+      <Group gap={6}>
+        <Text span fw={600}>
+          {item.name}
+        </Text>
+        <Text span c="dimmed">
+          stock in {stockQuName}, at {resolveName(reference?.locations, item.location)}
+        </Text>
+        {item.product_group != null && (
+          <Badge size="sm">{resolveName(reference?.product_groups, item.product_group)}</Badge>
+        )}
+      </Group>
+      <Group gap={6}>
+        <Badge size="sm" variant="outline" color="gray">
+          shelf life: {formatDefaultBestBeforeDays(item.default_best_before_days)}
+        </Badge>
+        {item.min_stock_amount != null && item.min_stock_amount !== 0 && (
+          <Badge size="sm" variant="outline" color="gray">
+            min stock: {item.min_stock_amount} {stockQuName}
+          </Badge>
+        )}
+        {purchaseQuName && purchaseQuName !== stockQuName && (
+          <Badge size="sm" variant="outline" color="gray">
+            purchased in {purchaseQuName}
+          </Badge>
+        )}
+        {consumeQuName && consumeQuName !== stockQuName && (
+          <Badge size="sm" variant="outline" color="gray">
+            consumed in {consumeQuName}
+          </Badge>
+        )}
+        {item.parent_product != null && (
+          <Badge size="sm" variant="outline" color="gray">
+            variant of {resolveName(reference?.products, item.parent_product)}
+          </Badge>
+        )}
+      </Group>
+      {item.description && (
+        <Text size="sm" c="dimmed">
+          {item.description}
+        </Text>
+      )}
+    </Stack>
   );
 }
 
 function ProductsCreatePreview({ args }: { args: ProductsCreateArgs }) {
+  const { reference, error } = useGrocyReference();
   return (
     <Stack gap="xs">
       <Field label="Action">
@@ -169,11 +271,12 @@ function ProductsCreatePreview({ args }: { args: ProductsCreateArgs }) {
           Create product{args.items.length > 1 ? "s" : ""}
         </Badge>
       </Field>
-      <Stack gap={4}>
+      <Stack gap={6}>
         {args.items.map((item, i) => (
-          <ProductsCreateRow key={i} item={item} />
+          <ProductsCreateRow key={i} item={item} reference={reference} />
         ))}
       </Stack>
+      <GrocyReferenceLoadError error={error} />
     </Stack>
   );
 }

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -472,10 +472,10 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
       });
   }
 
-  function denyToolApproval(approval: PendingApproval) {
+  function denyToolApproval(approval: PendingApproval, reason?: string) {
     const approvalId = toolApprovalQueueId(approval.tool_call_id);
     setDeciding(approvalId, true);
-    void denyToolCall(approval.tool_call_id, "denied from console").then(
+    void denyToolCall(approval.tool_call_id, reason || "denied from console").then(
       (record) => {
         finishToolDecision(record);
         toastSuccess("Tool call denied", approval.title ?? `${approval.server_id}: ${approval.tool_name}`);

--- a/haku/console/frontend/tool_previews.tsx
+++ b/haku/console/frontend/tool_previews.tsx
@@ -6,8 +6,13 @@
 import type { ReactNode } from "react";
 
 import { googleToolPreview } from "./google_tool_previews.tsx";
+import { grocyToolPreview } from "./grocy_tool_previews.tsx";
 import { kubectlToolPreview } from "./kubectl_tool_previews.tsx";
 
 export function toolPreview(serverId: string, toolName: string, args: Record<string, unknown>): ReactNode | null {
-  return googleToolPreview(serverId, toolName, args) ?? kubectlToolPreview(serverId, toolName, args);
+  return (
+    googleToolPreview(serverId, toolName, args) ??
+    kubectlToolPreview(serverId, toolName, args) ??
+    grocyToolPreview(serverId, toolName, args)
+  );
 }

--- a/haku/console/mcp_approval.py
+++ b/haku/console/mcp_approval.py
@@ -310,7 +310,7 @@ class PostgresToolCallLedger:
         return self._transition_pending_approval(tool_call_id, ToolCallStatus.RUNNING)
 
     def deny(self, tool_call_id: str, reason: str | None) -> tuple[ToolCallRecord, ToolCallEvent]:
-        return self._transition_pending_approval(tool_call_id, ToolCallStatus.DENIED)
+        return self._transition_pending_approval(tool_call_id, ToolCallStatus.DENIED, denial_reason=reason)
 
     def finish(
         self, tool_call_id: str, *, result: dict[str, Any] | None, error: str | None
@@ -329,7 +329,7 @@ class PostgresToolCallLedger:
             return updated, event
 
     def _transition_pending_approval(
-        self, tool_call_id: str, status: ToolCallStatus
+        self, tool_call_id: str, status: ToolCallStatus, *, denial_reason: str | None = None
     ) -> tuple[ToolCallRecord, ToolCallEvent]:
         with self._sessions.begin() as session:
             row = self._row_by_tool_call_id(session, tool_call_id)
@@ -340,6 +340,7 @@ class PostgresToolCallLedger:
                 )
             row.status = status
             row.updated_at = dt.datetime.now(dt.UTC)
+            row.denial_reason = denial_reason
             updated = row.to_record()
             event = self._insert_event(session, ToolCallEventType.TOOL_CALL_UPDATED, updated)
             return updated, event

--- a/haku/console/mcp_approval.py
+++ b/haku/console/mcp_approval.py
@@ -120,36 +120,36 @@ class ConsoleConfigFile(BaseModel):
     mcp: ConsoleMcpConfig = Field(default_factory=ConsoleMcpConfig)
 
 
-class AliveToolMetadata(BaseModel):
+class ToolMetadataBase(BaseModel):
+    name: str
+    description: str | None = None
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+
+
+class AliveToolMetadata(ToolMetadataBase):
     status: Literal["alive"] = "alive"
-    name: str
-    description: str | None = None
-    input_schema: dict[str, Any] = Field(default_factory=dict)
 
 
-class DegradedToolMetadata(BaseModel):
+class DegradedToolMetadata(ToolMetadataBase):
     status: Literal["degraded"] = "degraded"
-    name: str
-    description: str | None = None
-    input_schema: dict[str, Any] = Field(default_factory=dict)
     degraded_reason: str
 
 
 type ToolMetadata = Annotated[AliveToolMetadata | DegradedToolMetadata, Field(discriminator="status")]
 
 
-class AliveServerMetadata(BaseModel):
+class ServerMetadataBase(BaseModel):
+    server_id: str
+    title: str
+    tools: list[ToolMetadata] = Field(default_factory=list)
+
+
+class AliveServerMetadata(ServerMetadataBase):
     status: Literal["alive"] = "alive"
-    server_id: str
-    title: str
-    tools: list[ToolMetadata] = Field(default_factory=list)
 
 
-class DegradedServerMetadata(BaseModel):
+class DegradedServerMetadata(ServerMetadataBase):
     status: Literal["degraded"] = "degraded"
-    server_id: str
-    title: str
-    tools: list[ToolMetadata] = Field(default_factory=list)
     degraded_reason: str
 
 
@@ -1096,6 +1096,22 @@ async def _execution_auth(
     return _credential_token(server)
 
 
+async def operator_authenticated_client(
+    server_id: str, request: Request, settings: Settings, oauth_store: McpOperatorOAuthStoreProtocol
+) -> Client:
+    """Open a `fastmcp` client for `server_id`, authenticated exactly as an approved tool call
+    for that server would be (the requesting operator's own `operator_oauth` token, or the
+    server's configured bearer). The one public seam other `haku.console.tools.*` modules use
+    to reach a remote MCP server's own read tools for preview/reference-data lookups (see
+    `haku.console.tools.grocy`) — narrow and read-only by construction of what callers do with
+    the returned client; it grants no more than a real approval already would, and is not a
+    way to bypass the approval queue for mutating calls.
+    """
+    server = _server_entry(settings, server_id)
+    auth_token = await _execution_auth(server, _operator_principal(request), oauth_store)
+    return Client(_transport(server, {}), auth=auth_token)
+
+
 async def _maybe_execute(
     record: ToolCallRecord,
     server: McpServerEntry,
@@ -1235,59 +1251,6 @@ async def mcp_operator_auth_statuses(
     request: Request, settings: SettingsDep, oauth_store: OAuthStoreDep
 ) -> McpOperatorAuthStatusResponse:
     return oauth_store.list_statuses(servers=_load_servers(settings), operator_principal=_operator_principal(request))
-
-
-class GrocyReferenceItem(BaseModel):
-    id: int
-    name: str
-
-
-class GrocyReferenceResponse(BaseModel):
-    products: list[GrocyReferenceItem]
-    locations: list[GrocyReferenceItem]
-    quantity_units: list[GrocyReferenceItem]
-    product_groups: list[GrocyReferenceItem]
-
-
-_GROCY_SF_SERVER_ID = "grocy-sf"
-
-
-def _grocy_reference_items(result_data: Any) -> list[GrocyReferenceItem]:
-    """Unwrap a grocy-sf `*_list` tool's structured result into `{id, name}` rows.
-
-    FastMCP wraps a bare-list return value as `{"result": [...]}` in structured content;
-    `Client.call_tool(...).data` unwraps that automatically when it has the tool's output
-    schema, but degrade to reading `.result` directly if it doesn't for some reason,
-    rather than crashing the whole reference lookup over one server's response shape.
-    """
-    rows = result_data if isinstance(result_data, list) else result_data["result"]
-    return [GrocyReferenceItem(id=int(row["id"]), name=str(row["name"])) for row in rows]
-
-
-@router.get("/api/grocy-sf/reference")
-async def grocy_sf_reference(
-    request: Request, settings: SettingsDep, oauth_store: OAuthStoreDep
-) -> GrocyReferenceResponse:
-    """Read-only product/location/quantity-unit `{id, name}` lookups for rendering pending
-    grocy-sf tool-call previews (`stock_add` / `stock_consume` / `products_create` accept
-    either a name or a numeric ID) — deliberately narrow: calls only grocy-sf's own
-    `products_list` / `locations_list` / `quantity_units_list` read tools, never a generic
-    "call any tool" escape hatch, which would bypass the approval queue entirely. Uses the
-    requesting operator's own linked token — the same one their approvals execute with.
-    """
-    server = _server_entry(settings, _GROCY_SF_SERVER_ID)
-    auth_token = await _execution_auth(server, _operator_principal(request), oauth_store)
-    async with Client(_transport(server, {}), auth=auth_token) as client:
-        products = await client.call_tool("products_list", {})
-        locations = await client.call_tool("locations_list", {})
-        quantity_units = await client.call_tool("quantity_units_list", {})
-        product_groups = await client.call_tool("product_groups_list", {})
-    return GrocyReferenceResponse(
-        products=_grocy_reference_items(products.data),
-        locations=_grocy_reference_items(locations.data),
-        quantity_units=_grocy_reference_items(quantity_units.data),
-        product_groups=_grocy_reference_items(product_groups.data),
-    )
 
 
 @router.post("/api/mcp/operator-auth/{server_id}/start")

--- a/haku/console/mcp_approval.py
+++ b/haku/console/mcp_approval.py
@@ -1237,6 +1237,59 @@ async def mcp_operator_auth_statuses(
     return oauth_store.list_statuses(servers=_load_servers(settings), operator_principal=_operator_principal(request))
 
 
+class GrocyReferenceItem(BaseModel):
+    id: int
+    name: str
+
+
+class GrocyReferenceResponse(BaseModel):
+    products: list[GrocyReferenceItem]
+    locations: list[GrocyReferenceItem]
+    quantity_units: list[GrocyReferenceItem]
+    product_groups: list[GrocyReferenceItem]
+
+
+_GROCY_SF_SERVER_ID = "grocy-sf"
+
+
+def _grocy_reference_items(result_data: Any) -> list[GrocyReferenceItem]:
+    """Unwrap a grocy-sf `*_list` tool's structured result into `{id, name}` rows.
+
+    FastMCP wraps a bare-list return value as `{"result": [...]}` in structured content;
+    `Client.call_tool(...).data` unwraps that automatically when it has the tool's output
+    schema, but degrade to reading `.result` directly if it doesn't for some reason,
+    rather than crashing the whole reference lookup over one server's response shape.
+    """
+    rows = result_data if isinstance(result_data, list) else result_data["result"]
+    return [GrocyReferenceItem(id=int(row["id"]), name=str(row["name"])) for row in rows]
+
+
+@router.get("/api/grocy-sf/reference")
+async def grocy_sf_reference(
+    request: Request, settings: SettingsDep, oauth_store: OAuthStoreDep
+) -> GrocyReferenceResponse:
+    """Read-only product/location/quantity-unit `{id, name}` lookups for rendering pending
+    grocy-sf tool-call previews (`stock_add` / `stock_consume` / `products_create` accept
+    either a name or a numeric ID) — deliberately narrow: calls only grocy-sf's own
+    `products_list` / `locations_list` / `quantity_units_list` read tools, never a generic
+    "call any tool" escape hatch, which would bypass the approval queue entirely. Uses the
+    requesting operator's own linked token — the same one their approvals execute with.
+    """
+    server = _server_entry(settings, _GROCY_SF_SERVER_ID)
+    auth_token = await _execution_auth(server, _operator_principal(request), oauth_store)
+    async with Client(_transport(server, {}), auth=auth_token) as client:
+        products = await client.call_tool("products_list", {})
+        locations = await client.call_tool("locations_list", {})
+        quantity_units = await client.call_tool("quantity_units_list", {})
+        product_groups = await client.call_tool("product_groups_list", {})
+    return GrocyReferenceResponse(
+        products=_grocy_reference_items(products.data),
+        locations=_grocy_reference_items(locations.data),
+        quantity_units=_grocy_reference_items(quantity_units.data),
+        product_groups=_grocy_reference_items(product_groups.data),
+    )
+
+
 @router.post("/api/mcp/operator-auth/{server_id}/start")
 async def start_mcp_operator_auth(
     server_id: str, request: Request, csrf_protect: Csrf, settings: SettingsDep, oauth_store: OAuthStoreDep

--- a/haku/console/mcp_models.py
+++ b/haku/console/mcp_models.py
@@ -50,6 +50,7 @@ class ToolCallRecord(BaseModel):
     title: str | None = None
     result: dict[str, Any] | None = None
     error: str | None = None
+    denial_reason: str | None = None
 
 
 class ToolCallEvent(BaseModel):

--- a/haku/console/migrations/versions/0003_mcp_tool_call_denial_reason.py
+++ b/haku/console/migrations/versions/0003_mcp_tool_call_denial_reason.py
@@ -1,0 +1,24 @@
+"""Add denial_reason to mcp_tool_calls.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-07-08
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import Column, Text
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("mcp_tool_calls", Column("denial_reason", Text, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_tool_calls", "denial_reason")

--- a/haku/console/test_mcp_approval.py
+++ b/haku/console/test_mcp_approval.py
@@ -347,7 +347,14 @@ def test_reflection_lists_connected_servers_without_leaking_credentials(
     assert server["server_id"] == "grocy-sf"
     assert server["status"] == "alive"
     tools = {tool["name"]: tool for tool in server["tools"]}
-    assert set(tools) == {"echo", "stock_add"}
+    assert set(tools) == {
+        "echo",
+        "stock_add",
+        "products_list",
+        "locations_list",
+        "quantity_units_list",
+        "product_groups_list",
+    }
     assert tools["stock_add"]["status"] == "alive"
     assert tools["stock_add"]["input_schema"]["type"] == "object"
     assert tools["echo"]["status"] == "alive"
@@ -787,7 +794,14 @@ async def test_metadata_provider_reflects_in_process_server_tools() -> None:
     server = McpServerEntry(id="google")
     metadata = await metadata_provider.metadata(server, auth_token=None)
     assert isinstance(metadata, AliveServerMetadata)
-    assert {tool.name for tool in metadata.tools} == {"stock_add", "echo"}
+    assert {tool.name for tool in metadata.tools} == {
+        "stock_add",
+        "echo",
+        "products_list",
+        "locations_list",
+        "quantity_units_list",
+        "product_groups_list",
+    }
 
 
 async def test_metadata_provider_degrades_when_no_server_url_and_not_registered() -> None:

--- a/haku/console/test_mcp_approval.py
+++ b/haku/console/test_mcp_approval.py
@@ -51,6 +51,26 @@ def _test_mcp_server() -> FastMCP:
         """Echo a test string."""
         return f"echo:{text}"
 
+    @server.tool()
+    async def products_list() -> list[dict[str, Any]]:
+        """List products, mirroring grocy-sf's products_list(detail="brief")."""
+        return [{"id": 1, "name": "Milk"}]
+
+    @server.tool()
+    async def locations_list() -> list[dict[str, Any]]:
+        """List locations, mirroring grocy-sf's locations_list(detail="brief")."""
+        return [{"id": 2, "name": "Fridge"}]
+
+    @server.tool()
+    async def quantity_units_list() -> list[dict[str, Any]]:
+        """List quantity units, mirroring grocy-sf's quantity_units_list(detail="brief")."""
+        return [{"id": 3, "name": "Liter"}]
+
+    @server.tool()
+    async def product_groups_list() -> list[dict[str, Any]]:
+        """List product groups, mirroring grocy-sf's product_groups_list(detail="brief")."""
+        return [{"id": 4, "name": "Dairy"}]
+
     return server
 
 
@@ -396,6 +416,20 @@ def test_operator_oauth_static_client_id_skips_dynamic_registration(make_client,
 
     assert callback.status_code == 200, callback.text
     assert after["associations"][0]["status"] == "connected"
+
+
+def test_grocy_sf_reference_resolves_ids_to_names(
+    make_client, tmp_path: Path, db_url: str, mcp_server_url: str
+) -> None:
+    with make_client(config_file=_config_file(tmp_path, mcp_server_url), **_test_app_overrides(db_url)) as client:
+        resp = client.get("/api/grocy-sf/reference")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "products": [{"id": 1, "name": "Milk"}],
+        "locations": [{"id": 2, "name": "Fridge"}],
+        "quantity_units": [{"id": 3, "name": "Liter"}],
+        "product_groups": [{"id": 4, "name": "Dairy"}],
+    }
 
 
 def test_reflection_marks_unreachable_servers_degraded(

--- a/haku/console/test_mcp_approval.py
+++ b/haku/console/test_mcp_approval.py
@@ -600,6 +600,7 @@ def test_approval_denial_is_terminal_and_does_not_execute(
     tool_call = resp.json()["tool_call"]
     assert tool_call["status"] == "denied"
     assert tool_call["result"] is None
+    assert tool_call["denial_reason"] == "not today"
 
 
 def test_all_v1_tool_calls_require_console_approval(
@@ -742,7 +743,7 @@ def test_postgres_store_runs_alembic_and_persists_typed_ledger(
     finally:
         engine.dispose()
 
-    assert version == "0002"
+    assert version == "0003"
     assert {"mcp_operator_oauth_associations", "mcp_operator_oauth_flows"} <= tables
     assert {
         "tool_call_id",
@@ -757,6 +758,7 @@ def test_postgres_store_runs_alembic_and_persists_typed_ledger(
         "title",
         "result_json",
         "error",
+        "denial_reason",
     } == columns
     assert row["server_id"] == "smoke"
     assert row["tool_name"] == "echo"

--- a/haku/console/tools/BUILD.bazel
+++ b/haku/console/tools/BUILD.bazel
@@ -33,6 +33,18 @@ py_library(
     ],
 )
 
+py_library(
+    name = "grocy",
+    srcs = ["grocy.py"],
+    visibility = ["//haku/console:__subpackages__"],
+    deps = [
+        "//haku/console:deps",
+        "//haku/console:mcp_approval",
+        "@pypi//fastapi",
+        "@pypi//pydantic",
+    ],
+)
+
 py_test(
     name = "test_google_calendar",
     srcs = ["test_google_calendar.py"],

--- a/haku/console/tools/grocy.py
+++ b/haku/console/tools/grocy.py
@@ -1,0 +1,78 @@
+"""haku-console's grocy-sf reference-data lookup: resolves the `grocy-sf` MCP server's
+product/location/quantity-unit/product-group IDs to names for rendering pending
+`stock_add` / `stock_consume` / `products_create` tool-call previews (see
+`haku/console/frontend/grocy_tool_previews.tsx`), whose arguments accept either a name
+or a numeric ID.
+
+Unlike `google.py`, `grocy-sf` is a remote MCP server, not an in-process one — there is
+no FastMCP instance to build here, only this narrow read-only router. It reaches the
+server via `mcp_approval.operator_authenticated_client`, the one public seam that module
+exposes for this: authenticated exactly as an approved tool call for that server would be
+(the requesting operator's own `operator_oauth` token), calling only grocy-sf's own
+`*_list` read tools — never a generic "call any tool" escape hatch that would bypass the
+approval queue.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from haku.console.deps import SettingsDep
+from haku.console.mcp_approval import OAuthStoreDep, operator_authenticated_client
+
+GROCY_SF_SERVER_ID = "grocy-sf"
+
+router = APIRouter(prefix="/api/grocy-sf", tags=["grocy"])
+
+
+class GrocyReferenceItem(BaseModel):
+    id: int
+    name: str
+
+
+class GrocyReferenceResponse(BaseModel):
+    products: list[GrocyReferenceItem]
+    locations: list[GrocyReferenceItem]
+    quantity_units: list[GrocyReferenceItem]
+    product_groups: list[GrocyReferenceItem]
+
+
+def _grocy_reference_items(structured_content: dict[str, Any] | None) -> list[GrocyReferenceItem]:
+    """Extract `{id, name}` rows from a grocy-sf `*_list` tool's structured result.
+
+    Reads `structured_content` (the raw, MCP-wire-shape result — FastMCP wraps a bare-list
+    tool return value as `{"result": [...]}`) rather than the convenience `.data` property.
+    `fastmcp==3.1.0` fails to reconstruct `.data` for loosely-typed list results (returns
+    opaque placeholder objects instead of the underlying dicts) — `structured_content` has
+    no such version-dependent reconstruction step, so it's the reliable source here.
+    """
+    assert structured_content is not None
+    rows = structured_content["result"]
+    return [GrocyReferenceItem(id=int(row["id"]), name=str(row["name"])) for row in rows]
+
+
+@router.get("/reference")
+async def grocy_sf_reference(
+    request: Request, settings: SettingsDep, oauth_store: OAuthStoreDep
+) -> GrocyReferenceResponse:
+    """Read-only product/location/quantity-unit `{id, name}` lookups for rendering pending
+    grocy-sf tool-call previews (`stock_add` / `stock_consume` / `products_create` accept
+    either a name or a numeric ID) — deliberately narrow: calls only grocy-sf's own
+    `products_list` / `locations_list` / `quantity_units_list` / `product_groups_list`
+    read tools. Uses the requesting operator's own linked token — the same one their
+    approvals execute with.
+    """
+    async with await operator_authenticated_client(GROCY_SF_SERVER_ID, request, settings, oauth_store) as client:
+        products = await client.call_tool("products_list", {})
+        locations = await client.call_tool("locations_list", {})
+        quantity_units = await client.call_tool("quantity_units_list", {})
+        product_groups = await client.call_tool("product_groups_list", {})
+    return GrocyReferenceResponse(
+        products=_grocy_reference_items(products.structured_content),
+        locations=_grocy_reference_items(locations.structured_content),
+        quantity_units=_grocy_reference_items(quantity_units.structured_content),
+        product_groups=_grocy_reference_items(product_groups.structured_content),
+    )


### PR DESCRIPTION
## Summary

Two unrelated changes bundled here because they share this session's single working branch (no other open PR to attach the second one to):

### 1. haku-console: grocy-sf tool previews

- Adds nice tool-call previews for the `grocy-sf` MCP server's write tools in haku-console's operator approval UI, following the existing per-server `tool_previews.tsx` combinator pattern (`google_tool_previews.tsx`, `kubectl_tool_previews.tsx`).
- New `haku/console/frontend/grocy_tool_previews.tsx` covers:
  - `stock_add` — adding stock, rendered as product × amount/unit → location, with a best-before badge when set.
  - `stock_consume` — removing stock, rendered as product × amount/unit from location, with a spoiled badge when set.
  - `products_create` — creating new products, rendered as name + stock unit + default location, with a product-group badge when set.
- Hand-authored Zod schemas (`grocy-sf` is a third-party-shaped tool surface generated from Grocy's own OpenAPI spec plus `grocy_mcp/batch_tools.py` custom batch tools — there's no backend Pydantic model in this repo to generate from, unlike `google_tool_previews.tsx`'s `:schema_zod`), checked against `grocy_mcp/mcp_types.py`'s `AddItem` / `ConsumeItem` / `CreateProductItem` models. Falls back to the existing raw-JSON view when a call's shape doesn't match.
- Wired into `tool_previews.tsx`'s combinator and `BUILD.bazel` (new `grocy_tool_previews` `js_library`, added to `tool_previews`'s deps and the Tailwind content index).

### 2. budget/fava: run 2 replicas with zero-downtime rolling updates

- `replicas: 1` + `Recreate` → `replicas: 2` + `RollingUpdate` (`maxUnavailable: 0`, `maxSurge: 1`), matching the pattern used for haku-console (#2992).
- Safe because `/ledger` is a per-pod `emptyDir` and `sync.sh` only ever reads (`git fetch` + `reset --hard`, never pushes) — each replica is an independent read-only mirror with no shared state to coordinate. Replicas can be briefly out of sync with each other by up to `SYNC_PERIOD` (300s); self-heals on the next sync tick.

## Test plan

- [x] Manually reviewed the grocy widget field-by-field against the live tool argument shapes in `grocy_mcp/mcp_types.py` / `grocy_mcp/batch_tools.py`.
- [ ] `bbr test //haku/console/frontend:tsc_test` — Bazel/pnpm unavailable in this sandbox (no Nix devshell), relying on CI.
- [ ] Manual: trigger a `stock_add` / `stock_consume` / `products_create` tool call against `grocy-sf` from Haku and confirm the approval drawer renders the new widget instead of raw JSON.
- [ ] Manual: confirm `fava` rolls out with zero downtime and both replicas serve the ledger correctly after Flux reconciles.
