### PR TITLE
haku-console frontend: split client.ts per integration, dedupe ApprovalQueueItem

### DIFF
--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -35,6 +35,24 @@ js_library(
 )
 
 js_library(
+    name = "google_client",
+    srcs = ["google_client.ts"],
+    deps = [
+        ":client",
+        ":schema",
+    ],
+)
+
+js_library(
+    name = "grocy_client",
+    srcs = ["grocy_client.ts"],
+    deps = [
+        ":client",
+        ":schema",
+    ],
+)
+
+js_library(
     name = "approval_state",
     srcs = ["approval_state.ts"],
     deps = [
@@ -96,8 +114,8 @@ js_library(
     name = "google_tool_previews",
     srcs = ["google_tool_previews.tsx"],
     deps = [
-        ":client",
         ":field",
+        ":google_client",
         ":schema_zod",
         "//:node_modules/@mantine/core",
         "//:node_modules/date-fns",
@@ -121,8 +139,8 @@ js_library(
     name = "grocy_tool_previews",
     srcs = ["grocy_tool_previews.tsx"],
     deps = [
-        ":client",
         ":field",
+        ":grocy_client",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
         "//:node_modules/zod",
@@ -206,7 +224,9 @@ filegroup(
         "confirm_dialog.tsx",
         "console_panel.tsx",
         "field.tsx",
+        "google_client.ts",
         "google_tool_previews.tsx",
+        "grocy_client.ts",
         "grocy_tool_previews.tsx",
         "haku_ui_embed.tsx",
         "index.html",

--- a/haku/console/frontend/approval_state.ts
+++ b/haku/console/frontend/approval_state.ts
@@ -8,9 +8,14 @@ export interface GeolocationApproval {
   createdAt: string;
 }
 
+interface ApprovalQueueItemBase {
+  id: string;
+  createdAt: string;
+}
+
 export type ApprovalQueueItem =
-  | { kind: "tool"; id: string; createdAt: string; approval: PendingApproval }
-  | { kind: "geolocation"; id: string; createdAt: string; approval: GeolocationApproval };
+  | (ApprovalQueueItemBase & { kind: "tool"; approval: PendingApproval })
+  | (ApprovalQueueItemBase & { kind: "geolocation"; approval: GeolocationApproval });
 
 export interface ApprovalDisplayFields {
   title: string;

--- a/haku/console/frontend/client.ts
+++ b/haku/console/frontend/client.ts
@@ -4,7 +4,9 @@ import type { components, paths } from "./api/schema";
 
 // Same-origin typed client (nginx serves this bundle and proxies /api). Types are
 // generated from the backend's OpenAPI schema: //haku/console/frontend:schema.
-const api = createClient<paths>({ baseUrl: "" });
+// Exported (not module-private) so per-integration client files (google_client.ts,
+// grocy_client.ts) share this one instance instead of each creating their own.
+export const api = createClient<paths>({ baseUrl: "" });
 
 export type ConfigResponse = components["schemas"]["ConfigResponse"];
 export type LaunchRoutineResult = components["schemas"]["LaunchRoutineResult"];
@@ -16,8 +18,9 @@ export type McpOperatorAuthStatus = components["schemas"]["McpOperatorAuthStatus
 export type McpOperatorAuthStartResponse = components["schemas"]["McpOperatorAuthStartResponse"];
 
 // FastAPI error responses are `{detail: string}`; surface that real reason rather
-// than a generic message, falling back when the body isn't shaped that way.
-function errorDetail(error: unknown, fallback: string): string {
+// than a generic message, falling back when the body isn't shaped that way. Exported
+// for per-integration client files to reuse the same error-unwrapping convention.
+export function errorDetail(error: unknown, fallback: string): string {
   if (error && typeof error === "object" && "detail" in error) {
     const { detail } = error as { detail: unknown };
     if (typeof detail === "string") return detail;
@@ -103,36 +106,4 @@ export async function approveToolCall(toolCallId: string): Promise<ToolCallRecor
 
 export async function denyToolCall(toolCallId: string, reason?: string): Promise<ToolCallRecord> {
   return decideToolCall(toolCallId, { decision: "deny", reason: reason ?? null }, "Failed to deny tool call");
-}
-
-export type GmailThreadPreview = components["schemas"]["GmailThreadPreview"];
-
-// The google tool argument types (EventDateTime, CreateCalendarEventArgs, ...) aren't
-// re-exported here: google_tool_previews.tsx gets both the runtime validator and the
-// inferred TS type from :schema_zod (api/schema.zod.ts), generated from the same
-// OpenAPI schema this file's `components["schemas"]` draws from — see
-// `GoogleToolArgumentExamples` in haku/console/tools/google.py for why these models
-// reach that schema even though nothing calls that endpoint for data.
-
-// Live subject/snippet/current-labels lookup for rendering a batch_modify_gmail_thread_labels
-// approval — the tool call's own arguments only carry thread IDs. Threads the operator's
-// account can't resolve (deleted, wrong account, …) are simply absent from the map.
-export async function fetchGmailThreadPreviews(threadIds: string[]): Promise<Record<string, GmailThreadPreview>> {
-  if (threadIds.length === 0) return {};
-  const { data, error } = await api.GET("/api/google/gmail/thread-previews", {
-    params: { query: { thread_id: threadIds } },
-  });
-  if (error || !data) throw new Error(errorDetail(error, "Failed to load Gmail thread previews"));
-  return data.threads;
-}
-
-export type GrocyReferenceResponse = components["schemas"]["GrocyReferenceResponse"];
-
-// Live product/location/quantity-unit `{id, name}` lookup for rendering pending grocy-sf
-// stock_add/stock_consume/products_create approvals — their arguments accept either a name
-// or a numeric ID, and only names render nicely on their own.
-export async function fetchGrocyReference(): Promise<GrocyReferenceResponse> {
-  const { data, error } = await api.GET("/api/grocy-sf/reference");
-  if (error || !data) throw new Error(errorDetail(error, "Failed to load grocy-sf reference data"));
-  return data;
 }

--- a/haku/console/frontend/google_client.ts
+++ b/haku/console/frontend/google_client.ts
@@ -1,0 +1,23 @@
+import { api, errorDetail } from "./client.ts";
+import type { components } from "./api/schema";
+
+export type GmailThreadPreview = components["schemas"]["GmailThreadPreview"];
+
+// The google tool argument types (EventDateTime, CreateCalendarEventArgs, ...) aren't
+// re-exported here: google_tool_previews.tsx gets both the runtime validator and the
+// inferred TS type from :schema_zod (api/schema.zod.ts), generated from the same
+// OpenAPI schema this file's `components["schemas"]` draws from — see
+// `GoogleToolArgumentExamples` in haku/console/tools/google.py for why these models
+// reach that schema even though nothing calls that endpoint for data.
+
+// Live subject/snippet/current-labels lookup for rendering a batch_modify_gmail_thread_labels
+// approval — the tool call's own arguments only carry thread IDs. Threads the operator's
+// account can't resolve (deleted, wrong account, …) are simply absent from the map.
+export async function fetchGmailThreadPreviews(threadIds: string[]): Promise<Record<string, GmailThreadPreview>> {
+  if (threadIds.length === 0) return {};
+  const { data, error } = await api.GET("/api/google/gmail/thread-previews", {
+    params: { query: { thread_id: threadIds } },
+  });
+  if (error || !data) throw new Error(errorDetail(error, "Failed to load Gmail thread previews"));
+  return data.threads;
+}

--- a/haku/console/frontend/google_tool_previews.tsx
+++ b/haku/console/frontend/google_tool_previews.tsx
@@ -19,7 +19,7 @@ import {
   zCreateGmailDraftArgs,
   zEventDateTime,
 } from "./api/schema.zod.ts";
-import { fetchGmailThreadPreviews, type GmailThreadPreview } from "./client.ts";
+import { fetchGmailThreadPreviews, type GmailThreadPreview } from "./google_client.ts";
 import { Field } from "./field.tsx";
 
 const GOOGLE_SERVER_ID = "google";

--- a/haku/console/frontend/grocy_client.ts
+++ b/haku/console/frontend/grocy_client.ts
@@ -1,0 +1,13 @@
+import { api, errorDetail } from "./client.ts";
+import type { components } from "./api/schema";
+
+export type GrocyReferenceResponse = components["schemas"]["GrocyReferenceResponse"];
+
+// Live product/location/quantity-unit `{id, name}` lookup for rendering pending grocy-sf
+// stock_add/stock_consume/products_create approvals — their arguments accept either a name
+// or a numeric ID, and only names render nicely on their own.
+export async function fetchGrocyReference(): Promise<GrocyReferenceResponse> {
+  const { data, error } = await api.GET("/api/grocy-sf/reference");
+  if (error || !data) throw new Error(errorDetail(error, "Failed to load grocy-sf reference data"));
+  return data;
+}

--- a/haku/console/frontend/grocy_tool_previews.tsx
+++ b/haku/console/frontend/grocy_tool_previews.tsx
@@ -20,7 +20,7 @@ import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
-import { fetchGrocyReference, type GrocyReferenceResponse } from "./client.ts";
+import { fetchGrocyReference, type GrocyReferenceResponse } from "./grocy_client.ts";
 import { Field } from "./field.tsx";
 
 const GROCY_SERVER_ID = "grocy-sf";


### PR DESCRIPTION
## Summary

Two small frontend cleanups from review feedback on earlier PRs in this series:

### 1. Split `client.ts` per integration

`client.ts` mixed generic capability/approval/MCP-auth fetchers together with Gmail-specific (`fetchGmailThreadPreviews`, `GmailThreadPreview`) and Grocy-specific (`fetchGrocyReference`, `GrocyReferenceResponse`) ones — grocy details didn't need to live with Google details. Split into:

- `google_client.ts` — Gmail thread-preview fetch, used by `google_tool_previews.tsx`.
- `grocy_client.ts` — grocy-sf reference-data fetch, used by `grocy_tool_previews.tsx`.
- `client.ts` — now just the generic capability/approval/config/MCP-auth surface, exporting `api` (the shared `openapi-fetch` client) and `errorDetail` (the shared error-unwrapping helper) as the seam the two new files build on.

Mirrors the backend's equivalent split (grocy-sf's reference endpoint already moved from `mcp_approval.py` into `haku/console/tools/grocy.py` in a prior PR).

### 2. Dedupe `ApprovalQueueItem`'s shared fields

The `"tool"` / `"geolocation"` variants both duplicated `id` and `createdAt` instead of sharing them from a base type — the same discriminated-union smell already fixed on the backend (`AliveToolMetadata`/`DegradedToolMetadata`, `AliveServerMetadata`/`DegradedServerMetadata` in `mcp_approval.py`, `GetOk`/`GetError` in `grocy_mcp/mcp_types.py`). Factored into `ApprovalQueueItemBase & {...}` intersections; discriminated narrowing (`item.kind === "tool"`) is unaffected since `kind` is still a literal directly on each variant.

## Test plan

- [x] Grepped for every `client.ts` import across the frontend — only the two preview files imported the moved symbols; both updated.
- [x] Verified `approvalQueueItems`'s two construction sites still satisfy the intersection type (flat object literals with all required fields) and that no test file constructs `ApprovalQueueItem` shapes directly.
- [x] Checked line lengths (prettier `printWidth: 120`) across all touched files.
- [ ] `bbr test //haku/console/frontend:tsc_test` — Bazel/pnpm unavailable in this sandbox, relying on CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRa6JHZU5xqM8r7hzFHF47)_