### PR TITLE
rotators: ignore repo prettier config for YAML formatting

### DIFF
--- a/devinfra/BUILD.bazel
+++ b/devinfra/BUILD.bazel
@@ -92,6 +92,16 @@ py_library(
     visibility = ["//visibility:public"],
 )
 
+py_test(
+    name = "test_prettier_cli",
+    srcs = ["test_prettier_cli.py"],
+    deps = [
+        ":prettier_cli",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
 pkg_tar(
     name = "prettier_cli_layer",
     srcs = ["//:node_modules/prettier"],

--- a/devinfra/prettier_cli.py
+++ b/devinfra/prettier_cli.py
@@ -10,6 +10,7 @@ def prettier_format_yaml_in_place(path: Path) -> None:
         [
             "prettier",
             "--write",
+            "--no-config",
             "--parser",
             "yaml",
             "--print-width",

--- a/devinfra/test_prettier_cli.py
+++ b/devinfra/test_prettier_cli.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest_bazel
+
+from devinfra import prettier_cli
+
+
+def test_prettier_format_yaml_in_place_ignores_repo_config(monkeypatch):
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(prettier_cli.subprocess, "run", fake_run)
+
+    prettier_cli.prettier_format_yaml_in_place(Path("secrets/haku-attic.yaml"))
+
+    assert calls == [
+        (
+            [
+                "prettier",
+                "--write",
+                "--no-config",
+                "--parser",
+                "yaml",
+                "--print-width",
+                "120",
+                "--tab-width",
+                "2",
+                "--no-use-tabs",
+                "secrets/haku-attic.yaml",
+            ],
+            {"check": True},
+        )
+    ]
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary

Runtime rotator images format generated SOPS YAML with explicit Prettier YAML options, but Prettier was still discovering the cloned repo's `.prettierrc.cjs`. That config requires frontend plugins such as `prettier-plugin-svelte`, which are intentionally not packaged into the minimal rotator images.

This changes the shared runtime helper to pass `--no-config` for generated YAML formatting and adds a regression test for the exact command line.

## Validation

- `pre-commit run --files devinfra/prettier_cli.py devinfra/test_prettier_cli.py devinfra/BUILD.bazel`
- `bbr test //devinfra:test_prettier_cli //cluster/rotators/attic_jwt_rotation:test_rotate //cluster/rotators/authentik_jwt_rotation:test_rotate //cluster/rotators/forgejo_token_rotation:test_rotate`
- `bbr build //cluster/rotators/attic_jwt_rotation:image //cluster/rotators/authentik_jwt_rotation:image //cluster/rotators/forgejo_token_rotation:image` completed successfully on BuildBuddy; the local `bbr` wrapper did not exit after remote completion and was interrupted.