### PR TITLE
haku-egress: allow api.coinbase.com for the Coinbase read-only source

### DIFF
--- a/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
@@ -51,6 +51,12 @@ spec:
         # Haku mailbox read API (bearer-gated, read-only; see haku/mailbox/README.md)
         # so sandbox pods can poll inbound operator mail.
         - matchName: haku-mailbox.allegedly.works
+        # Coinbase read-only source: Haku reads the operator's crypto balances
+        # (CDP Advanced Trade get_accounts) from a haku-sandbox pod — Plaid does
+        # not support Coinbase as a readable institution. Reuses the reflected
+        # read-only `coinbase-api-credentials` (cluster-sops-read) CDP key and
+        # marks ETH/BTC to USD via the public /v2/prices endpoint. Same host for both.
+        - matchName: api.coinbase.com
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Why

Haku can't see the operator's Coinbase balance — the last balance missing from net-worth /
the allocation review. **Plaid can't close it:** Plaid never added Coinbase as a *readable*
institution (only Binance.US / Kraken / Gemini / Blockchain.com / BitGo), and the operator's
Plaid Link dialog confirms "Coinbase isn't supported yet." Every "Coinbase + Plaid" integration
is the *reverse* direction (Coinbase using Plaid to link customers' banks).

So Haku reads Coinbase directly — the same shape as Plaid Postgres ("just a query from a
`haku-sandbox` pod"), **reusing the existing read-only CDP key** already in the cluster
(`coinbase-api-credentials`, nicknamed `cluster-sops-read`, in `openclaw-sandbox`) rather than
minting a new one. The read is CDP Advanced Trade `get_accounts` + the public `/v2/prices/*/spot`
to mark ETH/BTC to USD — all against `api.coinbase.com`.

Because that read runs from a `haku-sandbox` pod, it egresses through `haku-egress-proxy`, whose
FQDN allowlist must include `api.coinbase.com`.

## What this PR does

Adds `api.coinbase.com` to the `haku-egress-proxy` Cilium FQDN allowlist
(`cnp-haku-cloud-api-egress.yaml`). Additive, read-only endpoint. Nothing else.

## Remaining steps (not in this PR)

- **Operator (decrypt-gated, mine isn't):** confirm the `cluster-sops-read` CDP key is
  **View-only** in the CDP portal (else mint a fresh View-only key — it'll sit in the agent
  sandbox, so the key's own scope is the fence), and **reflect the secret into `haku-sandbox`**
  via the emberstack annotations, the same way `plaid-mcp-db-readonly` reflects to
  `augur,haku-sandbox` (pattern reference: `k8s/wayback-cache/token.sops.yaml`). The Coinbase
  secret isn't encrypted to the `haku` age recipient and I can't recover the key material, so I
  can't author that edit.
- **Haku (follow-up):** once the key reflects and this egress merges, verify the `get_accounts`
  read end-to-end from a pod, then add the durable source doc `haku/base/sources/coinbase.md`
  and a credential-table row in `haku/base/instructions.md` (so base documents a *tested* recipe),
  and reconcile the balance into the allocation review.

Full design + who-does-what lives in Haku's state (`plans/coinbase-readonly-reader.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHaayKCuSg3p8hWcC8mQbH

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHaayKCuSg3p8hWcC8mQbH)_