### PR TITLE
haku/console/frontend: group per-server tool previews under tool_previews/

### DIFF
--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -131,7 +131,7 @@ js_library(
 
 js_library(
     name = "google_tool_previews",
-    srcs = ["google_tool_previews.tsx"],
+    srcs = ["tool_previews/google.tsx"],
     deps = [
         ":field",
         ":google_client",
@@ -145,7 +145,7 @@ js_library(
 
 js_library(
     name = "kubectl_tool_previews",
-    srcs = ["kubectl_tool_previews.tsx"],
+    srcs = ["tool_previews/kubectl.tsx"],
     deps = [
         ":field",
         "//:node_modules/@mantine/core",
@@ -156,7 +156,7 @@ js_library(
 
 js_library(
     name = "grocy_tool_previews",
-    srcs = ["grocy_tool_previews.tsx"],
+    srcs = ["tool_previews/grocy.tsx"],
     deps = [
         ":field",
         ":grocy_client",
@@ -168,7 +168,7 @@ js_library(
 
 js_library(
     name = "tool_previews",
-    srcs = ["tool_previews.tsx"],
+    srcs = ["tool_previews/index.tsx"],
     deps = [
         ":google_tool_previews",
         ":grocy_tool_previews",
@@ -276,20 +276,20 @@ filegroup(
         "console_panel.tsx",
         "field.tsx",
         "google_client.ts",
-        "google_tool_previews.tsx",
         "grocy_client.ts",
-        "grocy_tool_previews.tsx",
         "haku_ui_embed.tsx",
         "icons.tsx",
         "index.html",
-        "kubectl_tool_previews.tsx",
         "main.tsx",
         "routing.ts",
         "theme.ts",
         "toast.ts",
         "tool_arguments_field.tsx",
         "tool_calls_page.tsx",
-        "tool_previews.tsx",
+        "tool_previews/google.tsx",
+        "tool_previews/grocy.tsx",
+        "tool_previews/index.tsx",
+        "tool_previews/kubectl.tsx",
     ],
 )
 
@@ -437,7 +437,7 @@ tsc_bin.tsc_test(
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
         "routing.test.ts",
-        "tool_previews.test.ts",
+        "tool_previews/index.test.ts",
         "tsconfig.json",
         ":main_lib",
         ":schema",
@@ -460,7 +460,7 @@ vitest_bin.vitest_test(
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
         "routing.test.ts",
-        "tool_previews.test.ts",
+        "tool_previews/index.test.ts",
         "vitest.config.ts",
         ":approval_state",
         ":bridge",

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -16,7 +16,7 @@ js_openapi_schema(
 
 # Runtime Zod validators for the same backend models, generated from the same OpenAPI
 # JSON as :schema above. Used where a widget parses tool-call arguments it doesn't fully
-# trust (google_tool_previews.tsx) — a single source of truth for both the TS type and
+# trust (tool_previews/google.tsx) — a single source of truth for both the TS type and
 # the runtime shape check, instead of a hand-written `typeof`-narrowing guard that can
 # drift from the Pydantic model.
 js_openapi_zod(
@@ -130,60 +130,12 @@ js_library(
 )
 
 js_library(
-    name = "google_tool_previews",
-    srcs = ["tool_previews/google.tsx"],
-    deps = [
-        ":field",
-        ":google_client",
-        ":schema_zod",
-        "//:node_modules/@mantine/core",
-        "//:node_modules/date-fns",
-        "//:node_modules/react",
-        "//:node_modules/zod",
-    ],
-)
-
-js_library(
-    name = "kubectl_tool_previews",
-    srcs = ["tool_previews/kubectl.tsx"],
-    deps = [
-        ":field",
-        "//:node_modules/@mantine/core",
-        "//:node_modules/react",
-        "//:node_modules/zod",
-    ],
-)
-
-js_library(
-    name = "grocy_tool_previews",
-    srcs = ["tool_previews/grocy.tsx"],
-    deps = [
-        ":field",
-        ":grocy_client",
-        "//:node_modules/@mantine/core",
-        "//:node_modules/react",
-        "//:node_modules/zod",
-    ],
-)
-
-js_library(
-    name = "tool_previews",
-    srcs = ["tool_previews/index.tsx"],
-    deps = [
-        ":google_tool_previews",
-        ":grocy_tool_previews",
-        ":kubectl_tool_previews",
-        "//:node_modules/react",
-    ],
-)
-
-js_library(
     name = "tool_arguments_field",
     srcs = ["tool_arguments_field.tsx"],
     deps = [
         ":field",
-        ":tool_previews",
         "//:node_modules/react",
+        "//haku/console/frontend/tool_previews",
     ],
 )
 
@@ -286,10 +238,7 @@ filegroup(
         "toast.ts",
         "tool_arguments_field.tsx",
         "tool_calls_page.tsx",
-        "tool_previews/google.tsx",
-        "tool_previews/grocy.tsx",
-        "tool_previews/index.tsx",
-        "tool_previews/kubectl.tsx",
+        "//haku/console/frontend/tool_previews:tailwind_srcs",
     ],
 )
 
@@ -437,7 +386,6 @@ tsc_bin.tsc_test(
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
         "routing.test.ts",
-        "tool_previews/index.test.ts",
         "tsconfig.json",
         ":main_lib",
         ":schema",
@@ -445,6 +393,7 @@ tsc_bin.tsc_test(
         ":screenshot_harness_lib",
         "//:node_modules",
         "//:node_modules/@haku/console-bridge",
+        "//haku/console/frontend/tool_previews:index_test",
     ],
     tags = ["lint"],
 )
@@ -460,15 +409,14 @@ vitest_bin.vitest_test(
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
         "routing.test.ts",
-        "tool_previews/index.test.ts",
         "vitest.config.ts",
         ":approval_state",
         ":bridge",
         ":geolocation",
         ":haku_ui_embed",
         ":routing",
-        ":tool_previews",
         "//:node_modules",
         "//:node_modules/@haku/console-bridge",
+        "//haku/console/frontend/tool_previews:index_test",
     ],
 )

--- a/haku/console/frontend/google_client.ts
+++ b/haku/console/frontend/google_client.ts
@@ -4,7 +4,7 @@ import type { components } from "./api/schema";
 export type GmailThreadPreview = components["schemas"]["GmailThreadPreview"];
 
 // The google tool argument types (EventDateTime, CreateCalendarEventArgs, ...) aren't
-// re-exported here: google_tool_previews.tsx gets both the runtime validator and the
+// re-exported here: tool_previews/google.tsx gets both the runtime validator and the
 // inferred TS type from :schema_zod (api/schema.zod.ts), generated from the same
 // OpenAPI schema this file's `components["schemas"]` draws from — see
 // `GoogleToolArgumentExamples` in haku/console/tools/google.py for why these models

--- a/haku/console/frontend/tool_arguments_field.tsx
+++ b/haku/console/frontend/tool_arguments_field.tsx
@@ -1,8 +1,8 @@
 import { Field } from "./field.tsx";
-import { toolPreview } from "./tool_previews.tsx";
+import { toolPreview } from "./tool_previews/index.tsx";
 
 /** Arguments field for a tool-call approval/result: a per-tool-type widget
- * (google_tool_previews.tsx, ...) when one matches, else the generic raw-JSON view.
+ * (the tool_previews/ per-server modules) when one matches, else the generic raw-JSON view.
  * Shared by the approval drawer and the past-tool-calls history view. */
 export function ToolArgumentsField({
   serverId,

--- a/haku/console/frontend/tool_previews/BUILD.bazel
+++ b/haku/console/frontend/tool_previews/BUILD.bazel
@@ -1,0 +1,69 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# Per-server approval-preview widgets. Each module owns one server's widgets and returns
+# null for anything outside its serverId; `tool_previews` (index.tsx) chains them.
+
+js_library(
+    name = "google",
+    srcs = ["google.tsx"],
+    deps = [
+        "//:node_modules/@mantine/core",
+        "//:node_modules/date-fns",
+        "//:node_modules/react",
+        "//:node_modules/zod",
+        "//haku/console/frontend:field",
+        "//haku/console/frontend:google_client",
+        "//haku/console/frontend:schema_zod",
+    ],
+)
+
+js_library(
+    name = "grocy",
+    srcs = ["grocy.tsx"],
+    deps = [
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+        "//:node_modules/zod",
+        "//haku/console/frontend:field",
+        "//haku/console/frontend:grocy_client",
+    ],
+)
+
+js_library(
+    name = "kubectl",
+    srcs = ["kubectl.tsx"],
+    deps = [
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+        "//:node_modules/zod",
+        "//haku/console/frontend:field",
+    ],
+)
+
+js_library(
+    name = "tool_previews",
+    srcs = ["index.tsx"],
+    deps = [
+        ":google",
+        ":grocy",
+        ":kubectl",
+        "//:node_modules/react",
+    ],
+)
+
+# Sources Tailwind must scan for class names; the parent's tailwind_content_srcs
+# concatenates this into the one file the stylesheet's @source lists.
+filegroup(
+    name = "tailwind_srcs",
+    srcs = glob(["*.tsx"]),
+)
+
+# The dispatcher's vitest spec; the parent's aggregate tsc_test + bridge_test consume it
+# (a js_test can't take a source file from another package directly, only via a library).
+js_library(
+    name = "index_test",
+    srcs = ["index.test.ts"],
+    deps = [":tool_previews"],
+)

--- a/haku/console/frontend/tool_previews/google.tsx
+++ b/haku/console/frontend/tool_previews/google.tsx
@@ -18,9 +18,9 @@ import {
   zCreateCalendarEventArgs,
   zCreateGmailDraftArgs,
   zEventDateTime,
-} from "./api/schema.zod.ts";
-import { fetchGmailThreadPreviews, type GmailThreadPreview } from "./google_client.ts";
-import { Field } from "./field.tsx";
+} from "../api/schema.zod.ts";
+import { fetchGmailThreadPreviews, type GmailThreadPreview } from "../google_client.ts";
+import { Field } from "../field.tsx";
 
 const GOOGLE_SERVER_ID = "google";
 

--- a/haku/console/frontend/tool_previews/grocy.tsx
+++ b/haku/console/frontend/tool_previews/grocy.tsx
@@ -1,11 +1,11 @@
 // Per-tool-type rendering for the remote `grocy-sf` MCP server (see
 // grocy_mcp/README.md and grocy_mcp/batch_tools.py). Falls back to the generic raw-JSON
-// view for anything that isn't shaped as expected — same caveat as kubectl_tool_previews.tsx:
+// view for anything that isn't shaped as expected — same caveat as kubectl.tsx:
 // arguments are only validated by the tool's own schema at execution time, not at submission.
 //
 // grocy-sf's tool surface is generated from Grocy's own OpenAPI spec plus custom batch
 // tools (grocy_mcp/batch_tools.py) — there's no backend Pydantic model haku-console owns to
-// generate Zod schemas from (unlike google_tool_previews.tsx's :schema_zod), so these are
+// generate Zod schemas from (unlike google.tsx's :schema_zod), so these are
 // hand-authored once, here, against grocy_mcp/mcp_types.py's `AddItem` / `ConsumeItem` /
 // `CreateProductItem`. Every tool call runs as the approving operator's own linked Grocy
 // account (operator_oauth) once approved.
@@ -20,8 +20,8 @@ import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
-import { fetchGrocyReference, type GrocyReferenceResponse } from "./grocy_client.ts";
-import { Field } from "./field.tsx";
+import { fetchGrocyReference, type GrocyReferenceResponse } from "../grocy_client.ts";
+import { Field } from "../field.tsx";
 
 const GROCY_SERVER_ID = "grocy-sf";
 

--- a/haku/console/frontend/tool_previews/index.test.ts
+++ b/haku/console/frontend/tool_previews/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { toolPreview } from "./tool_previews.tsx";
+import { toolPreview } from "./index.tsx";
 
 describe("toolPreview", () => {
   it("renders a preview for valid grocy-sf products_create args", () => {

--- a/haku/console/frontend/tool_previews/index.tsx
+++ b/haku/console/frontend/tool_previews/index.tsx
@@ -1,13 +1,13 @@
-// Central dispatcher over per-server tool-preview modules (google_tool_previews.tsx,
-// kubectl_tool_previews.tsx, ...). Each module owns one server's widgets and returns
+// Central dispatcher over per-server tool-preview modules (google.tsx,
+// kubectl.tsx, ...). Each module owns one server's widgets and returns
 // null for anything outside its own serverId, so adding a server is "write a new
 // per-server file + add one line here" — this file never grows past that.
 
 import type { ReactNode } from "react";
 
-import { googleToolPreview } from "./google_tool_previews.tsx";
-import { grocyToolPreview } from "./grocy_tool_previews.tsx";
-import { kubectlToolPreview } from "./kubectl_tool_previews.tsx";
+import { googleToolPreview } from "./google.tsx";
+import { grocyToolPreview } from "./grocy.tsx";
+import { kubectlToolPreview } from "./kubectl.tsx";
 
 export function toolPreview(serverId: string, toolName: string, args: Record<string, unknown>): ReactNode | null {
   return (

--- a/haku/console/frontend/tool_previews/kubectl.tsx
+++ b/haku/console/frontend/tool_previews/kubectl.tsx
@@ -1,6 +1,6 @@
 // Per-tool-type rendering for the remote `kubectl-passthrough-mcp` MCP server (see
 // cluster/k8s/agents/kubectl-passthrough-mcp/). Falls back to the generic raw-JSON view
-// for anything that isn't shaped as expected — same caveat as google_tool_previews.tsx:
+// for anything that isn't shaped as expected — same caveat as google.tsx:
 // arguments are only validated by the tool's own schema at execution time, not at
 // submission. Every tool here runs with the approving operator's own cluster-admin
 // identity (cluster_auth_mode=passthrough) once approved, so rendering the exact target
@@ -10,12 +10,12 @@ import { Badge, Group, Stack, Text } from "@mantine/core";
 import type { ReactNode } from "react";
 import { z } from "zod";
 
-import { Field } from "./field.tsx";
+import { Field } from "../field.tsx";
 
 const KUBECTL_SERVER_ID = "kubectl-passthrough-mcp";
 
 // kubectl-passthrough-mcp is a third-party binary (containers/kubernetes-mcp-server) —
-// there's no backend Pydantic model to generate these from (unlike google_tool_previews.tsx's
+// there's no backend Pydantic model to generate these from (unlike google.tsx's
 // :schema_zod), so they're hand-authored once, here, against that tool's real input schema
 // (checked via a live `tools/list` call against the deployed server).
 const zResourcesCreateOrUpdateArgs = z.object({


### PR DESCRIPTION
Mechanical reorg of the console's approval-drawer tool-preview widgets: move the per-server
preview modules and their dispatcher into a `tool_previews/` directory, then give that
directory its own package `BUILD.bazel` so the targets live next to their sources.

```text
haku/console/frontend/
  google_tool_previews.tsx   →  tool_previews/google.tsx    (googleToolPreview)
  grocy_tool_previews.tsx    →  tool_previews/grocy.tsx     (grocyToolPreview)
  kubectl_tool_previews.tsx  →  tool_previews/kubectl.tsx   (kubectlToolPreview)
  tool_previews.tsx          →  tool_previews/index.tsx     (toolPreview dispatcher)
  tool_previews.test.ts      →  tool_previews/index.test.ts
```

## What changed

- **Commit 1 — move under `tool_previews/`.** Files moved as git renames (history preserved);
  fixed the moved modules' now-one-level-deeper relative imports (`../field.tsx`,
  `../api/schema.zod.ts`, `../google_client.ts`, `../grocy_client.ts`), the dispatcher's
  sibling imports (`./google.tsx` …), and `console_panel.tsx` / `tool_arguments_field.tsx`
  import paths.
- **Commit 2 — own package BUILD.** Added `tool_previews/BUILD.bazel` (`:google`, `:grocy`,
  `:kubectl`, `:tool_previews`, `:tailwind_srcs`, `:index_test`). The parent package now
  references the sub-package (`//haku/console/frontend/tool_previews:tailwind_srcs`,
  `:index_test`, and `tool_arguments_field`'s dep) instead of listing preview sources
  directly. `js_test` can't consume a source file from another package, so the dispatcher's
  vitest spec is wrapped in an `:index_test` `js_library`.

## What did **not** change

- No behavior change — this is a decomposition, not a feature.
- The `google_client.ts` / `grocy_client.ts` data-fetch clients stay at the frontend root
  (the client layer, siblings of `client.ts`).

## Verification

- `bbr test //haku/console/frontend/...` → 3/3 pass (`tsc_test`, `bridge_test` incl. the
  dispatcher's `tool_previews/index.test.ts`, `screenshots`).
- `pre-commit` clean (buildifier, prettier, filename conventions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWWMs8UDB7vxQUFZ6vC5BB