### PR TITLE
haku/console: MCP accounts to a /settings page, location sharing to a pin popover

### DIFF
--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -130,9 +130,12 @@ schema-validates, and decides/confirms before acting. It also mirrors the iframe
 (`routeChanged`, validated as a path) into the console's own URL fragment so refresh and deep
 links restore the view. A persistent hamburger button — badged with a callout light when a
 tool call is awaiting approval — opens the shell's own console panel (`console_panel.tsx`),
-trusted chrome hosting shell-owned controls like the approval queue, the past-tool-calls
-link, the location-sharing stop/withdraw, and MCP account connect/reconnect/disconnect
-controls. See <docs/containment.md>.
+trusted chrome hosting the approval queue plus nav links to the full-page past-tool-calls
+history and settings views. Two shell-owned controls live outside the drawer: the
+location-sharing pin sits directly under the hamburger (shown only while consent is held,
+with a live indicator when location is actively read, and a popover carrying the
+stop/withdraw kill switch), and MCP account connect/reconnect/disconnect moved to the
+full-page settings view (`/settings`) since it's rarely touched. See <docs/containment.md>.
 
 ## Past tool calls — full-page history
 

--- a/haku/console/frontend/AGENTS.md
+++ b/haku/console/frontend/AGENTS.md
@@ -12,8 +12,8 @@ bbr test //haku/console/frontend:screenshots
 ```
 
 It renders each surface (`screenshots/harness.tsx`) to a PNG (one per scene: `history`,
-`drawer`, `drawer-access`) in the test's **undeclared outputs**. Browser rendering runs on
-the RBE worker, so this is a `bbr` test, not a local `bb run`. Fetch the PNGs with the
+`drawer`, `settings`, `controls`) in the test's **undeclared outputs**. Browser rendering
+runs on the RBE worker, so this is a `bbr` test, not a local `bb run`. Fetch the PNGs with the
 `buildbuddy_api` skill (download the target's undeclared test outputs), then open every one
 and actually check it looks good — spacing, alignment, contrast, truncation, that nothing
 overflows or collides, and that both content and chrome read clearly — not merely that it

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -90,6 +90,11 @@ js_library(
 )
 
 js_library(
+    name = "open_external",
+    srcs = ["open_external.ts"],
+)
+
+js_library(
     name = "routing",
     srcs = ["routing.ts"],
     deps = ["//:node_modules/react"],
@@ -175,6 +180,20 @@ js_library(
 )
 
 js_library(
+    name = "settings_page",
+    srcs = ["settings_page.tsx"],
+    deps = [
+        ":approval_state",
+        ":client",
+        ":icons",
+        ":open_external",
+        ":toast",
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+    ],
+)
+
+js_library(
     name = "haku_ui_embed",
     srcs = ["haku_ui_embed.tsx"],
     deps = [
@@ -185,6 +204,7 @@ js_library(
         ":console_panel",
         ":geolocation",
         ":geolocation_grant",
+        ":open_external",
         ":toast",
         ":tool_call_events",
         "//:node_modules/@haku/console-bridge",
@@ -200,6 +220,7 @@ js_library(
         ":client",
         ":haku_ui_embed",
         ":routing",
+        ":settings_page",
         ":tool_calls_page",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
@@ -236,7 +257,9 @@ filegroup(
         "icons.tsx",
         "index.html",
         "main.tsx",
+        "open_external.ts",
         "routing.ts",
+        "settings_page.tsx",
         "theme.ts",
         "toast.ts",
         "tool_arguments_field.tsx",
@@ -315,6 +338,7 @@ js_library(
         ":approval_state",
         ":client",
         ":console_panel",
+        ":settings_page",
         ":theme",
         ":tool_calls_page",
         "//:node_modules/@mantine/core",
@@ -388,6 +412,7 @@ tsc_bin.tsc_test(
         "bridge_client.test.ts",
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
+        "open_external.test.ts",
         "routing.test.ts",
         # Ambient types for the @tabler/icons-react per-icon subpath imports (icons.tsx).
         "tabler_icons.d.ts",
@@ -413,12 +438,14 @@ vitest_bin.vitest_test(
         "bridge_client.test.ts",
         "geolocation.test.ts",
         "haku_ui_embed.test.ts",
+        "open_external.test.ts",
         "routing.test.ts",
         "vitest.config.ts",
         ":approval_state",
         ":bridge",
         ":geolocation",
         ":haku_ui_embed",
+        ":open_external",
         ":routing",
         "//:node_modules",
         "//:node_modules/@haku/console-bridge",

--- a/haku/console/frontend/README.md
+++ b/haku/console/frontend/README.md
@@ -8,17 +8,24 @@ components + **Tailwind v4** utilities — modeled on
 `finance/augur/frontend` (references root `//:node_modules/*`; no per-package
 `package.json`).
 
-- `main.tsx` (wraps the app in `MantineProvider`) → `app.tsx` (routes between the two
-  console views) → either `haku_ui_embed.tsx` (the full-page framed haku-ui plus shell
-  chrome: approval drawer, bridge, confirms) or `tool_calls_page.tsx` (the full-page
-  past-tool-calls history).
-- `routing.ts` — the console's tiny pathname router. Two views keyed on URL **path**
-  (`/` embed, `/tool-calls` history) so console navigation never collides with the hash,
-  which is reserved for mirroring the framed haku-ui route.
+- `main.tsx` (wraps the app in `MantineProvider`) → `app.tsx` (routes between the console
+  views) → `haku_ui_embed.tsx` (the full-page framed haku-ui plus shell chrome: approval
+  drawer, bridge, confirms), `tool_calls_page.tsx` (the full-page past-tool-calls history),
+  or `settings_page.tsx` (the full-page operator settings — MCP account linkage).
+- `routing.ts` — the console's tiny pathname router. Three views keyed on URL **path**
+  (`/` embed, `/tool-calls` history, `/settings` settings) so console navigation never
+  collides with the hash, which is reserved for mirroring the framed haku-ui route.
 - `console_panel.tsx` — the shell drawer (`ShellDrawer`) and its persistent toggle
-  (`ShellControls`): a hamburger icon badged with a pending-approval callout light. Hosts
-  the approval queue, the past-tool-calls link, and the Access tab (location + MCP
-  accounts).
+  (`ShellControls`): a hamburger icon badged with a pending-approval callout light, with a
+  location-sharing pin below it (shown only while the standing grant is held; a live
+  indicator dot marks an active read, and its popover carries the stop/withdraw kill
+  switch). The drawer hosts the approval queue plus nav links to the past-tool-calls and
+  settings pages.
+- `settings_page.tsx` — the full-page operator settings view (`/settings`): MCP operator
+  account connect/reconnect/disconnect, moved out of the drawer since it's rarely touched.
+- `open_external.ts` — `openExternal(url)`: opens a link in a new tab with the opener
+  severed, shared by the embed shell (the `openLink` bridge action) and the settings page
+  (the MCP OAuth popup).
 - `tool_arguments_field.tsx` / `icons.tsx` — shared tool-argument renderer (per-server
   preview or raw JSON) and inline-SVG icons (never the `@tabler` barrel — see
   `debug/esbuild_tabler_memory.md`), used by both the drawer and the history view.

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { type ConfigResponse, fetchConfig } from "./client.ts";
 import { HakuUiEmbed } from "./haku_ui_embed.tsx";
 import { useConsoleView } from "./routing.ts";
