### PR TITLE
haku/console: full-page past-tool-calls history view (live), panel toggle, deny-with-reason, screenshot target

### DIFF
--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -128,10 +128,22 @@ shell holds (`startGeolocationWatch`); location is gated by a shell-owned standi
 grant since the iframe has no `allow="geolocation"`. The shell origin-checks,
 schema-validates, and decides/confirms before acting. It also mirrors the iframe's hash route
 (`routeChanged`, validated as a path) into the console's own URL fragment so refresh and deep
-links restore the view. A persistent ⚙ escape button opens the shell's own console panel
-(`console_panel.tsx`) — trusted chrome hosting shell-owned controls like the
-location-sharing stop/withdraw and MCP account connect/reconnect/disconnect controls. See
-<docs/containment.md>.
+links restore the view. A persistent hamburger button — badged with a callout light when a
+tool call is awaiting approval — opens the shell's own console panel (`console_panel.tsx`),
+trusted chrome hosting shell-owned controls like the approval queue, the past-tool-calls
+link, the location-sharing stop/withdraw, and MCP account connect/reconnect/disconnect
+controls. See <docs/containment.md>.
+
+## Past tool calls — full-page history
+
+Beyond the drawer's ephemeral "Recent" list, the console owns a **full-page history view**
+of the whole tool-call audit ledger (`frontend/tool_calls_page.tsx`), reached from the
+console panel and living at its own route, `/tool-calls` (`frontend/routing.ts`). Because
+the console's own pages are distinguished by URL **path** — the hash stays reserved for
+mirroring the framed haku-ui route — the shell renders the history view instead of the
+iframe when the path matches. It reads `GET /api/tool-calls?newest_first=true`, so the
+newest calls survive the query's limit. Production's nginx already serves the SPA for any
+non-asset/API path; `app.py`'s dev fallback mirrors that so deep links work locally too.
 
 ## Layout
 

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -18,7 +18,7 @@ from contextlib import asynccontextmanager
 
 import uvicorn
 from fastapi import FastAPI, Request, Response
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi_csrf_protect import CsrfProtect
 from fastapi_csrf_protect.exceptions import CsrfProtectError
@@ -128,6 +128,16 @@ def create_app(settings: Settings) -> FastAPI:
     # haku-console-static nginx image and leaves static_dir unset on this process.
     # Mounted last so the API routes above take precedence.
     if settings.static_dir is not None and settings.static_dir.is_dir():
+        index_file = settings.static_dir / "index.html"
+
+        # SPA client-side routes (frontend/routing.ts, e.g. /tool-calls) have no file on
+        # disk; production's nginx serves index.html for them (try_files $uri /index.html).
+        # Mirror that here — registered before the mount so it wins — so the dev fallback
+        # can deep-link a console route instead of 404ing.
+        @app.get("/tool-calls")
+        async def _spa_route() -> FileResponse:
+            return FileResponse(index_file)
+
         app.mount("/", StaticFiles(directory=settings.static_dir, html=True), name="spa")
 
     return app

