### PR TITLE
haku/console: drop redundant cross-tab BroadcastChannel from the live tool-call signal

### DIFF
--- a/haku/console/frontend/README.md
+++ b/haku/console/frontend/README.md
@@ -23,9 +23,9 @@ components + **Tailwind v4** utilities — modeled on
   preview or raw JSON) and inline-SVG icons (never the `@tabler` barrel — see
   `debug/esbuild_tabler_memory.md`), used by both the drawer and the history view.
 - `tool_call_events.ts` — `useToolCallEvents(onEvent)`: the shared live signal (the
-  `/api/approvals/ws` WebSocket + a cross-tab BroadcastChannel) that refetches on every
-  submit/approve/deny/finish. Both the approval drawer and the history view use it, so the
-  full page updates live without a reload.
+  `/api/approvals/ws` WebSocket) that refetches on every submit/approve/deny/finish. The
+  server broadcasts each event to every connected tab, so both the approval drawer and the
+  history view stay live without a reload — no client-side cross-tab plumbing needed.
 - `client.ts` — typed `openapi-fetch` client; the types come from the backend's
   OpenAPI schema (the `:schema` target runs `//haku/console:export_schema_bin`), so
   the Pydantic models are the single source of truth for the wire contract. Includes the

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -246,9 +246,9 @@ export function HakuUiEmbed({
     );
   }
 
-  // Live tool-call signal: initial fetch on mount plus a refetch on every WS/cross-tab
-  // event. `notifyPeers` wakes other console tabs after this one approves/denies.
-  const { notifyPeers } = useToolCallEvents(refreshToolApprovals);
+  // Live tool-call signal: initial fetch on mount plus a refetch on every server WS event
+  // (which the server also broadcasts to every other tab, so they refresh too).
+  useToolCallEvents(refreshToolApprovals);
 
   function refreshMcpAuthStatuses(notify = false) {
     if (notify) mcpAuthChannelRef.current?.postMessage({ type: "mcpAuthChanged" });
@@ -431,13 +431,11 @@ export function HakuUiEmbed({
         finishToolDecision(record);
         toastSuccess("Tool call finished", `${record.server_id}.${record.tool_name}: ${record.status}`);
         refreshToolApprovals();
-        notifyPeers();
       })
       .catch((e: unknown) => {
         setDeciding(approvalId, false);
         toastError("Tool call failed", e);
         refreshToolApprovals();
-        notifyPeers();
       });
   }
 
@@ -449,13 +447,11 @@ export function HakuUiEmbed({
         finishToolDecision(record);
         toastSuccess("Tool call denied", approval.title ?? `${approval.server_id}: ${approval.tool_name}`);
         refreshToolApprovals();
-        notifyPeers();
       },
       (e: unknown) => {
         setDeciding(approvalId, false);
         toastError("Couldn't deny tool call", e);
         refreshToolApprovals();
-        notifyPeers();
       }
     );
   }

--- a/haku/console/frontend/tool_call_events.ts
+++ b/haku/console/frontend/tool_call_events.ts
@@ -1,32 +1,21 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 
 // The console's "tool-call state may have changed, re-read it" signal, shared by every
-// surface that shows tool calls (the approval drawer and the full history view). It fuses
-// two sources: the server-pushed `/api/approvals/ws` WebSocket (a submit/approve/deny/finish
-// happened somewhere) and a cross-tab BroadcastChannel (another console tab made a change).
-// `onEvent` fires once on mount (initial read) and again on every event; `notifyPeers()`
-// lets a tab that just changed state wake its siblings.
-const TOOL_CALL_CHANNEL = "haku-console-tool-approvals";
-
-export function useToolCallEvents(onEvent: () => void): { notifyPeers: () => void } {
-  // Held in a ref so a changing callback identity never re-opens the socket/channel.
+// surface that shows tool calls (the approval drawer and the full history view). The
+// authoritative source is the server-pushed `/api/approvals/ws` WebSocket: the backend's
+// ToolCallEventHub broadcasts every submit/approve/deny/finish to every connected tab
+// (across replicas via Postgres LISTEN/NOTIFY), so a change in one tab reaches the others
+// through the server. `onEvent` fires once on mount (initial read) and again on every event.
+export function useToolCallEvents(onEvent: () => void): void {
+  // Held in a ref so a changing callback identity never re-opens the socket.
   const onEventRef = useRef(onEvent);
   useEffect(() => {
     onEventRef.current = onEvent;
   });
 
-  const channelRef = useRef<BroadcastChannel | null>(null);
-
   useEffect(() => {
     const fire = () => onEventRef.current();
-    fire(); // initial read; the WS/channel below only deliver subsequent changes
-
-    let channel: BroadcastChannel | null = null;
-    if ("BroadcastChannel" in window) {
-      channel = new BroadcastChannel(TOOL_CALL_CHANNEL);
-      channelRef.current = channel;
-      channel.onmessage = () => fire();
-    }
+    fire(); // initial read; the WS below only delivers subsequent changes
 
     let closed = false;
     let ws: WebSocket | null = null;
@@ -49,10 +38,6 @@ export function useToolCallEvents(onEvent: () => void): { notifyPeers: () => voi
     return () => {
       closed = true;
       ws?.close();
-      if (channelRef.current === channel) channelRef.current = null;
-      channel?.close();
     };
   }, []);
-
-  return { notifyPeers: useCallback(() => channelRef.current?.postMessage({ type: "toolCallsChanged" }), []) };
 }


### PR DESCRIPTION
Removes the client-side cross-tab `BroadcastChannel` from `useToolCallEvents`.

The server's `ToolCallEventHub` already broadcasts every submit/approve/deny/finish over `/api/approvals/ws` to every connected tab (across replicas via Postgres `LISTEN/NOTIFY`), so a change in one tab reaches the others through the server. The client-side `BroadcastChannel` was therefore only a latency optimization. Dropping it and the `notifyPeers` call sites leaves `useToolCallEvents` doing just the initial read plus the server WS subscription.

**Stacked on #3007** — this depends on the `useToolCallEvents` hook introduced there (`tool_call_events.ts` doesn't exist on `devel`), so its base is that PR's branch rather than `devel`; GitHub will retarget it to `devel` once #3007 merges. Splitting it out per review feedback on #3007 so the feature PR stays a behavior-preserving refactor and this optimization removal is reviewed on its own.

## Testing

`bbr test` green: `tsc_test`, `bridge_test` (vitest), the production `bundle`, and the `screenshots` render test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5PSCrFPzAn61Yqr2hZE9a)_