### PR TITLE
haku/console: import icons from @tabler/icons-react instead of inline SVG

### DIFF
--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -98,7 +98,10 @@ js_library(
 js_library(
     name = "icons",
     srcs = ["icons.tsx"],
-    deps = ["//:node_modules/react"],
+    deps = [
+        "//:node_modules/@tabler/icons-react",
+        "//:node_modules/react",
+    ],
 )
 
 js_library(
@@ -386,6 +389,8 @@ tsc_bin.tsc_test(
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
         "routing.test.ts",
+        # Ambient types for the @tabler/icons-react per-icon subpath imports (icons.tsx).
+        "tabler_icons.d.ts",
         "tsconfig.json",
         ":main_lib",
         ":schema",

--- a/haku/console/frontend/icons.tsx
+++ b/haku/console/frontend/icons.tsx
@@ -1,54 +1,25 @@
-// Inline SVG icons — deliberately NOT `@tabler/icons-react`: its barrel OOMs esbuild on
-// RBE (~8.7 GB peak) and even a per-icon subpath import needs an ambient declaration.
-// See debug/esbuild_tabler_memory.md → "Inline SVG". Each glyph strokes `currentColor`
-// so it inherits the button/text color and both color schemes.
-import type { SVGProps } from "react";
+// Tabler icons via **per-icon subpath imports** — never `import { … } from "@tabler/icons-react"`
+// (the barrel OOMs esbuild on RBE at ~8.7 GB; see debug/esbuild_tabler_memory.md). Types for the
+// `.mjs` subpaths come from the ambient declaration in `tabler_icons.d.ts`. Thin wrappers keep a
+// stable local name + a consistent glyph size; callers can still override via props.
+import IconArrowLeft from "@tabler/icons-react/dist/esm/icons/IconArrowLeft.mjs";
+import IconHistory from "@tabler/icons-react/dist/esm/icons/IconHistory.mjs";
+import IconMenu2 from "@tabler/icons-react/dist/esm/icons/IconMenu2.mjs";
+import type { ComponentProps } from "react";
 
-function Glyph(props: SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-      {...props}
-    />
-  );
-}
+type TablerIconProps = ComponentProps<typeof IconMenu2>;
 
 /** Hamburger — the shell's console-panel toggle. */
-export function MenuIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <Glyph {...props}>
-      <line x1="4" y1="6" x2="20" y2="6" />
-      <line x1="4" y1="12" x2="20" y2="12" />
-      <line x1="4" y1="18" x2="20" y2="18" />
-    </Glyph>
-  );
+export function MenuIcon(props: TablerIconProps) {
+  return <IconMenu2 size={20} {...props} />;
 }
 
 /** Clock-with-rewind — links to the past-tool-calls history view. */
-export function HistoryIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <Glyph {...props}>
-      <path d="M3 3v5h5" />
-      <path d="M3.05 13A9 9 0 1 0 6 5.3L3 8" />
-      <path d="M12 7v5l3 2" />
-    </Glyph>
-  );
+export function HistoryIcon(props: TablerIconProps) {
+  return <IconHistory size={20} {...props} />;
 }
 
 /** Left arrow — the history view's back-to-embed control. */
-export function ArrowLeftIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <Glyph {...props}>
-      <line x1="19" y1="12" x2="5" y2="12" />
-      <polyline points="12 19 5 12 12 5" />
-    </Glyph>
-  );
+export function ArrowLeftIcon(props: TablerIconProps) {
+  return <IconArrowLeft size={20} {...props} />;
 }

--- a/haku/console/frontend/tabler_icons.d.ts
+++ b/haku/console/frontend/tabler_icons.d.ts
@@ -1,0 +1,21 @@
+// Ambient types for the @tabler/icons-react per-icon subpath imports used by icons.tsx. The
+// `.mjs` subpaths resolve to real but untyped files, so each needs an *exact* module
+// declaration. Kept as a global script (no top-level import/export — the React imports live
+// INSIDE each block) so the declarations register globally. The subpath form is mandatory:
+// the `@tabler/icons-react` barrel OOMs esbuild on RBE (~8.7 GB; debug/esbuild_tabler_memory.md).
+// Add a block here for each icon imported.
+declare module "@tabler/icons-react/dist/esm/icons/IconMenu2.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}
+declare module "@tabler/icons-react/dist/esm/icons/IconHistory.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}
+declare module "@tabler/icons-react/dist/esm/icons/IconArrowLeft.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}


### PR DESCRIPTION
Swaps the console's three hand-rolled inline SVG glyphs for `IconMenu2` / `IconHistory` / `IconArrowLeft` from `@tabler/icons-react` (already a declared root dep).

- **Subpath imports only.** Icons are imported via the per-icon subpath form (`@tabler/icons-react/dist/esm/icons/IconX.mjs`), never the barrel — the barrel OOMs esbuild on RBE (~8.7 GB; see `debug/esbuild_tabler_memory.md`). This mirrors `x/rspcache/admin_ui`. Verified the production bundle still builds well under the default RBE VM.
- **Types for the untyped subpaths.** The `.mjs` subpaths ship no declarations, so `tabler_icons.d.ts` declares them for the `tsc` gate. It's a global *script* (the React imports live inside each `declare module` block, not at the top level) — a top-level import makes the file a module and the ambient declarations stop applying. Wired into the `tsc_test` data.
- Thin wrappers keep the local `MenuIcon` / `HistoryIcon` / `ArrowLeftIcon` names and a consistent size; callers are unchanged.

## Testing

`bbr test` green: `tsc_test`, `bridge_test`, the production `bundle` (no esbuild OOM), and the `screenshots` render test — and I eyeballed the regenerated drawer screenshot to confirm the Tabler `IconHistory` renders cleanly in the "Past tool calls" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5PSCrFPzAn61Yqr2hZE9a)_