+import { SettingsPage } from "./settings_page.tsx";
 import { ToolCallsPage } from "./tool_calls_page.tsx";
 
 // The console is now just the trusted outer shell: a full-page frame for Haku's own UI
@@ -31,9 +32,10 @@ export default function App() {
     };
   }, []);
 
-  // The history view is a self-contained console page that reads its own API and needs no
-  // shell config, so it renders regardless of the config load (and even if it failed).
+  // The history and settings views are self-contained console pages that read their own API
+  // and need no shell config, so they render regardless of the config load (even if it failed).
   if (view === "toolCalls") return <ToolCallsPage onBack={() => navigate("embed")} />;
+  if (view === "settings") return <SettingsPage onBack={() => navigate("embed")} />;
 
   // The initial config load is the one thing rendered by the shell itself; a failure
   // leaves nothing to frame, so it gets a persistent page-level message.
@@ -57,6 +59,7 @@ export default function App() {
       uiUrl={config.haku_ui_url}
       launchAvailable={config.launch_routine_url != null}
       onOpenToolCalls={() => navigate("toolCalls")}
+      onOpenSettings={() => navigate("settings")}
     />
   );
 }

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Badge, Button, Group, Indicator, SegmentedControl, Stack, Text, Textarea } from "@mantine/core";
+import { ActionIcon, Badge, Button, Group, Indicator, Popover, Stack, Text, Textarea } from "@mantine/core";
 import type { KeyboardEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 
@@ -14,18 +14,14 @@ import {
   type RecentToolCall,
   terminalStatusLabel,
 } from "./approval_state.ts";
-import type { McpOperatorAuthStatus, PendingApproval } from "./client.ts";
+import type { PendingApproval } from "./client.ts";
 import { Field } from "./field.tsx";
-import { HistoryIcon, MenuIcon } from "./icons.tsx";
+import { HistoryIcon, MapPinIcon, MenuIcon, SettingsIcon } from "./icons.tsx";
 import { ACTION_COLOR } from "./theme.ts";
 import { ToolArgumentsField } from "./tool_arguments_field.tsx";
 
-export type ShellDrawerTab = "approvals" | "access";
-
 export interface ShellDrawerProps {
   opened: boolean;
-  activeTab: ShellDrawerTab;
-  onOpenTab: (tab: ShellDrawerTab) => void;
   onClose: () => void;
   pendingApprovals: PendingApproval[];
   geolocationApprovals: GeolocationApproval[];
@@ -41,19 +37,18 @@ export interface ShellDrawerProps {
   onDenyGeolocation: (approval: GeolocationApproval) => void;
   onDismissRecentToolCall: (toolCallId: string) => void;
   onOpenToolCalls: () => void;
-  geoGranted: boolean;
-  tracking: boolean;
-  onWithdrawGeolocation: () => void;
-  mcpAuthStatuses: McpOperatorAuthStatus[];
-  onConnectMcp: (serverId: string) => void;
-  onDisconnectMcp: (serverId: string) => void;
-  onRefreshMcp: () => void;
+  onOpenSettings: () => void;
 }
 
 export interface ShellControlsProps {
   pendingCount: number;
   opened: boolean;
   onToggle: () => void;
+  // Location-sharing control (rendered only when the standing grant is held): the map-pin
+  // popover under the hamburger, with a live indicator while a watch is actively reading.
+  geoGranted: boolean;
+  tracking: boolean;
+  onWithdrawGeolocation: () => void;
 }
 
 // zIndex maxed so shell chrome sits above the full-page iframe; controls are one below.
@@ -94,12 +89,75 @@ function RecentCountdown({ recent, nowMs }: { recent: RecentToolCall; nowMs: num
   );
 }
 
-// The one persistent piece of shell chrome over the framed haku-ui: a generic panel
-// toggle. The count of pending approvals surfaces as a pulsing red callout on the icon —
-// a "something needs you" light — without spelling the drawer's contents onto the button.
-export function ShellControls({ pendingCount, opened, onToggle }: ShellControlsProps) {
+// The location-sharing control: a map-pin under the hamburger, shown only while the shell
+// holds the standing grant. A pulsing teal indicator dot marks that a watch is *actively*
+// reading location right now (`tracking`); the plain pin means sharing is merely allowed.
+// Its popover carries the state and the stop/withdraw kill switch (out of the drawer, since
+// it's a rare one-tap action best reachable straight from the chrome).
+function LocationControl({ tracking, onWithdraw }: { tracking: boolean; onWithdraw: () => void }) {
+  const [opened, setOpened] = useState(false);
   return (
-    <Group className="haku-shell-controls" gap="xs" style={{ zIndex: PANEL_Z - 1 }}>
+    <Popover opened={opened} onChange={setOpened} position="left" withArrow shadow="md" width={248}>
+      <Popover.Target>
+        <Indicator color="teal" size={10} offset={4} processing disabled={!tracking} withBorder>
+          <ActionIcon
+            size="lg"
+            variant="default"
+            color={ACTION_COLOR}
+            onClick={() => setOpened((o) => !o)}
+            aria-label={tracking ? "Location sharing: live" : "Location sharing: allowed"}
+          >
+            <MapPinIcon />
+          </ActionIcon>
+        </Indicator>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <Stack gap="xs">
+          <Group justify="space-between" align="center" wrap="nowrap">
+            <Text fw={600} size="sm">
+              Location sharing
+            </Text>
+            <Badge color={tracking ? "teal" : "blue"} variant="light">
+              {tracking ? "Live" : "Allowed"}
+            </Badge>
+          </Group>
+          <Text size="xs" c="dimmed">
+            {tracking
+              ? "Haku's UI is reading your location right now."
+              : "Haku's UI may read your location until you withdraw consent."}
+          </Text>
+          <Button
+            size="compact-sm"
+            variant="light"
+            color="red"
+            fullWidth
+            onClick={() => {
+              onWithdraw();
+              setOpened(false);
+            }}
+          >
+            {tracking ? "Stop & withdraw" : "Withdraw"}
+          </Button>
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
+
+// The persistent shell chrome over the framed haku-ui, stacked top-right: a generic panel
+// toggle (its pending-approval count surfaces as a pulsing red callout — a "something needs
+// you" light, without spelling the drawer's contents onto the button) and, when location is
+// shared, the location-sharing pin below it.
+export function ShellControls({
+  pendingCount,
+  opened,
+  onToggle,
+  geoGranted,
+  tracking,
+  onWithdrawGeolocation,
+}: ShellControlsProps) {
+  return (
+    <Stack className="haku-shell-controls" gap="xs" align="flex-end" style={{ zIndex: PANEL_Z - 1 }}>
       <Indicator
         color="red"
         size={16}
@@ -118,7 +176,8 @@ export function ShellControls({ pendingCount, opened, onToggle }: ShellControlsP
           <MenuIcon />
         </ActionIcon>
       </Indicator>
-    </Group>
+      {geoGranted && <LocationControl tracking={tracking} onWithdraw={onWithdrawGeolocation} />}
+    </Stack>
   );
 }
 
@@ -662,157 +721,47 @@ function ApprovalsTab({
   );
 }
 
-function AccessTab({
-  geoGranted,
-  tracking,
-  onWithdrawGeolocation,
-  mcpAuthStatuses,
-  onConnectMcp,
-  onDisconnectMcp,
-  onRefreshMcp,
-}: Pick<
-  ShellDrawerProps,
-  | "geoGranted"
-  | "tracking"
-  | "onWithdrawGeolocation"
-  | "mcpAuthStatuses"
-  | "onConnectMcp"
-  | "onDisconnectMcp"
-  | "onRefreshMcp"
->) {
-  return (
-    <Stack gap="md">
-      <section className="haku-shell-card">
-        <Group justify="space-between" align="center" gap="sm" wrap="nowrap">
-          <Text fw={600} size="sm">
-            Location sharing
-          </Text>
-          <Group gap="xs" justify="flex-end" wrap="nowrap">
-            <Badge color={tracking ? "teal" : geoGranted ? "blue" : "gray"} variant="light">
-              {tracking ? "Live" : geoGranted ? "Allowed" : "Off"}
-            </Badge>
-            {geoGranted && (
-              <Button size="compact-xs" variant="light" color="red" onClick={onWithdrawGeolocation}>
-                {tracking ? "Stop & withdraw" : "Withdraw"}
-              </Button>
-            )}
-          </Group>
-        </Group>
-      </section>
-      <section className="haku-shell-card">
-        <Group justify="space-between" align="center">
-          <Text fw={600} size="sm">
-            MCP accounts
-          </Text>
-          <Button size="compact-xs" variant="subtle" onClick={onRefreshMcp}>
-            Refresh
-          </Button>
-        </Group>
-        <Stack gap="sm" mt="sm">
-          {mcpAuthStatuses.length === 0 ? (
-            <Text size="sm" c="dimmed">
-              No operator-linked MCP servers are configured.
-            </Text>
-          ) : (
-            mcpAuthStatuses.map((status) => (
-              <div key={status.server_id} className="haku-shell-subcard">
-                <Group justify="space-between" align="flex-start" gap="xs">
-                  <Stack gap={2}>
-                    <Text size="sm" fw={500}>
-                      {status.server_id}
-                    </Text>
-                    <Text size="xs" c="dimmed">
-                      {status.status === "connected"
-                        ? `Linked for ${status.operator_principal}${
-                            shortDate(status.token_expires_at) ? ` until ${shortDate(status.token_expires_at)}` : ""
-                          }`
-                        : `Not linked for ${status.operator_principal}`}
-                    </Text>
-                  </Stack>
-                  <Badge color={status.status === "connected" ? "teal" : "gray"} variant="light">
-                    {status.status === "connected" ? "Connected" : "Unconnected"}
-                  </Badge>
-                </Group>
-                <Group justify="flex-end" gap="xs" mt="xs">
-                  {status.status === "connected" ? (
-                    <>
-                      <Button size="compact-xs" variant="light" onClick={() => onConnectMcp(status.server_id)}>
-                        Reconnect
-                      </Button>
-                      <Button
-                        size="compact-xs"
-                        variant="subtle"
-                        color="red"
-                        onClick={() => onDisconnectMcp(status.server_id)}
-                      >
-                        Disconnect
-                      </Button>
-                    </>
-                  ) : (
-                    <Button size="compact-xs" variant="light" onClick={() => onConnectMcp(status.server_id)}>
-                      Connect
-                    </Button>
-                  )}
-                </Group>
-              </div>
-            ))
-          )}
-        </Stack>
-      </section>
-    </Stack>
-  );
-}
-
 export function ShellDrawer(props: ShellDrawerProps) {
+  const pendingCount = props.pendingApprovals.length + props.geolocationApprovals.length;
   return (
     <div className="haku-shell-overlay" style={{ zIndex: PANEL_Z }} aria-hidden={!props.opened}>
       {props.opened && (
         <aside className="haku-shell-drawer" aria-label="Haku console controls">
           <section className="haku-shell-card haku-shell-drawer-nav">
             <Group justify="space-between" align="center" className="haku-shell-header">
-              <Text fw={700}>Haku console</Text>
+              <Group gap="xs" align="center">
+                <Text fw={700}>Approvals</Text>
+                <Badge color={pendingCount > 0 ? "yellow" : "gray"} variant="light">
+                  {pendingCount}
+                </Badge>
+              </Group>
               <Button size="compact-xs" variant="subtle" onClick={props.onClose}>
                 Close
               </Button>
             </Group>
-            <SegmentedControl
-              fullWidth
-              size="xs"
-              value={props.activeTab}
-              onChange={(value) => props.onOpenTab(value as ShellDrawerTab)}
-              data={[
-                {
-                  value: "approvals",
-                  label: `Approvals (${props.pendingApprovals.length + props.geolocationApprovals.length})`,
-                },
-                { value: "access", label: "Access" },
-              ]}
-            />
-            <Button
-              size="xs"
-              variant="light"
-              color={ACTION_COLOR}
-              fullWidth
-              leftSection={<HistoryIcon />}
-              onClick={props.onOpenToolCalls}
-            >
-              Past tool calls
-            </Button>
+            <Group grow gap="xs">
+              <Button
+                size="xs"
+                variant="light"
+                color={ACTION_COLOR}
+                leftSection={<HistoryIcon />}
+                onClick={props.onOpenToolCalls}
+              >
+                Past tool calls
+              </Button>
+              <Button
+                size="xs"
+                variant="light"
+                color={ACTION_COLOR}
+                leftSection={<SettingsIcon />}
+                onClick={props.onOpenSettings}
+              >
+                Settings
+              </Button>
+            </Group>
           </section>
           <div className="haku-shell-scroll">
-            {props.activeTab === "approvals" ? (
-              <ApprovalsTab {...props} />
-            ) : (
-              <AccessTab
-                geoGranted={props.geoGranted}
-                tracking={props.tracking}
-                onWithdrawGeolocation={props.onWithdrawGeolocation}
-                mcpAuthStatuses={props.mcpAuthStatuses}
-                onConnectMcp={props.onConnectMcp}
-                onDisconnectMcp={props.onDisconnectMcp}
-                onRefreshMcp={props.onRefreshMcp}
-              />
-            )}
+            <ApprovalsTab {...props} />
           </div>
         </aside>
       )}

--- a/haku/console/frontend/haku_ui_embed.test.ts
+++ b/haku/console/frontend/haku_ui_embed.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { hasGeolocationGrant, setGeolocationGrant } from "./geolocation_grant.ts";
-import { initialFrameSrc, openExternal } from "./haku_ui_embed.tsx";
+import { initialFrameSrc } from "./haku_ui_embed.tsx";
 
 describe("initialFrameSrc", () => {
   it("pins the origin and carries only the console hash into the frame's fragment", () => {
@@ -22,39 +22,6 @@ describe("initialFrameSrc", () => {
     expect(initialFrameSrc("https://haku-ui.allegedly.works/", "#//evil.example/x")).toBe(
       "https://haku-ui.allegedly.works/"
     );
-  });
-});
-
-describe("openExternal", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("uses the blank-tab handle as the HTTPS popup signal, then severs opener before navigation", () => {
-    const opened = { opener: window, location: { replace: vi.fn() } };
-    vi.spyOn(window, "open").mockReturnValue(opened as unknown as Window);
-
-    expect(openExternal("https://example.com/path")).toBe(true);
-
-    expect(window.open).toHaveBeenCalledWith("about:blank", "_blank");
-    expect(opened.opener).toBeNull();
-    expect(opened.location.replace).toHaveBeenCalledWith("https://example.com/path");
-  });
-
-  it("reports blocked HTTPS tabs when the blank tab returns no handle", () => {
-    vi.spyOn(window, "open").mockReturnValue(null);
-
-    expect(openExternal("https://example.com/path")).toBe(false);
-  });
-
-  it("opens mailto directly without leaving an about:blank tab", () => {
-    const opened = { opener: window };
-    vi.spyOn(window, "open").mockReturnValue(opened as unknown as Window);
-
-    expect(openExternal("mailto:ops@allegedly.works")).toBe(true);
-
-    expect(window.open).toHaveBeenCalledWith("mailto:ops@allegedly.works", "_blank");
-    expect(opened.opener).toBeNull();
   });
 });
 

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -15,19 +15,16 @@ import { isRoutePath, parseInbound, vetOpenLink } from "./bridge.ts";
 import {
   approveToolCall,
   denyToolCall,
-  disconnectMcpOperatorAuth,
-  fetchMcpOperatorAuthStatuses,
   fetchPendingApprovals,
   launchRoutine,
-  type McpOperatorAuthStatus,
   type PendingApproval,
   type ToolCallRecord,
-  startMcpOperatorAuth,
 } from "./client.ts";
 import { ConfirmDialog, type Escalation } from "./confirm_dialog.tsx";
-import { ShellControls, ShellDrawer, type ShellDrawerTab } from "./console_panel.tsx";
+import { ShellControls, ShellDrawer } from "./console_panel.tsx";
 import { GEO_PERMISSION_DENIED, GeolocationWatcher, getGeolocation } from "./geolocation.ts";
 import { hasGeolocationGrant, setGeolocationGrant } from "./geolocation_grant.ts";
+import { openExternal, POPUP_HINT } from "./open_external.ts";
 import { toastError, toastSuccess } from "./toast.ts";
 import { useToolCallEvents } from "./tool_call_events.ts";
 
@@ -41,21 +38,6 @@ import { useToolCallEvents } from "./tool_call_events.ts";
 // Authentik auth; **no `allow-popups`** (only the shell opens links), **no
 // `allow="fullscreen"`**, and **no `allow="geolocation"`** (only the shell reads location,
 // per its own consent grant; it holds every location watch). See docs/containment.md.
-
-// `noopener`/`noreferrer` force window.open() to return null even when the tab
-// opened, so open a same-origin blank tab first. The handle is the only reliable
-// popup-block signal; once it exists, sever opener before navigating it.
-export function openExternal(url: string): boolean {
-  const parsed = new URL(url);
-  const opened = window.open(parsed.protocol === "mailto:" ? url : "about:blank", "_blank");
-  if (!opened) return false;
-  opened.opener = null;
-  if (parsed.protocol !== "mailto:") opened.location.replace(url);
-  return true;
-}
-
-const POPUP_HINT = "Allow pop-ups for this site so the console can open links.";
-const MCP_AUTH_CHANNEL = "haku-console-mcp-auth";
 
 // Restore the route the console URL carries into the frame on first mount. The console
 // hash is treated strictly as a validated path, never a URL: the src is always `uiUrl`
@@ -74,10 +56,12 @@ export function HakuUiEmbed({
   uiUrl,
   launchAvailable,
   onOpenToolCalls,
+  onOpenSettings,
 }: {
   uiUrl: string;
   launchAvailable: boolean;
   onOpenToolCalls: () => void;
+  onOpenSettings: () => void;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   // The single escalation awaiting the operator's trusted confirm (a link to open or a run
@@ -88,9 +72,7 @@ export function HakuUiEmbed({
   const knownToolApprovalIdsRef = useRef<Set<string> | null>(null);
   const [geolocationApprovals, setGeolocationApprovals] = useState<GeolocationApproval[]>([]);
   const geolocationApprovalsRef = useRef<GeolocationApproval[]>([]);
-  const [mcpAuthStatuses, setMcpAuthStatuses] = useState<McpOperatorAuthStatus[]>([]);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [drawerTab, setDrawerTab] = useState<ShellDrawerTab>("approvals");
   const [selectedApprovalId, setSelectedApprovalId] = useState<string | null>(null);
   const [selectedRecentToolCallId, setSelectedRecentToolCallId] = useState<string | null>(null);
   const [decidingApprovalIds, setDecidingApprovalIds] = useState<string[]>([]);
@@ -99,7 +81,6 @@ export function HakuUiEmbed({
   // reload the frame); the iframe navigates itself, the console only reflects.
   const [frameSrc] = useState(() => initialFrameSrc(uiUrl, window.location.hash));
   const origin = new URL(uiUrl).origin;
-  const mcpAuthChannelRef = useRef<BroadcastChannel | null>(null);
   const activeAction: Escalation | null = pending;
 
   function reply(msg: Outbound) {
@@ -165,15 +146,10 @@ export function HakuUiEmbed({
     setGeoGranted(false);
   }
 
-  function openDrawerTab(tab: ShellDrawerTab) {
-    setDrawerTab(tab);
-    setDrawerOpen(true);
-  }
-
   function openApprovalQueueCompact() {
     setSelectedApprovalId(null);
     setSelectedRecentToolCallId(null);
-    openDrawerTab("approvals");
+    setDrawerOpen(true);
   }
 
   function setDeciding(id: string, deciding: boolean) {
@@ -252,50 +228,8 @@ export function HakuUiEmbed({
   // (which the server also broadcasts to every other tab, so they refresh too).
   useToolCallEvents(refreshToolApprovals);
 
-  function refreshMcpAuthStatuses(notify = false) {
-    if (notify) mcpAuthChannelRef.current?.postMessage({ type: "mcpAuthChanged" });
-    void fetchMcpOperatorAuthStatuses().then(
-      (statuses) => setMcpAuthStatuses(statuses),
-      (e: unknown) => toastError("Couldn't load MCP account links", e)
-    );
-  }
-
-  function connectMcp(serverId: string) {
-    void startMcpOperatorAuth(serverId)
-      .then((started) => {
-        if (!openExternal(started.authorization_url)) {
-          toastError("Pop-up blocked", POPUP_HINT);
-          return;
-        }
-        toastSuccess("MCP account link started", "Finish the authorization in the new tab.");
-      })
-      .catch((e: unknown) => toastError("Couldn't start MCP account link", e));
-  }
-
-  function disconnectMcp(serverId: string) {
-    void disconnectMcpOperatorAuth(serverId).then(
-      () => {
-        toastSuccess("MCP account disconnected", serverId);
-        refreshMcpAuthStatuses(true);
-      },
-      (e: unknown) => toastError("Couldn't disconnect MCP account", e)
-    );
-  }
-
   // Tear down any live browser watches if the console unmounts.
   useEffect(() => () => void watcher.stopAll(), [watcher]);
-
-  useEffect(() => {
-    refreshMcpAuthStatuses();
-    if (!("BroadcastChannel" in window)) return;
-    const channel = new BroadcastChannel(MCP_AUTH_CHANNEL);
-    mcpAuthChannelRef.current = channel;
-    channel.onmessage = () => refreshMcpAuthStatuses();
-    return () => {
-      if (mcpAuthChannelRef.current === channel) mcpAuthChannelRef.current = null;
-      channel.close();
-    };
-  }, []);
 
   useEffect(() => {
     function onMessage(e: MessageEvent) {
@@ -495,11 +429,12 @@ export function HakuUiEmbed({
         pendingCount={toolApprovals.length + geolocationApprovals.length}
         opened={drawerOpen}
         onToggle={() => setDrawerOpen((open) => !open)}
+        geoGranted={geoGranted}
+        tracking={tracking}
+        onWithdrawGeolocation={withdrawGeolocation}
       />
       <ShellDrawer
         opened={drawerOpen}
-        activeTab={drawerTab}
-        onOpenTab={openDrawerTab}
         onClose={() => setDrawerOpen(false)}
         pendingApprovals={toolApprovals}
         geolocationApprovals={geolocationApprovals}
@@ -510,12 +445,12 @@ export function HakuUiEmbed({
         onSelectApproval={(id) => {
           setSelectedApprovalId(id);
           setSelectedRecentToolCallId(null);
-          openDrawerTab("approvals");
+          setDrawerOpen(true);
         }}
         onSelectRecentToolCall={(toolCallId) => {
           setSelectedRecentToolCallId(toolCallId);
           setSelectedApprovalId(null);
-          openDrawerTab("approvals");
+          setDrawerOpen(true);
         }}
         onApproveTool={approveToolApproval}
         onDenyTool={denyToolApproval}
@@ -523,13 +458,7 @@ export function HakuUiEmbed({
         onDenyGeolocation={denyGeolocationApproval}
         onDismissRecentToolCall={dismissRecentToolCall}
         onOpenToolCalls={onOpenToolCalls}
-        geoGranted={geoGranted}
-        tracking={tracking}
-        onWithdrawGeolocation={withdrawGeolocation}
-        mcpAuthStatuses={mcpAuthStatuses}
-        onConnectMcp={connectMcp}
-        onDisconnectMcp={disconnectMcp}
-        onRefreshMcp={() => refreshMcpAuthStatuses(true)}
+        onOpenSettings={onOpenSettings}
       />
       <ConfirmDialog action={activeAction} onApprove={onApprove} onCancel={onCancel} />
     </>

--- a/haku/console/frontend/icons.tsx
+++ b/haku/console/frontend/icons.tsx
@@ -4,7 +4,9 @@
 // stable local name + a consistent glyph size; callers can still override via props.
 import IconArrowLeft from "@tabler/icons-react/dist/esm/icons/IconArrowLeft.mjs";
 import IconHistory from "@tabler/icons-react/dist/esm/icons/IconHistory.mjs";
+import IconMapPin from "@tabler/icons-react/dist/esm/icons/IconMapPin.mjs";
 import IconMenu2 from "@tabler/icons-react/dist/esm/icons/IconMenu2.mjs";
+import IconSettings from "@tabler/icons-react/dist/esm/icons/IconSettings.mjs";
 import type { ComponentProps } from "react";
 
 type TablerIconProps = ComponentProps<typeof IconMenu2>;
@@ -19,7 +21,17 @@ export function HistoryIcon(props: TablerIconProps) {
   return <IconHistory size={20} {...props} />;
 }
 
-/** Left arrow — the history view's back-to-embed control. */
+/** Left arrow — the full-page views' back-to-embed control. */
 export function ArrowLeftIcon(props: TablerIconProps) {
   return <IconArrowLeft size={20} {...props} />;
+}
+
+/** Gear — links to the settings view. */
+export function SettingsIcon(props: TablerIconProps) {
+  return <IconSettings size={20} {...props} />;
+}
+
+/** Map pin — the shell's location-sharing control. */
+export function MapPinIcon(props: TablerIconProps) {
+  return <IconMapPin size={20} {...props} />;
 }

--- a/haku/console/frontend/open_external.test.ts
+++ b/haku/console/frontend/open_external.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { openExternal } from "./open_external.ts";
+
+describe("openExternal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the blank-tab handle as the HTTPS popup signal, then severs opener before navigation", () => {
+    const opened = { opener: window, location: { replace: vi.fn() } };
+    vi.spyOn(window, "open").mockReturnValue(opened as unknown as Window);
+
+    expect(openExternal("https://example.com/path")).toBe(true);
+
+    expect(window.open).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(opened.opener).toBeNull();
+    expect(opened.location.replace).toHaveBeenCalledWith("https://example.com/path");
+  });
+
+  it("reports blocked HTTPS tabs when the blank tab returns no handle", () => {
+    vi.spyOn(window, "open").mockReturnValue(null);
+
+    expect(openExternal("https://example.com/path")).toBe(false);
+  });
+
+  it("opens mailto directly without leaving an about:blank tab", () => {
+    const opened = { opener: window };
+    vi.spyOn(window, "open").mockReturnValue(opened as unknown as Window);
+
+    expect(openExternal("mailto:ops@allegedly.works")).toBe(true);
+
+    expect(window.open).toHaveBeenCalledWith("mailto:ops@allegedly.works", "_blank");
+    expect(opened.opener).toBeNull();
+  });
+});

--- a/haku/console/frontend/open_external.ts
+++ b/haku/console/frontend/open_external.ts
@@ -1,0 +1,16 @@
+// Open an external link in a new tab with the opener severed. Shared by the embed shell
+// (openLink bridge action) and the settings page (MCP OAuth popup).
+//
+// `noopener`/`noreferrer` force window.open() to return null even when the tab opened, so
+// open a same-origin blank tab first. The handle is the only reliable popup-block signal;
+// once it exists, sever opener before navigating it.
+export function openExternal(url: string): boolean {
+  const parsed = new URL(url);
+  const opened = window.open(parsed.protocol === "mailto:" ? url : "about:blank", "_blank");
+  if (!opened) return false;
+  opened.opener = null;
+  if (parsed.protocol !== "mailto:") opened.location.replace(url);
+  return true;
+}
+
+export const POPUP_HINT = "Allow pop-ups for this site so the console can open links.";

--- a/haku/console/frontend/routing.test.ts
+++ b/haku/console/frontend/routing.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { HOME_PATH, TOOL_CALLS_PATH, viewForPathname } from "./routing.ts";
+import { HOME_PATH, SETTINGS_PATH, TOOL_CALLS_PATH, viewForPathname } from "./routing.ts";
 
 describe("viewForPathname", () => {
-  it("maps the tool-calls path to the history view and everything else to the embed", () => {
+  it("maps each console path to its view and everything else to the embed", () => {
     expect(viewForPathname(TOOL_CALLS_PATH)).toBe("toolCalls");
+    expect(viewForPathname(SETTINGS_PATH)).toBe("settings");
     expect(viewForPathname(HOME_PATH)).toBe("embed");
     // Any unknown path degrades to the embed shell, not a blank page.
     expect(viewForPathname("/something-else")).toBe("embed");
-    // Only the exact path matches — a nested path is not the history view.
+    // Only the exact path matches — a nested path is not the view.
     expect(viewForPathname(`${TOOL_CALLS_PATH}/extra`)).toBe("embed");
   });
 });

--- a/haku/console/frontend/routing.ts
+++ b/haku/console/frontend/routing.ts
@@ -1,27 +1,33 @@
 import { useCallback, useEffect, useState } from "react";
 
-// The console has two top-level views, distinguished by URL *path*. The path is used —
+// The console has three top-level views, distinguished by URL *path*. The path is used —
 // never the hash — because the hash is already reserved for mirroring the framed
 // haku-ui route (haku_ui_embed.tsx's routeChanged handler), so a path keeps the console's
 // own navigation from colliding with the frame's.
 //
 //   "/"            → the full-page haku-ui embed (the trusted shell)
 //   "/tool-calls"  → the console's own full-page history of every past MCP tool call
+//   "/settings"    → operator settings (MCP account linkage)
 //
 // Production's nginx serves index.html for any non-asset/API path (`try_files $uri
-// /index.html`), and the dev fallback mirrors that (app.py), so deep-linking either path
+// /index.html`), and the dev fallback mirrors that (app.py), so deep-linking any path
 // loads the SPA, which then renders the matching view from the pathname.
 export const TOOL_CALLS_PATH = "/tool-calls";
+export const SETTINGS_PATH = "/settings";
 export const HOME_PATH = "/";
 
-export type ConsoleView = "embed" | "toolCalls";
+export type ConsoleView = "embed" | "toolCalls" | "settings";
 
 export function viewForPathname(pathname: string): ConsoleView {
-  return pathname === TOOL_CALLS_PATH ? "toolCalls" : "embed";
+  if (pathname === TOOL_CALLS_PATH) return "toolCalls";
+  if (pathname === SETTINGS_PATH) return "settings";
+  return "embed";
 }
 
 function pathForView(view: ConsoleView): string {
-  return view === "toolCalls" ? TOOL_CALLS_PATH : HOME_PATH;
+  if (view === "toolCalls") return TOOL_CALLS_PATH;
+  if (view === "settings") return SETTINGS_PATH;
+  return HOME_PATH;
 }
 
 export function useConsoleView(): { view: ConsoleView; navigate: (view: ConsoleView) => void } {

--- a/haku/console/frontend/screenshots/harness.tsx
+++ b/haku/console/frontend/screenshots/harness.tsx
@@ -10,49 +10,54 @@ import "./mock_api.ts";
 import { MantineProvider } from "@mantine/core";
 import { createRoot } from "react-dom/client";
 
-import { ShellDrawer, type ShellDrawerProps, type ShellDrawerTab } from "../console_panel.tsx";
+import { ShellControls, ShellDrawer, type ShellDrawerProps } from "../console_panel.tsx";
+import { SettingsPage } from "../settings_page.tsx";
 import { hakuTheme } from "../theme.ts";
 import { ToolCallsPage } from "../tool_calls_page.tsx";
-import { SAMPLE_MCP, SAMPLE_PENDING, SAMPLE_RECENT } from "./sample_data.ts";
+import { SAMPLE_PENDING, SAMPLE_RECENT } from "./sample_data.ts";
 
 const noop = () => {};
 
-function drawerProps(activeTab: ShellDrawerTab): ShellDrawerProps {
-  return {
-    opened: true,
-    activeTab,
-    onOpenTab: noop,
-    onClose: noop,
-    pendingApprovals: SAMPLE_PENDING,
-    geolocationApprovals: [],
-    selectedApprovalId: null,
-    selectedRecentToolCallId: null,
-    decidingApprovalIds: [],
-    recentToolCalls: SAMPLE_RECENT,
-    onSelectApproval: noop,
-    onSelectRecentToolCall: noop,
-    onApproveTool: noop,
-    onDenyTool: noop,
-    onApproveGeolocation: noop,
-    onDenyGeolocation: noop,
-    onDismissRecentToolCall: noop,
-    onOpenToolCalls: noop,
-    geoGranted: true,
-    tracking: false,
-    onWithdrawGeolocation: noop,
-    mcpAuthStatuses: SAMPLE_MCP,
-    onConnectMcp: noop,
-    onDisconnectMcp: noop,
-    onRefreshMcp: noop,
-  };
-}
+const drawerProps: ShellDrawerProps = {
+  opened: true,
+  onClose: noop,
+  pendingApprovals: SAMPLE_PENDING,
+  geolocationApprovals: [],
+  selectedApprovalId: null,
+  selectedRecentToolCallId: null,
+  decidingApprovalIds: [],
+  recentToolCalls: SAMPLE_RECENT,
+  onSelectApproval: noop,
+  onSelectRecentToolCall: noop,
+  onApproveTool: noop,
+  onDenyTool: noop,
+  onApproveGeolocation: noop,
+  onDenyGeolocation: noop,
+  onDismissRecentToolCall: noop,
+  onOpenToolCalls: noop,
+  onOpenSettings: noop,
+};
 
 function sceneElement(scene: string) {
   switch (scene) {
-    case "drawer-access":
-      return <ShellDrawer {...drawerProps("access")} />;
+    case "settings":
+      // SettingsPage fetches /api/mcp/operator-auth on mount; mock_api.ts serves SAMPLE_MCP.
+      return <SettingsPage onBack={noop} />;
+    case "controls":
+      // The shell chrome stack: hamburger (with a pending callout) plus the location pin
+      // with its live indicator. render.mjs clicks the pin to open its popover.
+      return (
+        <ShellControls
+          pendingCount={1}
+          opened={false}
+          onToggle={noop}
+          geoGranted
+          tracking
+          onWithdrawGeolocation={noop}
+        />
+      );
     case "drawer":
-      return <ShellDrawer {...drawerProps("approvals")} />;
+      return <ShellDrawer {...drawerProps} />;
     default:
       return <ToolCallsPage onBack={noop} />;
   }

--- a/haku/console/frontend/screenshots/mock_api.ts
+++ b/haku/console/frontend/screenshots/mock_api.ts
@@ -3,7 +3,7 @@
 // module that captures `globalThis.fetch` (openapi-fetch does so when client.ts builds its
 // client) — harness.tsx imports this first. Paired with a `<base href>` in the harness page
 // (render.mjs) so the relative "/api/…" URL parses in the origin-less setContent page.
-import { SAMPLE_TOOL_CALLS } from "./sample_data.ts";
+import { SAMPLE_MCP, SAMPLE_TOOL_CALLS } from "./sample_data.ts";
 
 function requestUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") return input;
@@ -11,16 +11,17 @@ function requestUrl(input: RequestInfo | URL): string {
   return input.url;
 }
 
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
 const realFetch = globalThis.fetch;
 
 globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
   const url = requestUrl(input);
-  if (url.includes("/api/tool-calls")) {
-    return new Response(JSON.stringify({ tool_calls: SAMPLE_TOOL_CALLS }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
+  // Order matters: match the more specific /api/mcp/... path before /api/tool-calls.
+  if (url.includes("/api/mcp/operator-auth")) return jsonResponse({ associations: SAMPLE_MCP });
+  if (url.includes("/api/tool-calls")) return jsonResponse({ tool_calls: SAMPLE_TOOL_CALLS });
   if (realFetch) return realFetch(input, init);
-  return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+  return jsonResponse({});
 }) as typeof fetch;

--- a/haku/console/frontend/screenshots/render.mjs
+++ b/haku/console/frontend/screenshots/render.mjs
@@ -21,7 +21,10 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const SCENES = [
   { name: "history", viewport: { width: 1200, height: 1500 } },
   { name: "drawer", viewport: { width: 1200, height: 900 } },
-  { name: "drawer-access", viewport: { width: 1200, height: 900 } },
+  { name: "settings", viewport: { width: 1200, height: 900 } },
+  // `click` opens the location-sharing popover (its open state is internal to the control)
+  // so the screenshot captures the dropdown, not just the pin.
+  { name: "controls", viewport: { width: 520, height: 380 }, click: '[aria-label="Location sharing: live"]' },
 ];
 
 function outputDir() {
@@ -79,7 +82,7 @@ const browser = await launchPuppeteerBrowser({
   ],
 });
 try {
-  for (const { name, viewport } of SCENES) {
+  for (const { name, viewport, click } of SCENES) {
     const page = await browser.newPage();
     await page.setViewport({ ...viewport, deviceScaleFactor: 2 });
     await page.emulateMediaFeatures([{ name: "prefers-reduced-motion", value: "reduce" }]);
@@ -88,6 +91,12 @@ try {
     // Let Mantine mount and layout settle, and outlast the approval buttons' 400ms arm
     // delay so they render enabled (animations are reduced above).
     await new Promise((r) => setTimeout(r, 700));
+    // Some scenes need a click to reveal a popover whose open state is internal to the
+    // component (e.g. the location-sharing control); do it, then let the dropdown settle.
+    if (click) {
+      await page.click(click);
+      await new Promise((r) => setTimeout(r, 300));
+    }
     const dest = join(outDir, `${name}.png`);
     const png = await page.screenshot();
     writeFileSync(dest, png);

--- a/haku/console/frontend/settings_page.tsx
+++ b/haku/console/frontend/settings_page.tsx
@@ -1,0 +1,177 @@
+import { Badge, Button, Group, Loader, Stack, Text } from "@mantine/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { shortDate } from "./approval_state.ts";
+import {
+  disconnectMcpOperatorAuth,
+  fetchMcpOperatorAuthStatuses,
+  type McpOperatorAuthStatus,
+  startMcpOperatorAuth,
+} from "./client.ts";
+import { ArrowLeftIcon } from "./icons.tsx";
+import { openExternal, POPUP_HINT } from "./open_external.ts";
+import { toastError, toastSuccess } from "./toast.ts";
+
+// Other console tabs (and the OAuth-callback page) post here when an MCP account link
+// changes, so an open Settings page refetches without a manual reload.
+const MCP_AUTH_CHANNEL = "haku-console-mcp-auth";
+
+function McpAccountCard({
+  status,
+  onConnect,
+  onDisconnect,
+}: {
+  status: McpOperatorAuthStatus;
+  onConnect: () => void;
+  onDisconnect: () => void;
+}) {
+  const connected = status.status === "connected";
+  const until = shortDate(status.token_expires_at);
+  return (
+    <section className="haku-shell-card">
+      <Group justify="space-between" align="flex-start" gap="sm" wrap="nowrap">
+        <Stack gap={2} style={{ minWidth: 0 }}>
+          <Text fw={600}>{status.server_id}</Text>
+          <Text size="xs" c="dimmed">
+            {connected
+              ? `Linked for ${status.operator_principal}${until ? ` until ${until}` : ""}`
+              : `Not linked for ${status.operator_principal}`}
+          </Text>
+        </Stack>
+        <Badge color={connected ? "teal" : "gray"} variant="light">
+          {connected ? "Connected" : "Unconnected"}
+        </Badge>
+      </Group>
+      <Group justify="flex-end" gap="xs" mt="sm">
+        {connected ? (
+          <>
+            <Button size="compact-sm" variant="light" onClick={onConnect}>
+              Reconnect
+            </Button>
+            <Button size="compact-sm" variant="subtle" color="red" onClick={onDisconnect}>
+              Disconnect
+            </Button>
+          </>
+        ) : (
+          <Button size="compact-sm" variant="light" onClick={onConnect}>
+            Connect
+          </Button>
+        )}
+      </Group>
+    </section>
+  );
+}
+
+// Operator settings — the console's rarely-touched MCP account linkage, moved out of the
+// approval drawer into its own full-page route (routing.ts → "/settings").
+export function SettingsPage({ onBack }: { onBack: () => void }) {
+  const [statuses, setStatuses] = useState<McpOperatorAuthStatus[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const channelRef = useRef<BroadcastChannel | null>(null);
+
+  const load = useCallback((notifyPeers = false) => {
+    if (notifyPeers) channelRef.current?.postMessage({ type: "mcpAuthChanged" });
+    setLoading(true);
+    fetchMcpOperatorAuthStatuses().then(
+      (s) => {
+        setStatuses(s);
+        setError(null);
+        setLoading(false);
+      },
+      (e: unknown) => {
+        setError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      }
+    );
+  }, []);
+
+  useEffect(() => {
+    load();
+    if (!("BroadcastChannel" in window)) return;
+    const channel = new BroadcastChannel(MCP_AUTH_CHANNEL);
+    channelRef.current = channel;
+    channel.onmessage = () => load();
+    return () => {
+      if (channelRef.current === channel) channelRef.current = null;
+      channel.close();
+    };
+  }, [load]);
+
+  function connect(serverId: string) {
+    startMcpOperatorAuth(serverId).then(
+      (started) => {
+        if (!openExternal(started.authorization_url)) {
+          toastError("Pop-up blocked", POPUP_HINT);
+          return;
+        }
+        toastSuccess("MCP account link started", "Finish the authorization in the new tab.");
+      },
+      (e: unknown) => toastError("Couldn't start MCP account link", e)
+    );
+  }
+
+  function disconnect(serverId: string) {
+    disconnectMcpOperatorAuth(serverId).then(
+      () => {
+        toastSuccess("MCP account disconnected", serverId);
+        load(true);
+      },
+      (e: unknown) => toastError("Couldn't disconnect MCP account", e)
+    );
+  }
+
+  return (
+    <div className="haku-page">
+      <header className="haku-page-header">
+        <div className="haku-page-bar">
+          <Group gap="xs" wrap="nowrap" align="center">
+            <Button size="xs" variant="subtle" color="gray" leftSection={<ArrowLeftIcon />} onClick={onBack}>
+              Back
+            </Button>
+            <Text fw={700}>Settings</Text>
+          </Group>
+          <Button size="xs" variant="light" loading={loading} onClick={() => load()}>
+            Refresh
+          </Button>
+        </div>
+      </header>
+      <div className="haku-page-scroll">
+        <div className="haku-page-list">
+          <section className="haku-shell-card">
+            <Text fw={600}>MCP accounts</Text>
+            <Text size="xs" c="dimmed" mt={4}>
+              Operator OAuth links for connected MCP servers. Connect one to let the console execute its tools with your
+              account.
+            </Text>
+          </section>
+          {error && (
+            <Text c="red" size="sm">
+              Failed to load MCP accounts: {error}
+            </Text>
+          )}
+          {!statuses && !error && (
+            <Group justify="center" p="xl">
+              <Loader />
+            </Group>
+          )}
+          {statuses && statuses.length === 0 && (
+            <section className="haku-shell-card">
+              <Text size="sm" c="dimmed">
+                No operator-linked MCP servers are configured.
+              </Text>
+            </section>
+          )}
+          {statuses?.map((status) => (
+            <McpAccountCard
+              key={status.server_id}
+              status={status}
+              onConnect={() => connect(status.server_id)}
+              onDisconnect={() => disconnect(status.server_id)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -97,9 +97,10 @@
   right: 8px;
 }
 
-/* Full-page past-tool-calls history view (tool_calls_page.tsx) — its own route, so it
-   replaces the framed haku-ui rather than overlaying it. */
-.haku-history-page {
+/* Full-page console views on their own routes (past-tool-calls history in
+   tool_calls_page.tsx, operator settings in settings_page.tsx) — each replaces the framed
+   haku-ui rather than overlaying it. Shared page chrome, so both use these classes. */
+.haku-page {
   position: fixed;
   inset: 0;
   display: flex;
@@ -108,20 +109,20 @@
   color: var(--mantine-color-text);
 }
 
-.haku-history-header {
+.haku-page-header {
   flex: 0 0 auto;
   border-bottom: 1px solid var(--haku-border);
   background: var(--haku-panel-bg);
 }
 
-.haku-history-bar,
-.haku-history-list {
+.haku-page-bar,
+.haku-page-list {
   width: 100%;
   max-width: 56rem;
   margin: 0 auto;
 }
 
-.haku-history-bar {
+.haku-page-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -129,17 +130,23 @@
   padding: 0.6rem 1rem;
 }
 
-.haku-history-scroll {
+.haku-page-scroll {
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
 }
 
-.haku-history-list {
+.haku-page-list {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
   padding: 1rem;
+}
+
+/* Full-page cards sit on a solid page background, not floating over the iframe like the
+   drawer's — so drop the drawer's lift shadow and let the border alone delineate them. */
+.haku-page .haku-shell-card {
+  box-shadow: none;
 }
 
 .haku-shell-overlay {

--- a/haku/console/frontend/tabler_icons.d.ts
+++ b/haku/console/frontend/tabler_icons.d.ts
@@ -19,3 +19,13 @@ declare module "@tabler/icons-react/dist/esm/icons/IconArrowLeft.mjs" {
   const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
   export default Icon;
 }
+declare module "@tabler/icons-react/dist/esm/icons/IconSettings.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}
+declare module "@tabler/icons-react/dist/esm/icons/IconMapPin.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}

--- a/haku/console/frontend/tool_calls_page.tsx
+++ b/haku/console/frontend/tool_calls_page.tsx
@@ -166,9 +166,9 @@ export function ToolCallsPage({ onBack }: { onBack: () => void }) {
   );
 
   return (
-    <div className="haku-history-page">
-      <header className="haku-history-header">
-        <div className="haku-history-bar">
+    <div className="haku-page">
+      <header className="haku-page-header">
+        <div className="haku-page-bar">
           <Group gap="xs" wrap="nowrap" align="center">
             <Button size="xs" variant="subtle" color="gray" leftSection={<ArrowLeftIcon />} onClick={onBack}>
               Back
@@ -185,8 +185,8 @@ export function ToolCallsPage({ onBack }: { onBack: () => void }) {
           </Button>
         </div>
       </header>
-      <div className="haku-history-scroll">
-        <div className="haku-history-list">
+      <div className="haku-page-scroll">
+        <div className="haku-page-list">
           {error && (
             <Text c="red" size="sm">
               Failed to load tool calls: {error}


### PR DESCRIPTION
The approval drawer's **Access** tab held two rarely-touched controls that don't earn a persistent tab. This moves each to where it belongs and drops the tab (and the drawer's `SegmentedControl`).

## Changes

- **MCP accounts → a full-page `/settings` view** (`settings_page.tsx`), rendered like the past-tool-calls history and reached from a **Settings** nav link in the drawer. `routing.ts` grows a third path-keyed view (`/` · `/tool-calls` · `/settings`).
- **Location sharing → a map-pin control under the hamburger** (`ShellControls`), shown only while the shell's standing consent grant is held. A pulsing indicator dot marks that location is being read *right now*; the plain pin means sharing is merely allowed. Its popover carries the state badge and the **Stop & withdraw** kill switch.
- The drawer is now just the approval queue plus nav links to the history and settings pages.
- `openExternal` + `POPUP_HINT` moved to their own module (`open_external.ts`) — both the embed shell and the settings page need them; their tests moved alongside (`open_external.test.ts`).
- Full-page cards drop the drawer's lift shadow: on a solid page background the border alone delineates them.

## Screenshots

The screenshot generator gains a `settings` scene and a `controls` scene (`render.mjs` clicks the pin to capture the location popover), replacing the old `drawer-access` scene. Ran `//haku/console/frontend:screenshots` and eyeballed all four.

## Test

`bbr test //haku/console/frontend:{tsc_test,bridge_test,bundle,screenshots}` — all green on RBE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5PSCrFPzAn61Yqr2hZE9a

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5PSCrFPzAn61Yqr2hZE9a)_