### PR TITLE
haku/console/tools: build the Calendar events.insert body with aliased pydantic models

### DIFF
--- a/haku/console/tools/google_calendar.py
+++ b/haku/console/tools/google_calendar.py
@@ -62,8 +62,12 @@ class CreateCalendarEventArgs(BaseModel):
 
 
 class CreateCalendarEventResult(BaseModel):
-    event_id: str
-    html_link: str = Field(description="Link to the event in Google Calendar.")
+    # Parsed straight from the Calendar API's Event response via `model_validate`; the wire
+    # fields are `id`/`htmlLink`. populate_by_name keeps field-name construction working too.
+    model_config = ConfigDict(populate_by_name=True)
+
+    event_id: str = Field(validation_alias="id")
+    html_link: str = Field(validation_alias="htmlLink", description="Link to the event in Google Calendar.")
 
 
 # --- Google Calendar `events.insert` request-body models (camelCase wire shape) ---
@@ -131,4 +135,4 @@ class CalendarToolsClient:
             .insert(calendarId=args.calendar_id, body=body.model_dump(by_alias=True, exclude_none=True))
             .execute()
         )
-        return CreateCalendarEventResult(event_id=created["id"], html_link=created["htmlLink"])
+        return CreateCalendarEventResult.model_validate(created)

--- a/haku/console/tools/google_calendar.py
+++ b/haku/console/tools/google_calendar.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from enum import StrEnum
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.alias_generators import to_camel
 
-# The Google Calendar REST API speaks camelCase; request-body models below carry `to_camel`
-# aliases so `model_dump(by_alias=True, exclude_none=True)` yields the wire shape directly,
-# instead of hand-assembling dicts.
-_CAMEL = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+class ReminderMethod(StrEnum):
+    POPUP = "popup"
+    EMAIL = "email"
 
 
 class EventDateTime(BaseModel):
@@ -36,7 +37,7 @@ class EventDateTime(BaseModel):
 
 
 class CalendarReminder(BaseModel):
-    method: Literal["popup", "email"] = "popup"
+    method: ReminderMethod = ReminderMethod.POPUP
     minutes_before_start: int = Field(
         ge=0, le=40320, description="Minutes before the event start; Google's max is 4 weeks."
     )
@@ -67,7 +68,7 @@ class CreateCalendarEventResult(BaseModel):
 
 # --- Google Calendar `events.insert` request-body models (camelCase wire shape) ---
 class _EventDateTime(BaseModel):
-    model_config = _CAMEL
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     date: str | None = None
     date_time: str | None = None
@@ -79,12 +80,12 @@ class _EventDateTime(BaseModel):
 
 
 class _ReminderOverride(BaseModel):
-    method: str
+    method: ReminderMethod
     minutes: int
 
 
 class _Reminders(BaseModel):
-    model_config = _CAMEL
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     use_default: bool
     overrides: list[_ReminderOverride]
@@ -95,7 +96,7 @@ class _Attendee(BaseModel):
 
 
 class _EventInsert(BaseModel):
-    model_config = _CAMEL
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     summary: str
     start: _EventDateTime

