### PR TITLE
Auto-rotate Forgejo registry secret daily to bound drift

### DIFF
--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -188,13 +188,17 @@ resource "forgejo_repository_action_secret" "registry_push" {
   }
 }
 
-# The Forgejo provider cannot read back Actions secret values, so opaque value
-# drift can look like "NoDrift" to Terraform while CI still receives stale auth.
-# This controller-owned refresh marker forces the provider to rewrite the secret
-# once now; bump the marker if the secret ever needs an explicit declarative
-# rewrite again.
+# The Forgejo provider cannot read Actions-secret values back, so the secret is
+# effectively write-only: out-of-band drift (a write that silently failed, a
+# restored Forgejo DB) reads as NoDrift on every future plan while CI receives
+# stale auth (bit twice: 2026-07-06 and 2026-07-08). Since drift cannot be
+# *detected*, re-assert instead of marking: this terraform_data replaces itself
+# whenever the plan's calendar date changes, cascading via replace_triggered_by
+# into a rewrite of the secret from random_password.haku — bounding any silent
+# drift to <24h with no manual marker to remember to bump. Password rotations
+# still propagate immediately via replace_triggered_by on random_password.haku.
 resource "terraform_data" "registry_push_secret_refresh" {
-  triggers_replace = ["2026-07-08-haku-registry-push-token-resync"]
+  triggers_replace = [formatdate("YYYY-MM-DD", plantimestamp())]
 }
 
 # Registration token for the contained Forgejo Actions runner (cluster/k8s/haku-ci),

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -194,7 +194,7 @@ resource "forgejo_repository_action_secret" "registry_push" {
 # once now; bump the marker if the secret ever needs an explicit declarative
 # rewrite again.
 resource "terraform_data" "registry_push_secret_refresh" {
-  triggers_replace = ["2026-07-06-haku-registry-push-token-resync"]
+  triggers_replace = ["2026-07-08-haku-registry-push-token-resync"]
 }
 
 # Registration token for the contained Forgejo Actions runner (cluster/k8s/haku-ci),


### PR DESCRIPTION
## Summary
Replace the manual refresh marker for the Forgejo registry push secret with an automatic daily rotation mechanism. This ensures any silent authentication drift is bounded to less than 24 hours without requiring manual intervention.

## Key Changes
- Changed `triggers_replace` from a static date string (`"2026-07-06-haku-registry-push-token-resync"`) to a dynamic expression using `formatdate("YYYY-MM-DD", plantimestamp())`
- This causes the `terraform_data.registry_push_secret_refresh` resource to replace itself whenever the calendar date changes
- The replacement cascades via `replace_triggered_by` to force a rewrite of the secret from `random_password.haku`
- Updated the comment to explain the new automatic drift-bounding strategy

## Implementation Details
The Forgejo provider cannot read back Actions secret values, making secrets effectively write-only. Out-of-band drift (failed writes, restored databases) cannot be detected by Terraform. Rather than relying on manual marker bumps to trigger rewrites, this change uses the current date as a trigger, ensuring the secret is automatically rewritten daily. This bounds any undetected drift to a maximum of 24 hours while password rotations still propagate immediately through the existing `replace_triggered_by` mechanism on `random_password.haku`.

https://claude.ai/code/session_013cqH5HEuFcbnXnDp3zFzPk