### PR TITLE
grocy_mcp: dedupe GetOk/GetError shared fields into GetResultBase

### DIFF
--- a/grocy_mcp/mcp_types.py
+++ b/grocy_mcp/mcp_types.py
@@ -135,17 +135,18 @@ class CreateError(BaseModel):
     error: str
 
 
-class GetOk(BaseModel):
-    kind: Literal["ok"] = "ok"
+class GetResultBase(BaseModel):
     entity_type: ReadableEntityType
     object_id: int
+
+
+class GetOk(GetResultBase):
+    kind: Literal["ok"] = "ok"
     data: dict[str, Any]
 
 
-class GetError(BaseModel):
+class GetError(GetResultBase):
     kind: Literal["error"] = "error"
-    entity_type: ReadableEntityType
-    object_id: int
     error: str
 
 


### PR DESCRIPTION
## Summary

- `GetOk` and `GetError` (the discriminated-union result type `entities_get` returns) both duplicated `entity_type` and `object_id` instead of sharing them from a common base — factored into `GetResultBase`, with `GetOk`/`GetError` inheriting from it and adding only their own discriminator + result field.
- Matches the same fix just applied to haku-console's `AliveToolMetadata`/`DegradedToolMetadata` and `AliveServerMetadata`/`DegradedServerMetadata` (per review feedback on an earlier PR in this session) — same smell, same fix pattern.
- Checked every other `Ok`/`Error` pair in `grocy_mcp/mcp_types.py` (`CreateOk`/`CreateError`, `StockOpOk`/`StockOpError`, `StockEntryOk`/`StockEntryError`, `ShoppingListItemOk`/`ShoppingListItemError`) — none share more than the `kind` discriminator, so none needed the same treatment.

## Test plan

- [x] `ruff check` / `ruff format --diff` clean.
- [x] Manually constructed `GetOk`/`GetError` instances and confirmed `model_dump()` produces the same field set/values as before the refactor (both call sites in `grocy_mcp/batch_tools.py` use keyword args, unaffected by the inheritance change).
- [ ] `bbr test //grocy_mcp:test_docstring_cross_links` and the rest of `//grocy_mcp/...` — Bazel unavailable in this sandbox, relying on CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRa6JHZU5xqM8r7hzFHF47)_