### PR TITLE
Update Codex CLI to 0.144.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1783049332,
-        "narHash": "sha256-bEsnLkSDPy0O3J8WkbUVcOAM8ERP5AkNE5LAdPIZu/8=",
+        "lastModified": 1783703657,
+        "narHash": "sha256-gys1Ug6wlOg97RTBHacrgbdsKEuwUxV+CKTjp4FbKqk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0eb539e65647b5d0282fecc937b77144e9d7965f",
+        "rev": "3c703572247bf53a37ba039eba7399ccae6e3e4f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,7 @@
       self,
       nixpkgs,
       nixpkgs-unstable,
+      nixpkgs-master,
       home-manager,
       nix-colors,
       nixGL,
@@ -119,11 +120,17 @@
         config.allowUnfree = true;
       };
 
+      pkgsMaster = import nixpkgs-master {
+        inherit system;
+        config.allowUnfree = true;
+      };
+
       # Shared home-manager args passed to every HM configuration.
       hmCommonArgs = {
         inherit
           nix-colors
           pkgsUnstable
+          pkgsMaster
           claude-plugins-official
           siderolabs-docs
           gafferPkgs
@@ -429,7 +436,13 @@
           # buildEnv; see cluster/k8s/agents/codex-pod/README.md.
           # Build: nix build .#codex-pod-image
           # Load:  docker load < result
-          codex-pod-image = import ./x/codex_pod_image { inherit pkgs pkgsUnstable home-manager; };
+          codex-pod-image = import ./x/codex_pod_image {
+            inherit
+              pkgs
+              pkgsMaster
+              home-manager
+              ;
+          };
           # NixOS-based RBE worker (systemd, envfs, nix-ld).
           # Build: nix build .#nix-rbe-nixos
           # Load:  docker import result/tarball/*.tar.xz nix-rbe-nixos

--- a/haku/dispatch/worker/Dockerfile
+++ b/haku/dispatch/worker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git ca-certificates python3 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.198 @openai/codex@0.142.5 \
+RUN npm install -g @anthropic-ai/claude-code@2.1.198 @openai/codex@0.144.1 \
     && npm cache clean --force
 
 COPY entrypoint.py /opt/haku/entrypoint.py

--- a/nix/home/codex/default.nix
+++ b/nix/home/codex/default.nix
@@ -1,7 +1,7 @@
 # Codex configuration module
 {
   pkgs,
-  pkgsUnstable,
+  pkgsMaster,
   lib,
   config,
   sharedSkillsArgs,
@@ -223,8 +223,8 @@ in
 
   config.programs.codex = {
     enable = true;
-    # Prefer the unstable codex package if available.
-    package = pkgsUnstable.codex;
+    # Codex ships frequently; use the narrow master input instead of moving whole hosts.
+    package = pkgsMaster.codex;
     # Avoid letting the upstream module overwrite ~/.codex/config.toml.
     # The activation script below handles merging our desired settings.
   };

--- a/x/codex_pod_image/default.nix
+++ b/x/codex_pod_image/default.nix
@@ -14,7 +14,7 @@
 # Load:   docker load < result
 {
   pkgs,
-  pkgsUnstable,
+  pkgsMaster,
   home-manager,
 }:
 let
@@ -23,7 +23,7 @@ let
   codexEnv = pkgs.buildEnv {
     name = "codex-env";
     paths = [
-      pkgsUnstable.codex # Codex CLI (unstable, as home-manager pins it for agent-box)
+      pkgsMaster.codex # Codex CLI (master, as home-manager pins it for agent-box)
       pkgs.bashInteractive
       pkgs.coreutils
       pkgs.moreutils


### PR DESCRIPTION
## Summary

- route the Home Manager Codex package through the existing narrow `nixpkgs-master` input
- use the same `pkgsMaster.codex` package in the Nix-built `codex-pod` image
- update the Haku worker Dockerfile npm pin to `@openai/codex@0.144.1`
- update only the `nixpkgs-master` entry in `flake.lock`

## Why

`nixos-unstable` still packages Codex `0.142.5`, while the current npm release is `0.144.1`. The repo already has `nixpkgs-master` for packages that temporarily need changes newer than unstable, so this keeps the blast radius narrow instead of moving broader host inputs.

## Validation

- `npm view @openai/codex version` -> `0.144.1`
- committed `nixpkgs-master` lock before this PR evaluated to Codex `0.142.3`
- `nix eval --raw .#nixosConfigurations.agent-box.config.home-manager.users.codex.programs.codex.package.version` -> `0.144.1`
- `nix eval --raw .#codex-pod-image.drvPath`
- `git diff --check`
- commit hooks passed: `nixfmt`, `statix`, `ducktape pre-commit`, `ducktape pytest-main-check`, `ducktape enforce-bazel-tests`

Note: I did not complete a full local build of `pkgsMaster.codex`; it was compiling `codex-0.144.1` from source for a long time, so I stopped it after confirming the selected package and image derivations evaluate.