### PR TITLE
tf/gitops/haku-state: provision haku/ducktape mirror for haku-ci Bazel builds

### DIFF
--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -204,20 +204,20 @@ resource "terraform_data" "registry_push_secret_refresh" {
 
 # ── Ducktape source mirror for haku-ci's Bazel builds ────────────────────────────────
 # Haku's UI Bazel build consumes ducktape's shared @haku/console-bridge package as a bzlmod
-# `git_override` (haku-state MODULE.bazel). Rather than have haku-ci fetch the agentydragon-owned
-# mirror directly, keep the dependency haku-owned and in-cluster: a private pull-mirror in haku's
-# own namespace. It syncs from the in-cluster `agentydragon/ducktape` (itself a github→forgejo
-# mirror); haku already has read on that repo (granted in tf/gitops/forgejo-agentydragon-repos),
-# so haku's basic-auth embedded in clone_addr is sufficient — no GitHub token and no external
-# egress. `mirror`/`clone_addr` are ForceNew: changing the source recreates the repo.
+# `git_override` (haku-state MODULE.bazel). Give haku its own private mirror so haku-ci fetches a
+# haku-owned repo rather than the agentydragon-owned one. It pull-mirrors directly from the public
+# ducktape GitHub (the upstream source of truth): a public source needs no auth_token, and Forgejo
+# already has egress to github.com (the agentydragon mirror pulls from there too). Single-hop, and
+# decoupled from agentydragon's Forgejo mirror. `mirror`/`clone_addr` are ForceNew: changing the
+# source recreates the repo.
 resource "forgejo_repository" "ducktape_mirror" {
   owner           = forgejo_user.haku.login
   name            = "ducktape"
-  description     = "Haku-owned in-cluster mirror of ducktape, for haku-ci Bazel builds (git_override)."
+  description     = "Haku-owned mirror of ducktape (from public GitHub), for haku-ci Bazel builds (git_override)."
   private         = true
   mirror          = true
   service         = "git"
-  clone_addr      = "http://${forgejo_user.haku.login}:${random_password.haku.result}@forgejo-http.forgejo:3000/agentydragon/ducktape.git"
+  clone_addr      = "https://github.com/agentydragon/ducktape.git"
   mirror_interval = "0h10m0s"
 }
 

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -7,6 +7,11 @@
 # `claude` agent account. A Kubernetes Secret in the `haku-sandbox` namespace
 # carries the git credentials, consumed by in-cluster scan runs. Mirrors
 # tf/gitops/augur-evidence. The repo starts empty (auto_init only) — no seed.
+#
+# It also owns a haku-owned in-cluster mirror `haku/ducktape` (a Forgejo pull-mirror)
+# so haku-ci's Bazel build can fetch ducktape source as a bzlmod git_override without
+# depending on the agentydragon-owned mirror — see the `ducktape_mirror` resource below.
+# Both live here because they only need haku's account (already provisioned here).
 
 data "kubernetes_secret" "forgejo_admin" {
   metadata {
@@ -195,6 +200,50 @@ resource "forgejo_repository_action_secret" "registry_push" {
 # rewrite again.
 resource "terraform_data" "registry_push_secret_refresh" {
   triggers_replace = ["2026-07-06-haku-registry-push-token-resync"]
+}
+
+# ── Ducktape source mirror for haku-ci's Bazel builds ────────────────────────────────
+# Haku's UI Bazel build consumes ducktape's shared @haku/console-bridge package as a bzlmod
+# `git_override` (haku-state MODULE.bazel). Rather than have haku-ci fetch the agentydragon-owned
+# mirror directly, keep the dependency haku-owned and in-cluster: a private pull-mirror in haku's
+# own namespace. It syncs from the in-cluster `agentydragon/ducktape` (itself a github→forgejo
+# mirror); haku already has read on that repo (granted in tf/gitops/forgejo-agentydragon-repos),
+# so haku's basic-auth embedded in clone_addr is sufficient — no GitHub token and no external
+# egress. `mirror`/`clone_addr` are ForceNew: changing the source recreates the repo.
+resource "forgejo_repository" "ducktape_mirror" {
+  owner           = forgejo_user.haku.login
+  name            = "ducktape"
+  description     = "Haku-owned in-cluster mirror of ducktape, for haku-ci Bazel builds (git_override)."
+  private         = true
+  mirror          = true
+  service         = "git"
+  clone_addr      = "http://${forgejo_user.haku.login}:${random_password.haku.result}@forgejo-http.forgejo:3000/agentydragon/ducktape.git"
+  mirror_interval = "0h10m0s"
+}
+
+# Read git credential for the haku-ci runner to fetch the ducktape mirror as a Bazel
+# git_override. Delivered as an Actions secret the bazel-ci workflow reads
+# (`${{ secrets.DUCKTAPE_MIRROR_READ_TOKEN }}`) and writes into git's credential store before the
+# bazel gate. It is haku's own credential (haku owns the mirror) — same rationale and read-back
+# caveat as REGISTRY_PUSH_TOKEN above, kept as a distinct secret so git-clone auth stays decoupled
+# from the registry push token.
+resource "forgejo_repository_action_secret" "ducktape_mirror_read" {
+  repository_id = forgejo_repository.state.id
+  name          = "DUCKTAPE_MIRROR_READ_TOKEN"
+  data          = random_password.haku.result
+
+  lifecycle {
+    replace_triggered_by = [
+      random_password.haku,
+      terraform_data.ducktape_mirror_secret_refresh,
+    ]
+  }
+}
+
+# Same read-back caveat as registry_push_secret_refresh: force one declarative rewrite so the
+# opaque Actions-secret value can't silently drift. Bump the marker to force a re-push later.
+resource "terraform_data" "ducktape_mirror_secret_refresh" {
+  triggers_replace = ["2026-07-11-haku-ducktape-mirror-token-init"]
 }
 
 # Registration token for the contained Forgejo Actions runner (cluster/k8s/haku-ci),


### PR DESCRIPTION
## What & why

The haku-state repo now consumes ducktape's shared `@haku/console-bridge` package (merged in #3006) as a bzlmod `git_override`. For that to work, the in-cluster **haku-ci Bazel runner must fetch ducktape source** — but `agentydragon/ducktape` is private and the runner has no git credential for it (its `git_override` fetch 401s).

Rather than wire cross-org auth to the agentydragon-owned mirror, give haku its **own** private mirror. This adds it to the existing `tf/gitops/haku-state` module (it only needs haku's account, already provisioned there — no new module or Flux wiring):

- **`forgejo_repository.ducktape_mirror`** — a private, haku-owned Forgejo pull-mirror `haku/ducktape` that pull-mirrors directly from the **public ducktape GitHub upstream**. A public source needs no `auth_token`; it's a single-hop mirror, decoupled from agentydragon's Forgejo mirror. Forgejo already has egress to github.com.
- **`forgejo_repository_action_secret.ducktape_mirror_read`** — `DUCKTAPE_MIRROR_READ_TOKEN` (haku's credential) on the haku-state repo. The haku-state `bazel-ci.yaml` workflow writes it into git's credential store before the bazel gate, so Bazel's `git_override` `git fetch` of the private `haku/ducktape` authenticates. Distinct from `REGISTRY_PUSH_TOKEN`, with the same read-back refresh-marker caveat.

## Verification

- `//tf/gitops/haku-state:validate` ✅ (caught + fixed a `mirror_interval` format issue against the real `svalabs/forgejo` provider schema), plus `:lint` / `:format` ✅.
- Pre-commit clean (`checkov`, `tflint`).

## Follow-up (haku-state)

Once Flux applies this and Forgejo's mirror syncs `cbf13ed9`: haku-state's `bazel-ci.yaml` gets the git-credential step and its `git_override` remote flips to `http://forgejo-http.forgejo:3000/haku/ducktape.git` (in the haku-state adoption PR).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GThTaBE4CFc5viUtT8WEXe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GThTaBE4CFc5viUtT8WEXe