### PR TITLE
gmail_api: fix refresh_handler keyword-argument mismatch

### DIFF
--- a/gmail_api/BUILD.bazel
+++ b/gmail_api/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devinfra/python:defs.bzl", "py_library")
+load("//devinfra/python:defs.bzl", "py_library", "py_test")
 
 py_library(
     name = "labels",
@@ -14,5 +14,14 @@ py_library(
     deps = [
         "@pypi//google_api_python_client",
         "@pypi//google_auth",
+    ],
+)
+
+py_test(
+    name = "test_service",
+    srcs = ["test_service.py"],
+    deps = [
+        ":service",
+        "@pypi//pytest_bazel",
     ],
 )

--- a/gmail_api/service.py
+++ b/gmail_api/service.py
@@ -38,7 +38,9 @@ def credentials_from_token_dir(token_dir: Path, scopes: Sequence[str]) -> Creden
     scopes cover from the one `Credentials` object.
     """
 
-    def refresh_handler(request: object, requested_scopes: Sequence[str] | None) -> tuple[str, dt.datetime]:
+    def refresh_handler(request: object, scopes: Sequence[str] | None) -> tuple[str, dt.datetime]:
+        # google-auth's Credentials.refresh() calls this with `scopes=` as a keyword
+        # argument (see google.oauth2.credentials); the parameter name must match exactly.
         token = (token_dir / "access_token").read_text().strip()
         return token, _read_expiry(token_dir / "expires_at")
 

--- a/gmail_api/test_service.py
+++ b/gmail_api/test_service.py
@@ -1,0 +1,29 @@
+"""Tests for credentials_from_token_dir's refresh handling."""
+
+import datetime as dt
+from pathlib import Path
+
+import pytest_bazel
+
+from gmail_api.service import credentials_from_token_dir
+
+
+def test_refresh_calls_handler_the_way_google_auth_does(tmp_path: Path) -> None:
+    """google-auth's Credentials.refresh() calls refresh_handler(request, scopes=scopes) —
+    a keyword argument named `scopes`. A prior refactor renamed the parameter to
+    `requested_scopes` and broke this at runtime (TypeError), undetected because no test
+    exercised the actual google-auth call convention.
+    """
+    expires_at = dt.datetime.now(dt.UTC).replace(tzinfo=None) + dt.timedelta(hours=1)
+    (tmp_path / "access_token").write_text("the-token")
+    (tmp_path / "expires_at").write_text(expires_at.isoformat())
+
+    creds = credentials_from_token_dir(tmp_path, ["https://www.googleapis.com/auth/gmail.modify"])
+    creds.refresh(None)
+
+    assert creds.token == "the-token"
+    assert creds.expiry == expires_at
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary

- `google-auth`'s `Credentials.refresh()` calls `refresh_handler(request, scopes=scopes)` — a fixed keyword name. #2989's refactor of `credentials_from_token_dir` renamed the inner `refresh_handler`'s second parameter from `scopes` to `requested_scopes` (to dodge shadowing the outer `scopes` param), which silently broke every token refresh through this path with `TypeError: refresh_handler() got an unexpected keyword argument 'scopes'`.
- Hit in production today via haku-console's `create_calendar_event` (the first estimated-tax reminder approval failed with exactly this error) and — since it's the same shared helper — also breaks `gmail-labeling`'s autonomous label-write path once its cached token expires.
- Fix: revert the parameter name to `scopes` (an inner function parameter shadowing an outer one is harmless in Python; the rename bought nothing and broke the real contract).
- Added a regression test that drives the real `Credentials.refresh()` call (not just the handler in isolation), so a future rename is caught before it ships.

## Test plan

- [x] `bbr test //gmail_api:test_service` — passes (new regression test exercises the actual google-auth call convention)
- [x] `ruff check` / `ruff format` / pre-commit hooks all pass
- [x] Confirmed via `git log -p` that #2989 introduced the rename (was `scopes` before, matching google-auth's calling convention)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GUU2Jm9XypVG5AH6R1QVrV)_