--- a/haku/console/frontend/AGENTS.md
+++ b/haku/console/frontend/AGENTS.md
@@ -1,0 +1,24 @@
+@README.md
+
+## Editing console visuals — always screenshot and eyeball
+
+When you change anything visual in this SPA — the past-tool-calls history view
+(`tool_calls_page.tsx`), the console panel/drawer (`console_panel.tsx`), the panel toggle,
+the tool-call cards, or their styles (`styles.src.css`) — regenerate and **look at** the
+screenshots before handing off:
+
+```bash
+bbr test //haku/console/frontend:screenshots
+```
+
+It renders each surface (`screenshots/harness.tsx`) to a PNG (one per scene: `history`,
+`drawer`, `drawer-access`) in the test's **undeclared outputs**. Browser rendering runs on
+the RBE worker, so this is a `bbr` test, not a local `bb run`. Fetch the PNGs with the
+`buildbuddy_api` skill (download the target's undeclared test outputs), then open every one
+and actually check it looks good — spacing, alignment, contrast, truncation, that nothing
+overflows or collides, and that both content and chrome read clearly — not merely that it
+rendered. The test is a generator, not a pixel-diff gate: it passes as long as every scene
+renders, so it never blocks CI on "looks different", but a blank/crashed scene fails it.
+
+Add a scene to `screenshots/harness.tsx` (and the `SCENES` list in `screenshots/render.mjs`)
+whenever you add a new surface.

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -83,6 +83,12 @@ js_library(
 )
 
 js_library(
+    name = "tool_call_events",
+    srcs = ["tool_call_events.ts"],
+    deps = ["//:node_modules/react"],
+)
+
+js_library(
     name = "routing",
     srcs = ["routing.ts"],
     deps = ["//:node_modules/react"],
@@ -204,6 +210,7 @@ js_library(
         ":field",
         ":icons",
         ":tool_arguments_field",
+        ":tool_call_events",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
     ],
@@ -221,6 +228,7 @@ js_library(
         ":geolocation",
         ":geolocation_grant",
         ":toast",
+        ":tool_call_events",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
     ],

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -83,6 +83,18 @@ js_library(
 )
 
 js_library(
+    name = "routing",
+    srcs = ["routing.ts"],
+    deps = ["//:node_modules/react"],
+)
+
+js_library(
+    name = "icons",
+    srcs = ["icons.tsx"],
+    deps = ["//:node_modules/react"],
+)
+
+js_library(
     name = "geolocation_grant",
     srcs = ["geolocation_grant.ts"],
 )
@@ -159,14 +171,39 @@ js_library(
 )
 
 js_library(
+    name = "tool_arguments_field",
+    srcs = ["tool_arguments_field.tsx"],
+    deps = [
+        ":field",
+        ":tool_previews",
+        "//:node_modules/react",
+    ],
+)
+
+js_library(
     name = "console_panel",
     srcs = ["console_panel.tsx"],
     deps = [
         ":approval_state",
         ":client",
         ":field",
+        ":icons",
         ":theme",
-        ":tool_previews",
+        ":tool_arguments_field",
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+    ],
+)
+
+js_library(
+    name = "tool_calls_page",
+    srcs = ["tool_calls_page.tsx"],
+    deps = [
+        ":approval_state",
+        ":client",
+        ":field",
+        ":icons",
+        ":tool_arguments_field",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
     ],
@@ -195,6 +232,8 @@ js_library(
     deps = [
         ":client",
         ":haku_ui_embed",
+        ":routing",
+        ":tool_calls_page",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
     ],
@@ -229,11 +268,15 @@ filegroup(
         "grocy_client.ts",
         "grocy_tool_previews.tsx",
         "haku_ui_embed.tsx",
+        "icons.tsx",
         "index.html",
         "kubectl_tool_previews.tsx",
         "main.tsx",
+        "routing.ts",
         "theme.ts",
         "toast.ts",
+        "tool_arguments_field.tsx",
+        "tool_calls_page.tsx",
         "tool_previews.tsx",
     ],
 )
@@ -302,6 +345,7 @@ tsc_bin.tsc_test(
         "bridge.test.ts",
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
+        "routing.test.ts",
         "tool_previews.test.ts",
         "tsconfig.json",
         ":main_lib",
@@ -321,12 +365,14 @@ vitest_bin.vitest_test(
         "bridge.test.ts",
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
+        "routing.test.ts",
         "tool_previews.test.ts",
         "vitest.config.ts",
         ":approval_state",
         ":bridge",
         ":geolocation",
         ":haku_ui_embed",
+        ":routing",
         ":tool_previews",
         "//:node_modules",
     ],

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library", "js_run_binary", "js_test")
 load("@npm_ducktape//:@tailwindcss/cli/package_json.bzl", tailwindcss_bin = "bin")
 load("@npm_ducktape//:typescript/package_json.bzl", tsc_bin = "bin")
 load("@npm_ducktape//:vitest/package_json.bzl", vitest_bin = "bin")
@@ -331,6 +331,84 @@ spa_bundle(
     deps = [":main_lib"],
 )
 
+# ── Visual screenshots ─────────────────────────────────────────────────────────
+#
+# `bbr test //haku/console/frontend:screenshots` renders each console visual surface
+# (screenshots/harness.tsx) to a PNG in the test's undeclared outputs, for eyeballing (see
+# AGENTS.md). Browser rendering runs on the RBE worker's display stack — a local Bazel
+# can't fetch repos in web sessions — so it is a js_test, not a `bb run` binary. It is a
+# generator, not a pixel-diff gate: it passes as long as every scene renders.
+
+js_library(
+    name = "screenshot_harness_lib",
+    srcs = [
+        "screenshots/harness.tsx",
+        "screenshots/mock_api.ts",
+        "screenshots/sample_data.ts",
+    ],
+    tags = ["no-lint"],
+    deps = [
+        ":approval_state",
+        ":client",
+        ":console_panel",
+        ":theme",
+        ":tool_calls_page",
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+        "//:node_modules/react-dom",
+    ],
+)
+
+js_binary(
+    name = "build_screenshot_harness",
+    data = [
+        "screenshots/esbuild.config.mjs",
+        ":screenshot_harness_lib",
+        "//:node_modules",
+    ],
+    entry_point = "screenshots/esbuild.config.mjs",
+)
+
+js_run_binary(
+    name = "screenshot_harness_bundle",
+    srcs = [
+        "screenshots/esbuild.config.mjs",
+        ":screenshot_harness_lib",
+    ],
+    outs = ["screenshots/dist/harness.js"],
+    args = ["screenshots/dist"],
+    chdir = package_name(),
+    tool = ":build_screenshot_harness",
+)
+
+# Single-file target so $(rootpath) resolves to one path.
+filegroup(
+    name = "screenshot_harness_js",
+    srcs = ["screenshots/dist/harness.js"],
+)
+
+js_test(
+    name = "screenshots",
+    size = "large",
+    data = [
+        ":screenshot_harness_js",
+        ":styles_css",
+        "//util/testing/frontend_visual:puppeteer_lib",
+        "@playwright_browsers//:chromium-headless-shell",
+    ],
+    entry_point = "screenshots/render.mjs",
+    env = {
+        "HARNESS_JS": "$(rootpath :screenshot_harness_js)",
+        "STYLES_CSS": "$(rootpath :styles_css)",
+        "PUPPETEER_EXECUTABLE_PATH": "$(rootpath @playwright_browsers//:chromium-headless-shell)",
+    },
+    no_copy_to_bin = [
+        ":screenshot_harness_js",
+        "//util/testing/frontend_visual:puppeteer_lib",
+        "@playwright_browsers//:chromium-headless-shell",
+    ],
+)
+
 # Full TypeScript type-check (the correctness gate esbuild bundling skips).
 tsc_bin.tsc_test(
     name = "tsc_test",
@@ -351,6 +429,7 @@ tsc_bin.tsc_test(
         ":main_lib",
         ":schema",
         ":schema_zod",
+        ":screenshot_harness_lib",
         "//:node_modules",
     ],
     tags = ["lint"],

--- a/haku/console/frontend/CLAUDE.md
+++ b/haku/console/frontend/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/haku/console/frontend/README.md
+++ b/haku/console/frontend/README.md
@@ -8,12 +8,20 @@ components + **Tailwind v4** utilities — modeled on
 `finance/augur/frontend` (references root `//:node_modules/*`; no per-package
 `package.json`).
 
-- `main.tsx` (wraps the app in `MantineProvider`) → `app.tsx` (the page: tiered open
-  items + global feedback box) → `task.tsx` (one item card with its action toggles
-  and a per-item feedback box).
-- `feedback.tsx` — shared feedback form (global note + per-item, the latter tagged
-  with the item id). The Mantine `Button`'s `loading` prop shows an in-flight spinner
-  while the commit-push lands; a failure surfaces inline on the `Textarea`.
+- `main.tsx` (wraps the app in `MantineProvider`) → `app.tsx` (routes between the two
+  console views) → either `haku_ui_embed.tsx` (the full-page framed haku-ui plus shell
+  chrome: approval drawer, bridge, confirms) or `tool_calls_page.tsx` (the full-page
+  past-tool-calls history).
+- `routing.ts` — the console's tiny pathname router. Two views keyed on URL **path**
+  (`/` embed, `/tool-calls` history) so console navigation never collides with the hash,
+  which is reserved for mirroring the framed haku-ui route.
+- `console_panel.tsx` — the shell drawer (`ShellDrawer`) and its persistent toggle
+  (`ShellControls`): a hamburger icon badged with a pending-approval callout light. Hosts
+  the approval queue, the past-tool-calls link, and the Access tab (location + MCP
+  accounts).
+- `tool_arguments_field.tsx` / `icons.tsx` — shared tool-argument renderer (per-server
+  preview or raw JSON) and inline-SVG icons (never the `@tabler` barrel — see
+  `debug/esbuild_tabler_memory.md`), used by both the drawer and the history view.
 - `client.ts` — typed `openapi-fetch` client; the types come from the backend's
   OpenAPI schema (the `:schema` target runs `//haku/console:export_schema_bin`), so
   the Pydantic models are the single source of truth for the wire contract. Includes the

--- a/haku/console/frontend/README.md
+++ b/haku/console/frontend/README.md
@@ -22,6 +22,10 @@ components + **Tailwind v4** utilities — modeled on
 - `tool_arguments_field.tsx` / `icons.tsx` — shared tool-argument renderer (per-server
   preview or raw JSON) and inline-SVG icons (never the `@tabler` barrel — see
   `debug/esbuild_tabler_memory.md`), used by both the drawer and the history view.
+- `tool_call_events.ts` — `useToolCallEvents(onEvent)`: the shared live signal (the
+  `/api/approvals/ws` WebSocket + a cross-tab BroadcastChannel) that refetches on every
+  submit/approve/deny/finish. Both the approval drawer and the history view use it, so the
+  full page updates live without a reload.
 - `client.ts` — typed `openapi-fetch` client; the types come from the backend's
   OpenAPI schema (the `:schema` target runs `//haku/console:export_schema_bin`), so
   the Pydantic models are the single source of truth for the wire contract. Includes the

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -3,15 +3,19 @@ import { useEffect, useState } from "react";
 
 import { type ConfigResponse, fetchConfig } from "./client.ts";
 import { HakuUiEmbed } from "./haku_ui_embed.tsx";
+import { useConsoleView } from "./routing.ts";
+import { ToolCallsPage } from "./tool_calls_page.tsx";
 
 // The console is now just the trusted outer shell: a full-page frame for Haku's own UI
 // (a sandboxed cross-origin iframe) plus the bridge that brokers the iframe's privileged
 // requests (opening links, launching a run). All product chrome — title bar, the global
 // feedback button, the launch dialog — lives in haku-ui now; only the trusted confirm +
-// capability firing stay here. See README + docs/containment.md.
+// capability firing stay here. The one other console-owned surface is the full-page
+// past-tool-calls history at its own route (routing.ts). See README + docs/containment.md.
 export default function App() {
   const [config, setConfig] = useState<ConfigResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const { view, navigate } = useConsoleView();
 
   useEffect(() => {
     let alive = true;
@@ -26,6 +30,10 @@ export default function App() {
       alive = false;
     };
   }, []);
+
+  // The history view is a self-contained console page that reads its own API and needs no
+  // shell config, so it renders regardless of the config load (and even if it failed).
+  if (view === "toolCalls") return <ToolCallsPage onBack={() => navigate("embed")} />;
 
   // The initial config load is the one thing rendered by the shell itself; a failure
   // leaves nothing to frame, so it gets a persistent page-level message.
@@ -44,5 +52,11 @@ export default function App() {
 
   // launch_routine_url is set iff the launch capability is configured (it's the routine's
   // page URL); pass that as whether the shell can honor a requestLaunch from the iframe.
-  return <HakuUiEmbed uiUrl={config.haku_ui_url} launchAvailable={config.launch_routine_url != null} />;
+  return (
+    <HakuUiEmbed
+      uiUrl={config.haku_ui_url}
+      launchAvailable={config.launch_routine_url != null}
+      onOpenToolCalls={() => navigate("toolCalls")}
+    />
+  );
 }

--- a/haku/console/frontend/approval_state.ts
+++ b/haku/console/frontend/approval_state.ts
@@ -137,6 +137,18 @@ export function terminalStatusLabel(status: ToolCallRecord["status"]): string {
   return "Pending";
 }
 
+export function statusColor(status: ToolCallRecord["status"]): string {
+  if (status === "ok") return "teal";
+  if (status === "error") return "red";
+  if (status === "denied") return "gray";
+  return "blue";
+}
+
+export function shortDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return new Date(value).toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
+}
+
 export function geolocationApprovalTitle(approval: GeolocationApproval): string {
   return approval.mode === "geolocationWatch" ? "Allow continuous location sharing?" : "Allow location sharing?";
 }

--- a/haku/console/frontend/client.ts
+++ b/haku/console/frontend/client.ts
@@ -59,6 +59,16 @@ export async function fetchPendingApprovals(): Promise<PendingApproval[]> {
   return data.approvals ?? [];
 }
 
+// The full tool-call audit ledger for the history view: newest first, so `limit` keeps
+// the most recent calls when the ledger has grown past it.
+export async function fetchToolCalls(limit: number): Promise<ToolCallRecord[]> {
+  const { data, error } = await api.GET("/api/tool-calls", {
+    params: { query: { newest_first: true, limit } },
+  });
+  if (error || !data) throw new Error(errorDetail(error, "Failed to load tool calls"));
+  return data.tool_calls ?? [];
+}
+
 export async function fetchMcpOperatorAuthStatuses(): Promise<McpOperatorAuthStatus[]> {
   const { data, error } = await api.GET("/api/mcp/operator-auth");
   if (error || !data) throw new Error(errorDetail(error, "Failed to load MCP account links"));

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Group, SegmentedControl, Stack, Text, Textarea } from "@mantine/core";
+import { ActionIcon, Badge, Button, Group, Indicator, SegmentedControl, Stack, Text, Textarea } from "@mantine/core";
 import type { KeyboardEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 
@@ -8,14 +8,17 @@ import {
   geolocationApprovalBody,
   geolocationApprovalTitle,
   recentToolCallCountdown,
+  shortDate,
+  statusColor,
   type GeolocationApproval,
   type RecentToolCall,
   terminalStatusLabel,
 } from "./approval_state.ts";
-import type { McpOperatorAuthStatus, PendingApproval, ToolCallRecord } from "./client.ts";
+import type { McpOperatorAuthStatus, PendingApproval } from "./client.ts";
 import { Field } from "./field.tsx";
+import { HistoryIcon, MenuIcon } from "./icons.tsx";
 import { ACTION_COLOR } from "./theme.ts";
-import { toolPreview } from "./tool_previews.tsx";
+import { ToolArgumentsField } from "./tool_arguments_field.tsx";
 
 export type ShellDrawerTab = "approvals" | "access";
 
@@ -37,6 +40,7 @@ export interface ShellDrawerProps {
   onApproveGeolocation: (approval: GeolocationApproval) => void;
   onDenyGeolocation: (approval: GeolocationApproval) => void;
   onDismissRecentToolCall: (toolCallId: string) => void;
+  onOpenToolCalls: () => void;
   geoGranted: boolean;
   tracking: boolean;
   onWithdrawGeolocation: () => void;
@@ -49,8 +53,7 @@ export interface ShellDrawerProps {
 export interface ShellControlsProps {
   pendingCount: number;
   opened: boolean;
-  activeTab: ShellDrawerTab;
-  onOpenTab: (tab: ShellDrawerTab) => void;
+  onToggle: () => void;
 }
 
 // zIndex maxed so shell chrome sits above the full-page iframe; controls are one below.
@@ -69,18 +72,6 @@ function useArmed(identity: string | null): boolean {
     return () => window.clearTimeout(t);
   }, [identity]);
   return armed;
-}
-
-function shortDate(value: string | null | undefined): string | null {
-  if (!value) return null;
-  return new Date(value).toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
-}
-
-function statusColor(status: ToolCallRecord["status"]): string {
-  if (status === "ok") return "teal";
-  if (status === "error") return "red";
-  if (status === "denied") return "gray";
-  return "blue";
 }
 
 function openOnCardKeyDown(e: KeyboardEvent<HTMLElement>, onOpen: () => void) {
@@ -103,43 +94,32 @@ function RecentCountdown({ recent, nowMs }: { recent: RecentToolCall; nowMs: num
   );
 }
 
-export function ShellControls({ pendingCount, opened, activeTab, onOpenTab }: ShellControlsProps) {
+// The one persistent piece of shell chrome over the framed haku-ui: a generic panel
+// toggle. The count of pending approvals surfaces as a pulsing red callout on the icon —
+// a "something needs you" light — without spelling the drawer's contents onto the button.
+export function ShellControls({ pendingCount, opened, onToggle }: ShellControlsProps) {
   return (
     <Group className="haku-shell-controls" gap="xs" style={{ zIndex: PANEL_Z - 1 }}>
-      <Button
-        size="xs"
-        variant={opened && activeTab === "approvals" ? "filled" : "default"}
-        color={ACTION_COLOR}
-        onClick={() => onOpenTab("approvals")}
-        rightSection={
-          pendingCount > 0 ? (
-            <Badge size="xs" color="red" variant="filled">
-              {pendingCount}
-            </Badge>
-          ) : null
-        }
+      <Indicator
+        color="red"
+        size={16}
+        offset={4}
+        processing
+        disabled={pendingCount === 0}
+        label={pendingCount > 0 ? pendingCount : undefined}
       >
-        Approvals
-      </Button>
+        <ActionIcon
+          size="lg"
+          variant={opened ? "filled" : "default"}
+          color={ACTION_COLOR}
+          onClick={onToggle}
+          aria-label={opened ? "Close console panel" : "Open console panel"}
+        >
+          <MenuIcon />
+        </ActionIcon>
+      </Indicator>
     </Group>
   );
-}
-
-/** Arguments field for a tool-call approval/result: a per-tool-type widget
- * (google_tool_previews.tsx) when one matches, else the generic raw-JSON view. */
-function ToolArgumentsField({
-  serverId,
-  toolName,
-  args,
-  argumentsJson,
-}: {
-  serverId: string;
-  toolName: string;
-  args: Record<string, unknown>;
-  argumentsJson: string;
-}) {
-  const nice = toolPreview(serverId, toolName, args);
-  return <Field label="Arguments">{nice ?? <pre className="haku-shell-json">{argumentsJson}</pre>}</Field>;
 }
 
 function ToolApprovalDetail({
@@ -787,6 +767,16 @@ export function ShellDrawer(props: ShellDrawerProps) {
                 { value: "access", label: "Access" },
               ]}
             />
+            <Button
+              size="xs"
+              variant="light"
+              color={ACTION_COLOR}
+              fullWidth
+              leftSection={<HistoryIcon />}
+              onClick={props.onOpenToolCalls}
+            >
+              Past tool calls
+            </Button>
           </section>
           <div className="haku-shell-scroll">
             {props.activeTab === "approvals" ? (

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -275,10 +275,13 @@ function ToolApprovalCard({
   deciding: boolean;
   onSelect: () => void;
   onApprove: () => void;
-  onDeny: () => void;
+  onDeny: (reason?: string) => void;
 }) {
   const fields = approvalDisplayFields(approval);
   const armed = useArmed(`card:${approval.tool_call_id}`);
+  // An always-visible optional reason field so a single Deny click can carry a "why"
+  // straight from the card, without opening the detail view.
+  const [denyReason, setDenyReason] = useState("");
   return (
     <section
       className={`haku-shell-card haku-shell-approval-card ${selected ? "haku-shell-card-active" : ""}`}
@@ -309,20 +312,34 @@ function ToolApprovalCard({
           </Badge>
         </Group>
       </div>
-      <Group
-        justify="flex-end"
-        gap="xs"
-        mt="xs"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
-        <Button size="compact-xs" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
-          Deny
-        </Button>
-        <Button size="compact-xs" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
-          Approve
-        </Button>
-      </Group>
+      <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+        <Textarea
+          size="xs"
+          mt="xs"
+          label="Denial reason (optional)"
+          placeholder="Why are you denying this?"
+          autosize
+          minRows={1}
+          maxRows={4}
+          disabled={deciding}
+          value={denyReason}
+          onChange={(e) => setDenyReason(e.currentTarget.value)}
+        />
+        <Group justify="flex-end" gap="xs" mt="xs">
+          <Button
+            size="compact-xs"
+            variant="light"
+            color="red"
+            disabled={deciding || !armed}
+            onClick={() => onDeny(denyReason.trim() || undefined)}
+          >
+            Deny
+          </Button>
+          <Button size="compact-xs" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
+            Approve
+          </Button>
+        </Group>
+      </div>
     </section>
   );
 }
@@ -604,7 +621,7 @@ function ApprovalsTab({
                 deciding={deciding.has(item.id)}
                 onSelect={() => onSelectApproval(item.id)}
                 onApprove={() => onApproveTool(item.approval)}
-                onDeny={() => onDenyTool(item.approval)}
+                onDeny={(reason) => onDenyTool(item.approval, reason)}
               />
             ) : (
               <GeolocationApprovalCard

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -27,6 +27,7 @@ import { ShellControls, ShellDrawer, type ShellDrawerTab } from "./console_panel
 import { GEO_PERMISSION_DENIED, GeolocationWatcher, getGeolocation } from "./geolocation.ts";
 import { hasGeolocationGrant, setGeolocationGrant } from "./geolocation_grant.ts";
 import { toastError, toastSuccess } from "./toast.ts";
+import { useToolCallEvents } from "./tool_call_events.ts";
 
 // Haku's own UI service — a separate, Authentik-gated origin running in haku-sandbox —
 // embedded as a sandboxed cross-origin iframe (the whole console is now this frame). The
@@ -52,19 +53,7 @@ export function openExternal(url: string): boolean {
 }
 
 const POPUP_HINT = "Allow pop-ups for this site so the console can open links.";
-const TOOL_APPROVAL_CHANNEL = "haku-console-tool-approvals";
 const MCP_AUTH_CHANNEL = "haku-console-mcp-auth";
-
-type ToolApprovalChannelMessage = { type: "toolApprovalsChanged" };
-
-function isToolApprovalChannelMessage(value: unknown): value is ToolApprovalChannelMessage {
-  return Boolean(
-    value &&
-    typeof value === "object" &&
-    "type" in value &&
-    (value as { type?: unknown }).type === "toolApprovalsChanged"
-  );
-}
 
 // Restore the route the console URL carries into the frame on first mount. The console
 // hash is treated strictly as a validated path, never a URL: the src is always `uiUrl`
@@ -108,7 +97,6 @@ export function HakuUiEmbed({
   // reload the frame); the iframe navigates itself, the console only reflects.
   const [frameSrc] = useState(() => initialFrameSrc(uiUrl, window.location.hash));
   const origin = new URL(uiUrl).origin;
-  const toolApprovalChannelRef = useRef<BroadcastChannel | null>(null);
   const mcpAuthChannelRef = useRef<BroadcastChannel | null>(null);
   const activeAction: Escalation | null = pending;
 
@@ -251,16 +239,19 @@ export function HakuUiEmbed({
     setSelectedRecentToolCallId(null);
   }
 
-  function refreshToolApprovals(notifyPeers = false) {
-    if (notifyPeers) toolApprovalChannelRef.current?.postMessage({ type: "toolApprovalsChanged" });
+  function refreshToolApprovals() {
     void fetchPendingApprovals().then(
       (approvals) => applyToolApprovals(approvals),
       (e: unknown) => toastError("Couldn't load tool approvals", e)
     );
   }
 
-  function refreshMcpAuthStatuses(notifyPeers = false) {
-    if (notifyPeers) mcpAuthChannelRef.current?.postMessage({ type: "mcpAuthChanged" });
+  // Live tool-call signal: initial fetch on mount plus a refetch on every WS/cross-tab
+  // event. `notifyPeers` wakes other console tabs after this one approves/denies.
+  const { notifyPeers } = useToolCallEvents(refreshToolApprovals);
+
+  function refreshMcpAuthStatuses(notify = false) {
+    if (notify) mcpAuthChannelRef.current?.postMessage({ type: "mcpAuthChanged" });
     void fetchMcpOperatorAuthStatuses().then(
       (statuses) => setMcpAuthStatuses(statuses),
       (e: unknown) => toastError("Couldn't load MCP account links", e)
@@ -293,19 +284,6 @@ export function HakuUiEmbed({
   useEffect(() => () => void watcher.stopAll(), [watcher]);
 
   useEffect(() => {
-    if (!("BroadcastChannel" in window)) return;
-    const channel = new BroadcastChannel(TOOL_APPROVAL_CHANNEL);
-    toolApprovalChannelRef.current = channel;
-    channel.onmessage = (e: MessageEvent<unknown>) => {
-      if (isToolApprovalChannelMessage(e.data)) refreshToolApprovals();
-    };
-    return () => {
-      if (toolApprovalChannelRef.current === channel) toolApprovalChannelRef.current = null;
-      channel.close();
-    };
-  }, []);
-
-  useEffect(() => {
     refreshMcpAuthStatuses();
     if (!("BroadcastChannel" in window)) return;
     const channel = new BroadcastChannel(MCP_AUTH_CHANNEL);
@@ -314,25 +292,6 @@ export function HakuUiEmbed({
     return () => {
       if (mcpAuthChannelRef.current === channel) mcpAuthChannelRef.current = null;
       channel.close();
-    };
-  }, []);
-
-  useEffect(() => {
-    let closed = false;
-    let ws: WebSocket | null = null;
-    function refreshIfLive(notifyPeers = false) {
-      if (!closed) refreshToolApprovals(notifyPeers);
-    }
-    refreshIfLive();
-    const url = new URL("/api/approvals/ws", window.location.href);
-    url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
-    ws = new WebSocket(url);
-    ws.onopen = () => refreshIfLive();
-    ws.onmessage = () => refreshIfLive(true);
-    ws.onclose = () => refreshIfLive();
-    return () => {
-      closed = true;
-      ws?.close();
     };
   }, []);
 
@@ -471,12 +430,14 @@ export function HakuUiEmbed({
       .then((record) => {
         finishToolDecision(record);
         toastSuccess("Tool call finished", `${record.server_id}.${record.tool_name}: ${record.status}`);
-        refreshToolApprovals(true);
+        refreshToolApprovals();
+        notifyPeers();
       })
       .catch((e: unknown) => {
         setDeciding(approvalId, false);
         toastError("Tool call failed", e);
-        refreshToolApprovals(true);
+        refreshToolApprovals();
+        notifyPeers();
       });
   }
 
@@ -487,12 +448,14 @@ export function HakuUiEmbed({
       (record) => {
         finishToolDecision(record);
         toastSuccess("Tool call denied", approval.title ?? `${approval.server_id}: ${approval.tool_name}`);
-        refreshToolApprovals(true);
+        refreshToolApprovals();
+        notifyPeers();
       },
       (e: unknown) => {
         setDeciding(approvalId, false);
         toastError("Couldn't deny tool call", e);
-        refreshToolApprovals(true);
+        refreshToolApprovals();
+        notifyPeers();
       }
     );
   }

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -79,7 +79,15 @@ export function initialFrameSrc(uiUrl: string, consoleHash: string): string {
   return src.toString();
 }
 
-export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchAvailable: boolean }) {
+export function HakuUiEmbed({
+  uiUrl,
+  launchAvailable,
+  onOpenToolCalls,
+}: {
+  uiUrl: string;
+  launchAvailable: boolean;
+  onOpenToolCalls: () => void;
+}) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   // The single escalation awaiting the operator's trusted confirm (a link to open or a run
   // to launch). One typed action, dispatched on its `kind` — see ConfirmDialog's Escalation.
@@ -525,8 +533,7 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
       <ShellControls
         pendingCount={toolApprovals.length + geolocationApprovals.length}
         opened={drawerOpen}
-        activeTab={drawerTab}
-        onOpenTab={openDrawerTab}
+        onToggle={() => setDrawerOpen((open) => !open)}
       />
       <ShellDrawer
         opened={drawerOpen}
@@ -554,6 +561,7 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
         onApproveGeolocation={approveGeolocationApproval}
         onDenyGeolocation={denyGeolocationApproval}
         onDismissRecentToolCall={dismissRecentToolCall}
+        onOpenToolCalls={onOpenToolCalls}
         geoGranted={geoGranted}
         tracking={tracking}
         onWithdrawGeolocation={withdrawGeolocation}

--- a/haku/console/frontend/icons.tsx
+++ b/haku/console/frontend/icons.tsx
@@ -1,0 +1,54 @@
+// Inline SVG icons — deliberately NOT `@tabler/icons-react`: its barrel OOMs esbuild on
+// RBE (~8.7 GB peak) and even a per-icon subpath import needs an ambient declaration.
+// See debug/esbuild_tabler_memory.md → "Inline SVG". Each glyph strokes `currentColor`
+// so it inherits the button/text color and both color schemes.
+import type { SVGProps } from "react";
+
+function Glyph(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    />
+  );
+}
+
+/** Hamburger — the shell's console-panel toggle. */
+export function MenuIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Glyph {...props}>
+      <line x1="4" y1="6" x2="20" y2="6" />
+      <line x1="4" y1="12" x2="20" y2="12" />
+      <line x1="4" y1="18" x2="20" y2="18" />
+    </Glyph>
+  );
+}
+
+/** Clock-with-rewind — links to the past-tool-calls history view. */
+export function HistoryIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Glyph {...props}>
+      <path d="M3 3v5h5" />
+      <path d="M3.05 13A9 9 0 1 0 6 5.3L3 8" />
+      <path d="M12 7v5l3 2" />
+    </Glyph>
+  );
+}
+
+/** Left arrow — the history view's back-to-embed control. */
+export function ArrowLeftIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Glyph {...props}>
+      <line x1="19" y1="12" x2="5" y2="12" />
+      <polyline points="12 19 5 12 12 5" />
+    </Glyph>
+  );
+}

--- a/haku/console/frontend/routing.test.ts
+++ b/haku/console/frontend/routing.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { HOME_PATH, TOOL_CALLS_PATH, viewForPathname } from "./routing.ts";
+
+describe("viewForPathname", () => {
+  it("maps the tool-calls path to the history view and everything else to the embed", () => {
+    expect(viewForPathname(TOOL_CALLS_PATH)).toBe("toolCalls");
+    expect(viewForPathname(HOME_PATH)).toBe("embed");
+    // Any unknown path degrades to the embed shell, not a blank page.
+    expect(viewForPathname("/something-else")).toBe("embed");
+    // Only the exact path matches — a nested path is not the history view.
+    expect(viewForPathname(`${TOOL_CALLS_PATH}/extra`)).toBe("embed");
+  });
+});

--- a/haku/console/frontend/routing.ts
+++ b/haku/console/frontend/routing.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from "react";
+
+// The console has two top-level views, distinguished by URL *path*. The path is used —
+// never the hash — because the hash is already reserved for mirroring the framed
+// haku-ui route (haku_ui_embed.tsx's routeChanged handler), so a path keeps the console's
+// own navigation from colliding with the frame's.
+//
+//   "/"            → the full-page haku-ui embed (the trusted shell)
+//   "/tool-calls"  → the console's own full-page history of every past MCP tool call
+//
+// Production's nginx serves index.html for any non-asset/API path (`try_files $uri
+// /index.html`), and the dev fallback mirrors that (app.py), so deep-linking either path
+// loads the SPA, which then renders the matching view from the pathname.
+export const TOOL_CALLS_PATH = "/tool-calls";
+export const HOME_PATH = "/";
+
+export type ConsoleView = "embed" | "toolCalls";
+
+export function viewForPathname(pathname: string): ConsoleView {
+  return pathname === TOOL_CALLS_PATH ? "toolCalls" : "embed";
+}
+
+function pathForView(view: ConsoleView): string {
+  return view === "toolCalls" ? TOOL_CALLS_PATH : HOME_PATH;
+}
+
+export function useConsoleView(): { view: ConsoleView; navigate: (view: ConsoleView) => void } {
+  const [pathname, setPathname] = useState(() => window.location.pathname);
+  useEffect(() => {
+    const onPop = () => setPathname(window.location.pathname);
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+  const navigate = useCallback((next: ConsoleView) => {
+    const path = pathForView(next);
+    if (window.location.pathname === path) return;
+    // Preserve the hash (the mirrored iframe route) and any query across navigation so
+    // returning to the embed restores the frame's last view.
+    history.pushState(null, "", `${path}${window.location.search}${window.location.hash}`);
+    setPathname(path);
+  }, []);
+  return { view: viewForPathname(pathname), navigate };
+}

--- a/haku/console/frontend/screenshots/.gitignore
+++ b/haku/console/frontend/screenshots/.gitignore
@@ -1,0 +1,2 @@
+# Local `bazel run` fallback writes PNGs here; the RBE js_test uses undeclared outputs.
+/out/

--- a/haku/console/frontend/screenshots/esbuild.config.mjs
+++ b/haku/console/frontend/screenshots/esbuild.config.mjs
@@ -1,0 +1,24 @@
+// Bundles the screenshot harness (harness.tsx) into a single IIFE that renders into
+// #app. IIFE format so the generated file:// page (render.mjs) can <script>-load it
+// without module CORS restrictions in headless Chromium. Output: <outdir>/harness.js.
+import esbuild from "esbuild";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outdir = resolve(process.argv[2] || "dist");
+
+await esbuild.build({
+  entryPoints: [resolve(__dirname, "harness.tsx")],
+  bundle: true,
+  outdir,
+  format: "iife",
+  minify: false,
+  sourcemap: false,
+  target: ["es2022"],
+  jsx: "automatic",
+  entryNames: "harness",
+  nodePaths: [resolve(process.cwd(), "node_modules")],
+  preserveSymlinks: false,
+  logLevel: "info",
+});

--- a/haku/console/frontend/screenshots/harness.tsx
+++ b/haku/console/frontend/screenshots/harness.tsx
@@ -1,0 +1,68 @@
+// Screenshot harness: renders each console visual surface into #app with mocked data, one
+// scene per page load (selected by `window.__SCENE__`). Bundled to an IIFE by
+// esbuild.config.mjs and driven by render.mjs, which screenshots each scene to a PNG. A
+// generator for eyeballing the visuals, not a pixel-diff gate — see frontend/AGENTS.md.
+//
+// `./mock_api.ts` is imported FIRST so its `fetch` stub is installed before client.ts (via
+// tool_calls_page.tsx) captures `globalThis.fetch`; the history view then renders populated.
+import "./mock_api.ts";
+
+import { MantineProvider } from "@mantine/core";
+import { createRoot } from "react-dom/client";
+
+import { ShellDrawer, type ShellDrawerProps, type ShellDrawerTab } from "../console_panel.tsx";
+import { hakuTheme } from "../theme.ts";
+import { ToolCallsPage } from "../tool_calls_page.tsx";
+import { SAMPLE_MCP, SAMPLE_PENDING, SAMPLE_RECENT } from "./sample_data.ts";
+
+const noop = () => {};
+
+function drawerProps(activeTab: ShellDrawerTab): ShellDrawerProps {
+  return {
+    opened: true,
+    activeTab,
+    onOpenTab: noop,
+    onClose: noop,
+    pendingApprovals: SAMPLE_PENDING,
+    geolocationApprovals: [],
+    selectedApprovalId: null,
+    selectedRecentToolCallId: null,
+    decidingApprovalIds: [],
+    recentToolCalls: SAMPLE_RECENT,
+    onSelectApproval: noop,
+    onSelectRecentToolCall: noop,
+    onApproveTool: noop,
+    onDenyTool: noop,
+    onApproveGeolocation: noop,
+    onDenyGeolocation: noop,
+    onDismissRecentToolCall: noop,
+    onOpenToolCalls: noop,
+    geoGranted: true,
+    tracking: false,
+    onWithdrawGeolocation: noop,
+    mcpAuthStatuses: SAMPLE_MCP,
+    onConnectMcp: noop,
+    onDisconnectMcp: noop,
+    onRefreshMcp: noop,
+  };
+}
+
+function sceneElement(scene: string) {
+  switch (scene) {
+    case "drawer-access":
+      return <ShellDrawer {...drawerProps("access")} />;
+    case "drawer":
+      return <ShellDrawer {...drawerProps("approvals")} />;
+    default:
+      return <ToolCallsPage onBack={noop} />;
+  }
+}
+
+const scene = (window as unknown as { __SCENE__?: string }).__SCENE__ ?? "history";
+const container = document.getElementById("app");
+if (!container) throw new Error("missing #app");
+createRoot(container).render(
+  <MantineProvider defaultColorScheme="light" theme={hakuTheme}>
+    {sceneElement(scene)}
+  </MantineProvider>
+);

--- a/haku/console/frontend/screenshots/mock_api.ts
+++ b/haku/console/frontend/screenshots/mock_api.ts
@@ -1,0 +1,26 @@
+// Installs a canned-response `fetch` for the screenshot harness so data-fetching surfaces
+// (the history view) render populated instead of an error. MUST be imported before any
+// module that captures `globalThis.fetch` (openapi-fetch does so when client.ts builds its
+// client) — harness.tsx imports this first. Paired with a `<base href>` in the harness page
+// (render.mjs) so the relative "/api/…" URL parses in the origin-less setContent page.
+import { SAMPLE_TOOL_CALLS } from "./sample_data.ts";
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+const realFetch = globalThis.fetch;
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = requestUrl(input);
+  if (url.includes("/api/tool-calls")) {
+    return new Response(JSON.stringify({ tool_calls: SAMPLE_TOOL_CALLS }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  if (realFetch) return realFetch(input, init);
+  return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+}) as typeof fetch;

--- a/haku/console/frontend/screenshots/render.mjs
+++ b/haku/console/frontend/screenshots/render.mjs
@@ -1,0 +1,100 @@
+// Screenshot generator for the console's own visual surfaces. Inlines the compiled
+// stylesheet and the bundled harness (harness.tsx) into a headless-Chromium page, one
+// scene per load, and writes a PNG per scene. This is a generator for eyeballing the
+// visuals — NOT a pixel-diff regression gate — so it never fails on "looks different"; it
+// fails only if a scene crashes or renders an empty #app (waitForSelector below throws).
+//
+// It runs as an RBE js_test (browser rendering needs the RBE worker's display stack — a
+// local Bazel can't fetch repos in web sessions), writing the PNGs to the test's
+// undeclared outputs. See frontend/AGENTS.md for how to run it and fetch the PNGs.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { launchPuppeteerBrowser } from "../../../../util/testing/frontend_visual/puppeteer-lib.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// The console's full-page surfaces (ToolCallsPage, ShellDrawer) are position:fixed, so a
+// viewport screenshot — not an #app element shot — is what captures them. Each scene is a
+// separate page load driven by window.__SCENE__ (see harness.tsx).
+const SCENES = [
+  { name: "history", viewport: { width: 1200, height: 1500 } },
+  { name: "drawer", viewport: { width: 1200, height: 900 } },
+  { name: "drawer-access", viewport: { width: 1200, height: 900 } },
+];
+
+function outputDir() {
+  if (process.env.SCREENSHOT_OUT_DIR) return resolve(process.env.SCREENSHOT_OUT_DIR);
+  // Under `bbr test` the PNGs go to the test's undeclared outputs (fetched via the
+  // buildbuddy_api skill). Under a local `bazel run` (BUILD_WORKSPACE_DIRECTORY set) they
+  // land in the source tree for trivial opening.
+  if (process.env.TEST_UNDECLARED_OUTPUTS_DIR) return process.env.TEST_UNDECLARED_OUTPUTS_DIR;
+  if (process.env.BUILD_WORKSPACE_DIRECTORY) {
+    return join(process.env.BUILD_WORKSPACE_DIRECTORY, "haku/console/frontend/screenshots/out");
+  }
+  return resolve("screenshot-out");
+}
+
+function pageHtml(css, harnessJs, scene) {
+  // The <base href> gives the origin-less setContent page a URL against which the SPA's
+  // relative "/api/…" requests parse (the harness stubs the actual fetch). The scene global
+  // is set before the harness IIFE runs so it renders the right surface.
+  return [
+    "<!doctype html><html><head><meta charset='utf-8'>",
+    "<base href='https://haku-console.test/'>",
+    `<style>${css}</style></head><body><div id='app'></div>`,
+    `<script>window.__SCENE__=${JSON.stringify(scene)};</script>`,
+    `<script>${harnessJs}</script></body></html>`,
+  ].join("");
+}
+
+// Prefer the BUILD-wired $(rootpath) env (resolves against the js_test runfiles-root CWD);
+// fall back to this script's runfiles-relative location, where the harness bundle and
+// generated stylesheet sit at fixed workspace-relative paths alongside it.
+function readInput(envName, ...fallback) {
+  const fromEnv = process.env[envName];
+  const path = fromEnv && existsSync(fromEnv) ? fromEnv : join(HERE, ...fallback);
+  return readFileSync(path, "utf8");
+}
+
+const css = readInput("STYLES_CSS", "..", "generated", "styles.css");
+const harnessJs = readInput("HARNESS_JS", "dist", "harness.js");
+const outDir = outputDir();
+mkdirSync(outDir, { recursive: true });
+
+// Chromium: the BUILD wires PUPPETEER_EXECUTABLE_PATH to the hermetic @playwright_browsers
+// build under RBE; fall back to the ambient Playwright browser for a local `bazel run`.
+if (!process.env.PUPPETEER_EXECUTABLE_PATH && process.env.PLAYWRIGHT_BROWSERS_PATH) {
+  process.env.PUPPETEER_EXECUTABLE_PATH = join(process.env.PLAYWRIGHT_BROWSERS_PATH, "chromium");
+}
+
+const browser = await launchPuppeteerBrowser({
+  args: [
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-gpu",
+    "--force-color-profile=srgb",
+  ],
+});
+try {
+  for (const { name, viewport } of SCENES) {
+    const page = await browser.newPage();
+    await page.setViewport({ ...viewport, deviceScaleFactor: 2 });
+    await page.emulateMediaFeatures([{ name: "prefers-reduced-motion", value: "reduce" }]);
+    await page.setContent(pageHtml(css, harnessJs, name), { waitUntil: "load" });
+    await page.waitForSelector("#app > *", { timeout: 10_000 });
+    // Let Mantine mount and layout settle, and outlast the approval buttons' 400ms arm
+    // delay so they render enabled (animations are reduced above).
+    await new Promise((r) => setTimeout(r, 700));
+    const dest = join(outDir, `${name}.png`);
+    const png = await page.screenshot();
+    writeFileSync(dest, png);
+    console.log(`wrote ${dest}`);
+    await page.close();
+  }
+} finally {
+  await browser.close();
+}
+console.log(`\n${SCENES.length} screenshots in ${outDir}`);

--- a/haku/console/frontend/screenshots/sample_data.ts
+++ b/haku/console/frontend/screenshots/sample_data.ts
@@ -1,0 +1,81 @@
+// Deterministic sample data for the screenshot scenes (harness.tsx) and the API stub
+// (mock_api.ts). Kept separate so both share one source of truth.
+import type { RecentToolCall } from "../approval_state.ts";
+import type { McpOperatorAuthStatus, PendingApproval, ToolCallRecord } from "../client.ts";
+
+function toolCall(overrides: Partial<ToolCallRecord> & Pick<ToolCallRecord, "tool_call_id">): ToolCallRecord {
+  return {
+    server_id: "grocy-sf",
+    tool_name: "stock_add",
+    caller_principal: "haku-agent-api-token",
+    status: "ok",
+    created_at: "2026-07-09T14:32:00Z",
+    updated_at: "2026-07-09T14:32:04Z",
+    arguments: { items: [{ product_id: 42, amount: 2 }] },
+    rationale: "Thrive box delivered; adding its items to inventory.",
+    title: null,
+    result: { content: [{ type: "text", text: "stock_add:42:2" }], isError: false },
+    error: null,
+    denial_reason: null,
+    ...overrides,
+  };
+}
+
+export const SAMPLE_TOOL_CALLS: ToolCallRecord[] = [
+  toolCall({ tool_call_id: "tc_1", title: "Add Thrive box items to Grocy", status: "ok" }),
+  toolCall({
+    tool_call_id: "tc_2",
+    server_id: "google",
+    tool_name: "create_calendar_event",
+    title: "Create calendar event: Dentist",
+    status: "error",
+    rationale: "Booked a dentist appointment from the confirmation email.",
+    error: "Calendar API returned 403: insufficient scope for calendar.events.",
+    result: null,
+    caller_principal: "operator",
+    arguments: { summary: "Dentist", start: "2026-07-12T09:00:00", end: "2026-07-12T10:00:00" },
+  }),
+  toolCall({
+    tool_call_id: "tc_3",
+    server_id: "kubectl",
+    tool_name: "delete_pod",
+    title: "Delete crashlooping pod",
+    status: "denied",
+    rationale: "The worker pod has been CrashLoopBackOff for 20 minutes; restart it.",
+    denial_reason: "Not without a rollout plan — investigate the crash first.",
+    result: null,
+    caller_principal: "operator",
+    arguments: { namespace: "haku-sandbox", pod: "worker-6f9c2" },
+  }),
+];
+
+export const SAMPLE_PENDING: PendingApproval[] = [
+  {
+    tool_call_id: "tc_p1",
+    server_id: "grocy-sf",
+    tool_name: "shopping_list_items_remove",
+    title: "Remove bought items from the weekly list",
+    caller_principal: "haku-agent-api-token",
+    rationale: "These are already in stock after the Thrive delivery, so drop them from the list.",
+    arguments: { ids: [3, 7, 12] },
+    created_at: "2026-07-09T14:40:00Z",
+  },
+];
+
+export const SAMPLE_RECENT: RecentToolCall[] = [
+  {
+    record: toolCall({ tool_call_id: "tc_r1", title: "Add Thrive box items to Grocy", status: "ok" }),
+    hideAtMs: 12_000,
+  },
+];
+
+export const SAMPLE_MCP: McpOperatorAuthStatus[] = [
+  {
+    server_id: "grocy-sf",
+    status: "connected",
+    operator_principal: "agentydragon",
+    connected_at: "2026-07-01T09:00:00Z",
+    token_expires_at: "2026-08-01T09:00:00Z",
+    scope: "read write",
+  },
+];

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -97,6 +97,51 @@
   right: 8px;
 }
 
+/* Full-page past-tool-calls history view (tool_calls_page.tsx) — its own route, so it
+   replaces the framed haku-ui rather than overlaying it. */
+.haku-history-page {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--haku-page-bg);
+  color: var(--mantine-color-text);
+}
+
+.haku-history-header {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--haku-border);
+  background: var(--haku-panel-bg);
+}
+
+.haku-history-bar,
+.haku-history-list {
+  width: 100%;
+  max-width: 56rem;
+  margin: 0 auto;
+}
+
+.haku-history-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+}
+
+.haku-history-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.haku-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
 .haku-shell-overlay {
   position: fixed;
   inset: 0;

--- a/haku/console/frontend/tool_arguments_field.tsx
+++ b/haku/console/frontend/tool_arguments_field.tsx
@@ -1,0 +1,20 @@
+import { Field } from "./field.tsx";
+import { toolPreview } from "./tool_previews.tsx";
+
+/** Arguments field for a tool-call approval/result: a per-tool-type widget
+ * (google_tool_previews.tsx, ...) when one matches, else the generic raw-JSON view.
+ * Shared by the approval drawer and the past-tool-calls history view. */
+export function ToolArgumentsField({
+  serverId,
+  toolName,
+  args,
+  argumentsJson,
+}: {
+  serverId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  argumentsJson: string;
+}) {
+  const nice = toolPreview(serverId, toolName, args);
+  return <Field label="Arguments">{nice ?? <pre className="haku-shell-json">{argumentsJson}</pre>}</Field>;
+}

--- a/haku/console/frontend/tool_call_events.ts
+++ b/haku/console/frontend/tool_call_events.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useRef } from "react";
+
+// The console's "tool-call state may have changed, re-read it" signal, shared by every
+// surface that shows tool calls (the approval drawer and the full history view). It fuses
+// two sources: the server-pushed `/api/approvals/ws` WebSocket (a submit/approve/deny/finish
+// happened somewhere) and a cross-tab BroadcastChannel (another console tab made a change).
+// `onEvent` fires once on mount (initial read) and again on every event; `notifyPeers()`
+// lets a tab that just changed state wake its siblings.
+const TOOL_CALL_CHANNEL = "haku-console-tool-approvals";
+
+export function useToolCallEvents(onEvent: () => void): { notifyPeers: () => void } {
+  // Held in a ref so a changing callback identity never re-opens the socket/channel.
+  const onEventRef = useRef(onEvent);
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  });
+
+  const channelRef = useRef<BroadcastChannel | null>(null);
+
+  useEffect(() => {
+    const fire = () => onEventRef.current();
+    fire(); // initial read; the WS/channel below only deliver subsequent changes
+
+    let channel: BroadcastChannel | null = null;
+    if ("BroadcastChannel" in window) {
+      channel = new BroadcastChannel(TOOL_CALL_CHANNEL);
+      channelRef.current = channel;
+      channel.onmessage = () => fire();
+    }
+
+    let closed = false;
+    let ws: WebSocket | null = null;
+    // Only a real web origin can open the WS. A screenshot harness renders from an
+    // origin-less about:blank page, where the initial read above already populated the view
+    // and `new WebSocket` on a non-ws URL would throw — so skip it there.
+    const { protocol, href } = window.location;
+    if (protocol === "https:" || protocol === "http:") {
+      const url = new URL("/api/approvals/ws", href);
+      url.protocol = protocol === "https:" ? "wss:" : "ws:";
+      ws = new WebSocket(url);
+      const fireIfLive = () => {
+        if (!closed) fire();
+      };
+      ws.onopen = fireIfLive;
+      ws.onmessage = fireIfLive;
+      ws.onclose = fireIfLive;
+    }
+
+    return () => {
+      closed = true;
+      ws?.close();
+      if (channelRef.current === channel) channelRef.current = null;
+      channel?.close();
+    };
+  }, []);
+
+  return { notifyPeers: useCallback(() => channelRef.current?.postMessage({ type: "toolCallsChanged" }), []) };
+}

--- a/haku/console/frontend/tool_calls_page.tsx
+++ b/haku/console/frontend/tool_calls_page.tsx
@@ -1,0 +1,139 @@
+import { Badge, Button, Group, Loader, Stack, Text } from "@mantine/core";
+import { useCallback, useEffect, useState } from "react";
+
+import { approvalDisplayFields, shortDate, statusColor, terminalStatusLabel } from "./approval_state.ts";
+import { fetchToolCalls, type ToolCallRecord } from "./client.ts";
+import { Field } from "./field.tsx";
+import { ArrowLeftIcon } from "./icons.tsx";
+import { ToolArgumentsField } from "./tool_arguments_field.tsx";
+
+// Matches the backend's `le=500` cap on GET /api/tool-calls (mcp_approval.py).
+const HISTORY_LIMIT = 500;
+
+function ToolCallRow({ record }: { record: ToolCallRecord }) {
+  const fields = approvalDisplayFields(record);
+  return (
+    <section className="haku-shell-card">
+      <Stack gap="sm">
+        <Group justify="space-between" align="flex-start" gap="sm" wrap="nowrap">
+          <Stack gap={2} style={{ minWidth: 0 }}>
+            <Text fw={700}>{fields.title}</Text>
+            <Text size="xs" c="dimmed">
+              {fields.serverId}.{fields.toolName}
+            </Text>
+          </Stack>
+          <Badge color={statusColor(record.status)} variant="light">
+            {terminalStatusLabel(record.status)}
+          </Badge>
+        </Group>
+        {record.error && (
+          <Text size="sm" c="red">
+            {record.error}
+          </Text>
+        )}
+        <dl className="haku-shell-fields">
+          <div className="haku-shell-field-grid">
+            <Field label="Caller">{fields.callerPrincipal ?? "—"}</Field>
+            <Field label="Requested">{shortDate(fields.createdAt) ?? "—"}</Field>
+          </div>
+          {fields.rationale && <Field label="Rationale">{fields.rationale}</Field>}
+          {fields.denialReason && <Field label="Denial reason">{fields.denialReason}</Field>}
+          <ToolArgumentsField
+            serverId={fields.serverId}
+            toolName={fields.toolName}
+            args={record.arguments}
+            argumentsJson={fields.argumentsJson}
+          />
+          {record.result && (
+            <details className="haku-shell-disclosure">
+              <summary>Result</summary>
+              <pre className="haku-shell-json">{JSON.stringify(record.result, null, 2)}</pre>
+            </details>
+          )}
+          <details className="haku-shell-disclosure">
+            <summary>Tool call id</summary>
+            <code>{fields.toolCallId}</code>
+          </details>
+        </dl>
+      </Stack>
+    </section>
+  );
+}
+
+// The console's own full-page view of the whole tool-call audit ledger — a bigger,
+// persistent counterpart to the shell drawer's ephemeral "Recent" list. Its own route
+// (routing.ts → "/tool-calls"), so the framed haku-ui is unmounted while it's open.
+export function ToolCallsPage({ onBack }: { onBack: () => void }) {
+  const [records, setRecords] = useState<ToolCallRecord[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    fetchToolCalls(HISTORY_LIMIT).then(
+      (calls) => {
+        setRecords(calls);
+        setError(null);
+        setLoading(false);
+      },
+      (e: unknown) => {
+        setError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      }
+    );
+  }, []);
+
+  useEffect(load, [load]);
+
+  return (
+    <div className="haku-history-page">
+      <header className="haku-history-header">
+        <div className="haku-history-bar">
+          <Group gap="xs" wrap="nowrap" align="center">
+            <Button size="xs" variant="subtle" color="gray" leftSection={<ArrowLeftIcon />} onClick={onBack}>
+              Back
+            </Button>
+            <Text fw={700}>Past tool calls</Text>
+            {records && (
+              <Text size="sm" c="dimmed">
+                {records.length}
+              </Text>
+            )}
+          </Group>
+          <Button size="xs" variant="light" loading={loading} onClick={load}>
+            Refresh
+          </Button>
+        </div>
+      </header>
+      <div className="haku-history-scroll">
+        <div className="haku-history-list">
+          {error && (
+            <Text c="red" size="sm">
+              Failed to load tool calls: {error}
+            </Text>
+          )}
+          {!records && !error && (
+            <Group justify="center" p="xl">
+              <Loader />
+            </Group>
+          )}
+          {records && records.length === 0 && (
+            <section className="haku-shell-card">
+              <Text size="sm" c="dimmed">
+                No tool calls recorded yet.
+              </Text>
+            </section>
+          )}
+          {records?.map((record) => (
+            <ToolCallRow key={record.tool_call_id} record={record} />
+          ))}
+          {records && records.length === HISTORY_LIMIT && (
+            <Text size="xs" c="dimmed" ta="center">
+              Showing the {HISTORY_LIMIT} most recent tool calls.
+            </Text>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/haku/console/frontend/tool_calls_page.tsx
+++ b/haku/console/frontend/tool_calls_page.tsx
@@ -1,11 +1,12 @@
 import { Badge, Button, Group, Loader, Stack, Text } from "@mantine/core";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { approvalDisplayFields, shortDate, statusColor, terminalStatusLabel } from "./approval_state.ts";
 import { fetchToolCalls, type ToolCallRecord } from "./client.ts";
 import { Field } from "./field.tsx";
 import { ArrowLeftIcon } from "./icons.tsx";
 import { ToolArgumentsField } from "./tool_arguments_field.tsx";
+import { useToolCallEvents } from "./tool_call_events.ts";
 
 // Matches the backend's `le=500` cap on GET /api/tool-calls (mcp_approval.py).
 const HISTORY_LIMIT = 500;
@@ -83,7 +84,9 @@ export function ToolCallsPage({ onBack }: { onBack: () => void }) {
     );
   }, []);
 
-  useEffect(load, [load]);
+  // Live: initial load on mount plus a refetch whenever a tool call is submitted, approved,
+  // denied, or finishes anywhere — the same WS/cross-tab signal the approval drawer uses.
+  useToolCallEvents(load);
 
   return (
     <div className="haku-history-page">

--- a/haku/console/mcp_approval.py
+++ b/haku/console/mcp_approval.py
@@ -214,7 +214,12 @@ class ToolCallLedgerProtocol(Protocol):
     def get(self, tool_call_id: str) -> ToolCallRecord: ...
 
     def list(
-        self, *, statuses: list[ToolCallStatus] | None = None, since: dt.datetime | None = None, limit: int = 100
+        self,
+        *,
+        statuses: list[ToolCallStatus] | None = None,
+        since: dt.datetime | None = None,
+        limit: int = 100,
+        newest_first: bool = False,
     ) -> ToolCallListResponse: ...
 
     def events_after_id(self, after_event_id: int = 0) -> ToolCallEventsResponse: ...
@@ -285,7 +290,12 @@ class PostgresToolCallLedger:
         return row.to_record()
 
     def list(
-        self, *, statuses: list[ToolCallStatus] | None = None, since: dt.datetime | None = None, limit: int = 100
+        self,
+        *,
+        statuses: list[ToolCallStatus] | None = None,
+        since: dt.datetime | None = None,
+        limit: int = 100,
+        newest_first: bool = False,
     ) -> ToolCallListResponse:
         with self._sessions.begin() as session:
             stmt = select(McpToolCall)
@@ -293,7 +303,11 @@ class PostgresToolCallLedger:
                 stmt = stmt.where(McpToolCall.updated_at > since)
             if statuses:
                 stmt = stmt.where(McpToolCall.status.in_(statuses))
-            rows = session.scalars(stmt.order_by(McpToolCall.created_at).limit(limit)).all()
+            # `newest_first` makes `limit` keep the most recent calls (the audit/history
+            # view wants those); the default ascending order stays the queue-friendly
+            # oldest-first for pending-approval reads.
+            order = McpToolCall.created_at.desc() if newest_first else McpToolCall.created_at
+            rows = session.scalars(stmt.order_by(order).limit(limit)).all()
         records = [row.to_record() for row in rows]
         return ToolCallListResponse(tool_calls=records)
 
@@ -1227,8 +1241,9 @@ async def list_tool_calls(
     status: Annotated[list[ToolCallStatus] | None, Query()] = None,
     since: dt.datetime | None = None,
     limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    newest_first: bool = False,
 ) -> ToolCallListResponse:
-    return ledger.list(statuses=status, since=since, limit=limit)
+    return ledger.list(statuses=status, since=since, limit=limit, newest_first=newest_first)
 
 
 @router.get("/api/tool-calls/{tool_call_id}")

--- a/haku/console/test_app.py
+++ b/haku/console/test_app.py
@@ -49,5 +49,19 @@ def test_cache_policy_splits_hashed_assets_app_shell_and_api(make_client, tmp_pa
         assert c.get("/healthz").headers["cache-control"] == "no-store"
 
 
+def test_spa_route_deep_link_serves_index(make_client, tmp_path: Path) -> None:
+    # The console's own client-side routes (e.g. /tool-calls) have no file on disk; the dev
+    # fallback must serve the SPA shell for them, matching production's nginx try_files.
+    static_dir = tmp_path / "web"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<!doctype html><div id='root'></div>", encoding="utf-8")
+
+    with make_client(static_dir=static_dir) as c:
+        resp = c.get("/tool-calls")
+        assert resp.status_code == 200
+        assert "id='root'" in resp.text
+        assert resp.headers["cache-control"] == "no-cache, max-age=0, must-revalidate"
+
+
 if __name__ == "__main__":
     pytest_bazel.main()

--- a/haku/console/test_mcp_approval.py
+++ b/haku/console/test_mcp_approval.py
@@ -624,6 +624,23 @@ def test_all_v1_tool_calls_require_console_approval(
     assert listed["tool_calls"][0]["tool_call_id"] == body["tool_call_id"]
 
 
+def test_list_newest_first_keeps_the_most_recent(make_client, tmp_path: Path, db_url: str, mcp_server_url: str) -> None:
+    with make_client(config_file=_config_file(tmp_path, mcp_server_url), **_test_app_overrides(db_url)) as client:
+        first = _submit(client, amount=1)
+        second = _submit(client, amount=2)
+        third = _submit(client, amount=3)
+        newest = client.get("/api/tool-calls", params={"newest_first": "true"}).json()
+        newest_two = client.get("/api/tool-calls", params={"newest_first": "true", "limit": 2}).json()
+        oldest = client.get("/api/tool-calls").json()
+
+    ids = [first["tool_call_id"], second["tool_call_id"], third["tool_call_id"]]
+    assert [r["tool_call_id"] for r in newest["tool_calls"]] == list(reversed(ids))
+    # `limit` under newest_first keeps the most recent calls, not the oldest.
+    assert [r["tool_call_id"] for r in newest_two["tool_calls"]] == [third["tool_call_id"], second["tool_call_id"]]
+    # The default (no newest_first) stays oldest-first for the pending-approval queue.
+    assert [r["tool_call_id"] for r in oldest["tool_calls"]] == ids
+
+
 def test_websocket_receives_pending_approval_event(
     make_client, tmp_path: Path, db_url: str, mcp_server_url: str
 ) -> None:


### PR DESCRIPTION
## Summary

Adds a separate, full-page view of the whole MCP tool-call ledger to the Haku console, plus several related console improvements. Three commits:

### 1. Full-page "Past tool calls" history view + panel toggle (`e33349e9`)
- New route **`/tool-calls`** — a full page (not a sidebar) listing the whole tool-call ledger with color-coded status (OK / ERROR / DENIED), caller, timestamp, rationale, denial reason, JSON arguments, and collapsible result / id.
- **Routing change**: the console now distinguishes its own pages by URL *path* (`routing.ts`), leaving the hash reserved for mirroring the framed haku-ui route so console navigation never collides with the frame. Production nginx already serves the SPA for any non-asset path; `app.py`'s dev fallback mirrors that so deep links work locally too.
- Backend `GET /api/tool-calls` gains `newest_first=true` so the newest calls survive the query limit (default stays oldest-first for the pending-approval queue).
- Replaced the wrong "Approvals" text toggle with a generic **hamburger icon** carrying a **pulsing callout light** when a tool call awaits approval; added a "Past tool calls" link into the panel. Icons are inline SVG (the `@tabler` barrel OOMs esbuild — see `debug/esbuild_tabler_memory.md`).

### 2. Deny-with-reason + visual screenshot target (`d117c038`)
- Each pending approval card now has an always-visible optional **"Denial reason"** field, so a single Deny click carries a reason straight from the drawer.
- New **`//haku/console/frontend:screenshots`** — a js_test that renders each console surface (history view, approval drawer, access tab) to a PNG in its undeclared outputs for eyeballing. Runs on the RBE worker's display stack via the shared `frontend_visual` puppeteer lib + hermetic Playwright Chromium; a mocked fetch + `<base href>` let the origin-less harness render the data-fetching history view populated. A new `frontend/AGENTS.md` instructs always running it and visually checking the output when editing console visuals.

### 3. Live-update the full history via the shared WS signal (`c958a02c`)
- Extracted the console's tool-call change signal (the `/api/approvals/ws` WebSocket + cross-tab BroadcastChannel) into a `useToolCallEvents(onEvent)` hook. The approval drawer and the `/tool-calls` page both use it, so the full page refetches live on every submit / approve / deny / finish without a reload. The hook only opens the WebSocket from a real http(s) origin, keeping the screenshot harness safe.

## Testing

`bbr test`/`bbr build` all green: `tsc_test`, `bridge_test` (vitest), the production `bundle` (esbuild + tailwind), `test_app`, `test_mcp_approval` (incl. a new `newest_first` ordering test), the new `screenshots` render test, and Python lint (ruff + mypy). All three console surfaces were rendered and visually eyeballed via the new screenshot target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5PSCrFPzAn61Yqr2hZE9a)_