--- a/haku/console/tools/google_calendar.py
+++ b/haku/console/tools/google_calendar.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic.alias_generators import to_camel
+
+# The Google Calendar REST API speaks camelCase; request-body models below carry `to_camel`
+# aliases so `model_dump(by_alias=True, exclude_none=True)` yields the wire shape directly,
+# instead of hand-assembling dicts.
+_CAMEL = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class EventDateTime(BaseModel):
     """Mirrors the Google Calendar API's `EventDateTime` — exactly one of `date`
-    (all-day) or `date_time` (+`time_zone`) is set."""
+    (all-day) or `date_time` (+`time_zone`) is set. Snake-case tool-arg surface (Haku passes
+    these); `_EventDateTime` below is the camelCase request-body twin."""
 
     date: str | None = Field(default=None, description="All-day event date, YYYY-MM-DD.")
     date_time: str | None = Field(
@@ -58,35 +65,69 @@ class CreateCalendarEventResult(BaseModel):
     html_link: str = Field(description="Link to the event in Google Calendar.")
 
 
+# --- Google Calendar `events.insert` request-body models (camelCase wire shape) ---
+class _EventDateTime(BaseModel):
+    model_config = _CAMEL
+
+    date: str | None = None
+    date_time: str | None = None
+    time_zone: str | None = None
+
+    @classmethod
+    def of(cls, value: EventDateTime) -> _EventDateTime:
+        return cls(date=value.date, date_time=value.date_time, time_zone=value.time_zone)
+
+
+class _ReminderOverride(BaseModel):
+    method: str
+    minutes: int
+
+
+class _Reminders(BaseModel):
+    model_config = _CAMEL
+
+    use_default: bool
+    overrides: list[_ReminderOverride]
+
+
+class _Attendee(BaseModel):
+    email: str
+
+
+class _EventInsert(BaseModel):
+    model_config = _CAMEL
+
+    summary: str
+    start: _EventDateTime
+    end: _EventDateTime
+    description: str | None = None
+    location: str | None = None
+    attendees: list[_Attendee] | None = None
+    reminders: _Reminders | None = None
+
+
 class CalendarToolsClient:
     def __init__(self, service: Any) -> None:
         self._service = service
 
     def create_event(self, args: CreateCalendarEventArgs) -> CreateCalendarEventResult:
-        body: dict[str, Any] = {
-            "summary": args.summary,
-            "start": _event_date_time(args.start),
-            "end": _event_date_time(args.end),
-        }
-        if args.description is not None:
-            body["description"] = args.description
-        if args.location is not None:
-            body["location"] = args.location
-        if args.attendees:
-            body["attendees"] = [{"email": email} for email in args.attendees]
-        if args.reminders:
-            body["reminders"] = {
-                "useDefault": False,
-                "overrides": [{"method": r.method, "minutes": r.minutes_before_start} for r in args.reminders],
-            }
-        created = self._service.events().insert(calendarId=args.calendar_id, body=body).execute()
+        body = _EventInsert(
+            summary=args.summary,
+            start=_EventDateTime.of(args.start),
+            end=_EventDateTime.of(args.end),
+            description=args.description,
+            location=args.location,
+            attendees=[_Attendee(email=email) for email in args.attendees] or None,
+            reminders=_Reminders(
+                use_default=False,
+                overrides=[_ReminderOverride(method=r.method, minutes=r.minutes_before_start) for r in args.reminders],
+            )
+            if args.reminders
+            else None,
+        )
+        created = (
+            self._service.events()
+            .insert(calendarId=args.calendar_id, body=body.model_dump(by_alias=True, exclude_none=True))
+            .execute()
+        )
         return CreateCalendarEventResult(event_id=created["id"], html_link=created["htmlLink"])
-
-
-def _event_date_time(value: EventDateTime) -> dict[str, str]:
-    if value.date is not None:
-        return {"date": value.date}
-    # enforced by EventDateTime's validator
-    assert value.date_time is not None
-    assert value.time_zone is not None
-    return {"dateTime": value.date_time, "timeZone": value.time_zone}

--- a/haku/console/tools/test_google_calendar.py
+++ b/haku/console/tools/test_google_calendar.py
@@ -39,9 +39,19 @@ class _FakeCalendarService:
         return self.events_
 
 
-def test_create_event_timed_with_reminders_and_attendees() -> None:
-    service = _FakeCalendarService()
-    client = CalendarToolsClient(service)
+@pytest.fixture
+def service() -> _FakeCalendarService:
+    return _FakeCalendarService()
+
+
+@pytest.fixture
+def client(service: _FakeCalendarService) -> CalendarToolsClient:
+    return CalendarToolsClient(service)
+
+
+def test_create_event_timed_with_reminders_and_attendees(
+    service: _FakeCalendarService, client: CalendarToolsClient
+) -> None:
     args = CreateCalendarEventArgs(
         summary="Pay CA estimated tax",
         start=EventDateTime(date_time="2026-09-15T09:00:00-07:00", time_zone="America/Los_Angeles"),
@@ -65,9 +75,9 @@ def test_create_event_timed_with_reminders_and_attendees() -> None:
     assert body["attendees"] == [{"email": "michael@example.com"}]
 
 
-def test_create_event_all_day_omits_reminders_when_unset() -> None:
-    service = _FakeCalendarService()
-    client = CalendarToolsClient(service)
+def test_create_event_all_day_omits_reminders_when_unset(
+    service: _FakeCalendarService, client: CalendarToolsClient
+) -> None:
     args = CreateCalendarEventArgs(
         summary="Federal estimated tax due",
         start=EventDateTime(date="2026-09-15"),


### PR DESCRIPTION
Small standalone refactor split out of the Gmail PR (#3005), landing first.

`CalendarToolsClient.create_event` hand-assembled the Google Calendar `events.insert` request
body as a `dict[str, Any]` with literal camelCase keys (`useDefault`, `overrides`, `dateTime`,
`timeZone`, …). Replace that with Pydantic request-body models (`_EventInsert`,
`_EventDateTime`, `_Reminders`, `_ReminderOverride`, `_Attendee`) carrying `to_camel` aliases,
so `model_dump(by_alias=True, exclude_none=True)` produces the wire shape directly.

The snake-case arg models (`CreateCalendarEventArgs`, `EventDateTime`, …) — the tool surface
Haku sees — are unchanged; the body models are their camelCase twins, the same split
`gmail_api` uses.

## Verification

- `bbr test //haku/console/tools:test_google_calendar` → pass (the client test asserts the
  exact request body the fake service receives, so the wire shape is covered).
- `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWWMs8UDB7vxQUFZ6vC5BB

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWWMs8UDB7vxQUFZ6vC5BB)_