### PR TITLE
haku/console: approve/deny pending calls from the history page + drawer/README cleanups

### DIFF
--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -209,6 +209,8 @@ js_library(
         ":client",
         ":field",
         ":icons",
+        ":theme",
+        ":toast",
         ":tool_arguments_field",
         ":tool_call_events",
         "//:node_modules/@mantine/core",

--- a/haku/console/frontend/README.md
+++ b/haku/console/frontend/README.md
@@ -33,10 +33,6 @@ components + **Tailwind v4** utilities — modeled on
   MCP operator-account association helpers.
 - `confirm_dialog.tsx` — trusted top-layer confirmations for bridge launches, geolocation
   grants, off-whitelist opens, and MCP tool-call approvals.
-- `console_panel.tsx` — the single settings-button drawer for shell-owned controls. Keep
-  MCP account connect/reconnect/disconnect affordances here rather than adding more visible
-  widgets above the framed haku-ui.
-- `markdown.ts` — item `body` → sanitized HTML (`marked` + `dompurify`).
 - `styles.src.css` — `@import`s Tailwind + `@mantine/core` CSS; compiled by
   `@tailwindcss/cli` to `generated/styles.css`, then fingerprinted into
   `dist/assets/styles-<hash>.css`. Deviation from a plain Tailwind setup: the `@source`

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -312,34 +312,38 @@ function ToolApprovalCard({
           </Badge>
         </Group>
       </div>
-      <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
-        <Textarea
-          size="xs"
-          mt="xs"
-          label="Denial reason (optional)"
-          placeholder="Why are you denying this?"
-          autosize
-          minRows={1}
-          maxRows={4}
-          disabled={deciding}
-          value={denyReason}
-          onChange={(e) => setDenyReason(e.currentTarget.value)}
-        />
-        <Group justify="flex-end" gap="xs" mt="xs">
-          <Button
-            size="compact-xs"
-            variant="light"
-            color="red"
-            disabled={deciding || !armed}
-            onClick={() => onDeny(denyReason.trim() || undefined)}
-          >
-            Deny
-          </Button>
-          <Button size="compact-xs" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
-            Approve
-          </Button>
-        </Group>
-      </div>
+      {/* When selected, the detail panel above carries the reason field + actions, so the
+          list card collapses to a highlighted summary — no duplicate reason input. */}
+      {!selected && (
+        <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+          <Textarea
+            size="xs"
+            mt="xs"
+            label="Denial reason (optional)"
+            placeholder="Why are you denying this?"
+            autosize
+            minRows={1}
+            maxRows={4}
+            disabled={deciding}
+            value={denyReason}
+            onChange={(e) => setDenyReason(e.currentTarget.value)}
+          />
+          <Group justify="flex-end" gap="xs" mt="xs">
+            <Button
+              size="compact-xs"
+              variant="light"
+              color="red"
+              disabled={deciding || !armed}
+              onClick={() => onDeny(denyReason.trim() || undefined)}
+            >
+              Deny
+            </Button>
+            <Button size="compact-xs" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
+              Approve
+            </Button>
+          </Group>
+        </div>
+      )}
     </section>
   );
 }

--- a/haku/console/frontend/screenshots/sample_data.ts
+++ b/haku/console/frontend/screenshots/sample_data.ts
@@ -22,6 +22,16 @@ function toolCall(overrides: Partial<ToolCallRecord> & Pick<ToolCallRecord, "too
 }
 
 export const SAMPLE_TOOL_CALLS: ToolCallRecord[] = [
+  toolCall({
+    tool_call_id: "tc_0",
+    server_id: "grocy-sf",
+    tool_name: "shopping_list_items_remove",
+    title: "Remove bought items from the weekly list",
+    status: "pending_approval",
+    rationale: "These are already in stock after the Thrive delivery, so drop them from the list.",
+    result: null,
+    arguments: { ids: [3, 7, 12] },
+  }),
   toolCall({ tool_call_id: "tc_1", title: "Add Thrive box items to Grocy", status: "ok" }),
   toolCall({
     tool_call_id: "tc_2",

--- a/haku/console/frontend/tool_calls_page.tsx
+++ b/haku/console/frontend/tool_calls_page.tsx
@@ -1,18 +1,72 @@
-import { Badge, Button, Group, Loader, Stack, Text } from "@mantine/core";
+import { Badge, Button, Group, Loader, Stack, Text, Textarea } from "@mantine/core";
 import { useCallback, useState } from "react";
 
 import { approvalDisplayFields, shortDate, statusColor, terminalStatusLabel } from "./approval_state.ts";
-import { fetchToolCalls, type ToolCallRecord } from "./client.ts";
+import { approveToolCall, denyToolCall, fetchToolCalls, type ToolCallRecord } from "./client.ts";
 import { Field } from "./field.tsx";
 import { ArrowLeftIcon } from "./icons.tsx";
+import { ACTION_COLOR } from "./theme.ts";
+import { toastError, toastSuccess } from "./toast.ts";
 import { ToolArgumentsField } from "./tool_arguments_field.tsx";
 import { useToolCallEvents } from "./tool_call_events.ts";
 
 // Matches the backend's `le=500` cap on GET /api/tool-calls (mcp_approval.py).
 const HISTORY_LIMIT = 500;
 
-function ToolCallRow({ record }: { record: ToolCallRecord }) {
+function PendingActions({
+  deciding,
+  onApprove,
+  onDeny,
+}: {
+  deciding: boolean;
+  onApprove: () => void;
+  onDeny: (reason?: string) => void;
+}) {
+  const [denyReason, setDenyReason] = useState("");
+  return (
+    <div>
+      <Textarea
+        size="xs"
+        label="Denial reason (optional)"
+        placeholder="Why are you denying this?"
+        autosize
+        minRows={1}
+        maxRows={4}
+        disabled={deciding}
+        value={denyReason}
+        onChange={(e) => setDenyReason(e.currentTarget.value)}
+      />
+      <Group justify="flex-end" gap="xs" mt="xs">
+        <Button
+          size="compact-sm"
+          variant="light"
+          color="red"
+          loading={deciding}
+          onClick={() => onDeny(denyReason.trim() || undefined)}
+        >
+          Deny
+        </Button>
+        <Button size="compact-sm" color={ACTION_COLOR} loading={deciding} onClick={onApprove}>
+          Approve
+        </Button>
+      </Group>
+    </div>
+  );
+}
+
+function ToolCallRow({
+  record,
+  deciding,
+  onApprove,
+  onDeny,
+}: {
+  record: ToolCallRecord;
+  deciding: boolean;
+  onApprove: () => void;
+  onDeny: (reason?: string) => void;
+}) {
   const fields = approvalDisplayFields(record);
+  const pending = record.status === "pending_approval";
   return (
     <section className="haku-shell-card">
       <Stack gap="sm">
@@ -56,6 +110,7 @@ function ToolCallRow({ record }: { record: ToolCallRecord }) {
             <code>{fields.toolCallId}</code>
           </details>
         </dl>
+        {pending && <PendingActions deciding={deciding} onApprove={onApprove} onDeny={onDeny} />}
       </Stack>
     </section>
   );
@@ -64,10 +119,13 @@ function ToolCallRow({ record }: { record: ToolCallRecord }) {
 // The console's own full-page view of the whole tool-call audit ledger — a bigger,
 // persistent counterpart to the shell drawer's ephemeral "Recent" list. Its own route
 // (routing.ts → "/tool-calls"), so the framed haku-ui is unmounted while it's open.
+// A pending call that streams in (via the live WS signal) can be approved/denied here too,
+// through the same CSRF-gated endpoints the drawer uses, without going back to the shell.
 export function ToolCallsPage({ onBack }: { onBack: () => void }) {
   const [records, setRecords] = useState<ToolCallRecord[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [decidingId, setDecidingId] = useState<string | null>(null);
 
   const load = useCallback(() => {
     setLoading(true);
@@ -85,8 +143,27 @@ export function ToolCallsPage({ onBack }: { onBack: () => void }) {
   }, []);
 
   // Live: initial load on mount plus a refetch whenever a tool call is submitted, approved,
-  // denied, or finishes anywhere — the same WS/cross-tab signal the approval drawer uses.
+  // denied, or finishes anywhere — the same WS signal the approval drawer uses.
   useToolCallEvents(load);
+
+  const decide = useCallback(
+    (id: string, run: () => Promise<ToolCallRecord>, okTitle: string) => {
+      setDecidingId(id);
+      run().then(
+        (record) => {
+          toastSuccess(okTitle, `${record.server_id}.${record.tool_name}: ${record.status}`);
+          setDecidingId(null);
+          load();
+        },
+        (e: unknown) => {
+          toastError("Tool call decision failed", e);
+          setDecidingId(null);
+          load();
+        }
+      );
+    },
+    [load]
+  );
 
   return (
     <div className="haku-history-page">
@@ -128,7 +205,17 @@ export function ToolCallsPage({ onBack }: { onBack: () => void }) {
             </section>
           )}
           {records?.map((record) => (
-            <ToolCallRow key={record.tool_call_id} record={record} />
+            <ToolCallRow
+              key={record.tool_call_id}
+              record={record}
+              deciding={decidingId === record.tool_call_id}
+              onApprove={() =>
+                decide(record.tool_call_id, () => approveToolCall(record.tool_call_id), "Tool call approved")
+              }
+              onDeny={(reason) =>
+                decide(record.tool_call_id, () => denyToolCall(record.tool_call_id, reason), "Tool call denied")
+              }
+            />
           ))}
           {records && records.length === HISTORY_LIMIT && (
             <Text size="xs" c="dimmed" ta="center">


### PR DESCRIPTION
Follow-ups after the past-tool-calls view (#3007) and BroadcastChannel removal (#3008) landed.

- **Act on pending calls from `/tool-calls`.** The full-page history view now renders approve/deny + an optional denial-reason field on pending-approval rows, wired to the same CSRF-gated `approveToolCall`/`denyToolCall` endpoints the drawer uses. A pending call that streams in via the live WS signal can now be actioned there without navigating back to the shell drawer. Terminal (OK/ERROR/DENIED) rows stay read-only. A pending sample row exercises it in the screenshot scene.
- **Drawer de-dup.** When an approval card is selected, its detail panel already carries the reason field + actions, so the list card now collapses to a highlighted summary instead of showing a second, duplicate reason input.
- **README hygiene.** Drop stale `frontend/README.md` bullets left from the old architecture (`markdown.ts` no longer exists; a duplicate `console_panel.tsx` entry).

## Testing

`bbr test` green: `tsc_test`, `bridge_test` (vitest), the production `bundle`, and the `screenshots` render test — and I eyeballed the regenerated history screenshot to confirm the pending-row approve/deny UI renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5PSCrFPzAn61Yqr2hZE9a)_