### PR TITLE
haku/console/frontend: dispatch tool previews via a serverId registry + one test per module

### DIFF
--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -423,7 +423,10 @@ tsc_bin.tsc_test(
         ":screenshot_harness_lib",
         "//:node_modules",
         "//:node_modules/@haku/console-bridge",
+        "//haku/console/frontend/tool_previews:google_test",
+        "//haku/console/frontend/tool_previews:grocy_test",
         "//haku/console/frontend/tool_previews:index_test",
+        "//haku/console/frontend/tool_previews:kubectl_test",
     ],
     tags = ["lint"],
 )
@@ -449,6 +452,9 @@ vitest_bin.vitest_test(
         ":routing",
         "//:node_modules",
         "//:node_modules/@haku/console-bridge",
+        "//haku/console/frontend/tool_previews:google_test",
+        "//haku/console/frontend/tool_previews:grocy_test",
         "//haku/console/frontend/tool_previews:index_test",
+        "//haku/console/frontend/tool_previews:kubectl_test",
     ],
 )

--- a/haku/console/frontend/tool_previews/BUILD.bazel
+++ b/haku/console/frontend/tool_previews/BUILD.bazel
@@ -2,8 +2,9 @@ load("@aspect_rules_js//js:defs.bzl", "js_library")
 
 package(default_visibility = ["//visibility:public"])
 
-# Per-server approval-preview widgets. Each module owns one server's widgets and returns
-# null for anything outside its serverId; `tool_previews` (index.tsx) chains them.
+# Per-server approval-preview widgets. Each module owns one server's widgets and exports its
+# SERVER_ID + a (toolName, args) renderer; `tool_previews` (index.tsx) dispatches to them via
+# a serverId registry.
 
 js_library(
     name = "google",
@@ -60,8 +61,28 @@ filegroup(
     srcs = glob(["*.tsx"]),
 )
 
-# The dispatcher's vitest spec; the parent's aggregate tsc_test + bridge_test consume it
-# (a js_test can't take a source file from another package directly, only via a library).
+# One vitest spec per module (each test parallels the module it tests), wrapped as its own
+# js_library so the dep graph stays per-file; the parent's aggregate tsc_test + bridge_test
+# consume them (a js_test can't take a source file from another package directly, only via a
+# library).
+js_library(
+    name = "google_test",
+    srcs = ["google.test.ts"],
+    deps = [":google"],
+)
+
+js_library(
+    name = "grocy_test",
+    srcs = ["grocy.test.ts"],
+    deps = [":grocy"],
+)
+
+js_library(
+    name = "kubectl_test",
+    srcs = ["kubectl.test.ts"],
+    deps = [":kubectl"],
+)
+
 js_library(
     name = "index_test",
     srcs = ["index.test.ts"],

--- a/haku/console/frontend/tool_previews/google.test.ts
+++ b/haku/console/frontend/tool_previews/google.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { googleToolPreview } from "./google.tsx";
+
+describe("googleToolPreview", () => {
+  it("renders create_calendar_event for a valid all-day event", () => {
+    const preview = googleToolPreview("create_calendar_event", {
+      summary: "Standup",
+      start: { date: "2026-09-15" },
+      end: { date: "2026-09-16" },
+    });
+    expect(preview).not.toBeNull();
+    expect(preview).not.toBe(false);
+  });
+
+  it("renders batch_modify_gmail_thread_labels for valid args", () => {
+    expect(
+      googleToolPreview("batch_modify_gmail_thread_labels", { thread_ids: ["t1"], add: ["urgent"], remove: [] })
+    ).not.toBeNull();
+  });
+
+  it("renders create_gmail_draft for valid args", () => {
+    expect(
+      googleToolPreview("create_gmail_draft", { to: ["a@example.com"], subject: "Hello", body: "Hi" })
+    ).not.toBeNull();
+  });
+
+  it("returns null when args don't match the tool's schema", () => {
+    expect(googleToolPreview("create_calendar_event", { summary: "no start/end" })).toBeNull();
+  });
+
+  it("returns null for a tool it doesn't render", () => {
+    expect(googleToolPreview("list_events", {})).toBeNull();
+  });
+});

--- a/haku/console/frontend/tool_previews/google.tsx
+++ b/haku/console/frontend/tool_previews/google.tsx
@@ -22,7 +22,7 @@ import {
 import { fetchGmailThreadPreviews, type GmailThreadPreview } from "../google_client.ts";
 import { Field } from "../field.tsx";
 
-const GOOGLE_SERVER_ID = "google";
+export const GOOGLE_SERVER_ID = "google";
 
 type EventDateTime = z.infer<typeof zEventDateTime>;
 type CalendarReminder = z.infer<typeof zCalendarReminder>;
@@ -180,8 +180,7 @@ function CreateGmailDraftPreview({ args }: { args: CreateGmailDraftArgs }) {
 
 /** Nice per-tool rendering for the `google` server's tools; `null` when the (server, tool,
  * arguments) triple doesn't match a known widget, so the caller falls back to raw JSON. */
-export function googleToolPreview(serverId: string, toolName: string, args: Record<string, unknown>): ReactNode | null {
-  if (serverId !== GOOGLE_SERVER_ID) return null;
+export function googleToolPreview(toolName: string, args: Record<string, unknown>): ReactNode | null {
   if (toolName === "create_calendar_event") {
     const parsed = zCreateCalendarEventArgs.safeParse(args);
     return parsed.success ? <CreateCalendarEventPreview args={parsed.data} /> : null;

--- a/haku/console/frontend/tool_previews/grocy.test.ts
+++ b/haku/console/frontend/tool_previews/grocy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { grocyToolPreview } from "./grocy.tsx";
+
+describe("grocyToolPreview", () => {
+  it("renders products_create for valid args", () => {
+    const preview = grocyToolPreview("products_create", {
+      items: [{ name: "Oats", stock_qu: "Gram", location: "Pantry", default_best_before_days: 270 }],
+    });
+    expect(preview).not.toBeNull();
+    expect(preview).not.toBe(false);
+  });
+
+  it("falls through to null (not false) when args don't match the tool's schema", () => {
+    // Regression: the malformed shape a Jul 8 tool_request bug actually produced —
+    // {entity_type, body} nesting instead of flat fields. `parsed.success && <X/>` used to
+    // return `false` on a schema mismatch, not `null`, so the caller's `?? <pre>` raw-JSON
+    // fallback never kicked in — the operator saw a blank Arguments field instead of the JSON.
+    const preview = grocyToolPreview("products_create", {
+      items: [{ entity_type: "products", body: { name: "Oats", stock_qu: "Gram" } }],
+    });
+    expect(preview).toBeNull();
+  });
+});

--- a/haku/console/frontend/tool_previews/grocy.tsx
+++ b/haku/console/frontend/tool_previews/grocy.tsx
@@ -23,7 +23,7 @@ import { z } from "zod";
 import { fetchGrocyReference, type GrocyReferenceResponse } from "../grocy_client.ts";
 import { Field } from "../field.tsx";
 
-const GROCY_SERVER_ID = "grocy-sf";
+export const GROCY_SERVER_ID = "grocy-sf";
 
 // `int | str` on the Python side (name or ID) — resolved to a name for display either way.
 const zNameOrId = z.union([z.string(), z.number()]);
@@ -283,8 +283,7 @@ function ProductsCreatePreview({ args }: { args: ProductsCreateArgs }) {
 
 /** Nice per-tool rendering for the `grocy-sf` server's stock and product-creation tools;
  * `null` for anything else, so the caller falls back to raw JSON. */
-export function grocyToolPreview(serverId: string, toolName: string, args: Record<string, unknown>): ReactNode | null {
-  if (serverId !== GROCY_SERVER_ID) return null;
+export function grocyToolPreview(toolName: string, args: Record<string, unknown>): ReactNode | null {
   if (toolName === "stock_add") {
     const parsed = zStockAddArgs.safeParse(args);
     return parsed.success ? <StockAddPreview args={parsed.data} /> : null;

--- a/haku/console/frontend/tool_previews/index.test.ts
+++ b/haku/console/frontend/tool_previews/index.test.ts
@@ -2,29 +2,29 @@ import { describe, expect, it } from "vitest";
 
 import { toolPreview } from "./index.tsx";
 
-describe("toolPreview", () => {
-  it("renders a preview for valid grocy-sf products_create args", () => {
-    const preview = toolPreview("grocy-sf", "products_create", {
-      items: [{ name: "Oats", stock_qu: "Gram", location: "Pantry", default_best_before_days: 270 }],
-    });
-    expect(preview).not.toBeNull();
-    expect(preview).not.toBe(false);
+// The per-server renderers are covered in each module's own *.test.ts; this covers the
+// registry dispatch itself — routing by serverId and the two null paths.
+describe("toolPreview registry", () => {
+  it("dispatches to the registered renderer for a known serverId", () => {
+    expect(
+      toolPreview("grocy-sf", "products_create", {
+        items: [{ name: "Oats", stock_qu: "Gram", location: "Pantry", default_best_before_days: 270 }],
+      })
+    ).not.toBeNull();
+    expect(
+      toolPreview("google", "create_calendar_event", {
+        summary: "Standup",
+        start: { date: "2026-09-15" },
+        end: { date: "2026-09-16" },
+      })
+    ).not.toBeNull();
   });
 
-  it("falls through to null (not false) when args don't match the tool's schema", () => {
-    // Regression: the malformed shape a Jul 8 tool_request bug actually produced —
-    // {entity_type, body} nesting instead of flat fields. `parsed.success && <X/>`
-    // used to return `false` on a schema mismatch, not `null`, so `toolPreview`'s
-    // `??` chain (and console_panel.tsx's `nice ?? <pre>...</pre>` raw-JSON
-    // fallback) never kicked in — the operator saw a blank Arguments field
-    // instead of the raw JSON.
-    const preview = toolPreview("grocy-sf", "products_create", {
-      items: [{ entity_type: "products", body: { name: "Oats", stock_qu: "Gram" } }],
-    });
-    expect(preview).toBeNull();
-  });
-
-  it("returns null for an unknown server/tool combination", () => {
+  it("returns null for an unregistered server", () => {
     expect(toolPreview("some-other-server", "some_tool", {})).toBeNull();
+  });
+
+  it("returns null when the server is registered but the tool has no widget", () => {
+    expect(toolPreview("google", "list_events", {})).toBeNull();
   });
 });

--- a/haku/console/frontend/tool_previews/index.tsx
+++ b/haku/console/frontend/tool_previews/index.tsx
@@ -1,18 +1,23 @@
-// Central dispatcher over per-server tool-preview modules (google.tsx,
-// kubectl.tsx, ...). Each module owns one server's widgets and returns
-// null for anything outside its own serverId, so adding a server is "write a new
-// per-server file + add one line here" — this file never grows past that.
+// Registry mapping each MCP server id to its per-tool preview renderer. Each per-server
+// module (google.tsx, grocy.tsx, …) owns one server's widgets and exports its serverId plus
+// a (toolName, args) => ReactNode|null renderer; adding a server is "write a new module + one
+// registry entry here". `toolPreview` dispatches by serverId, so the file never grows a
+// hand-maintained `??` chain.
 
 import type { ReactNode } from "react";
 
-import { googleToolPreview } from "./google.tsx";
-import { grocyToolPreview } from "./grocy.tsx";
-import { kubectlToolPreview } from "./kubectl.tsx";
+import { GOOGLE_SERVER_ID, googleToolPreview } from "./google.tsx";
+import { GROCY_SERVER_ID, grocyToolPreview } from "./grocy.tsx";
+import { KUBECTL_SERVER_ID, kubectlToolPreview } from "./kubectl.tsx";
+
+type ToolPreviewRenderer = (toolName: string, args: Record<string, unknown>) => ReactNode | null;
+
+const RENDERERS: Record<string, ToolPreviewRenderer> = {
+  [GOOGLE_SERVER_ID]: googleToolPreview,
+  [GROCY_SERVER_ID]: grocyToolPreview,
+  [KUBECTL_SERVER_ID]: kubectlToolPreview,
+};
 
 export function toolPreview(serverId: string, toolName: string, args: Record<string, unknown>): ReactNode | null {
-  return (
-    googleToolPreview(serverId, toolName, args) ??
-    kubectlToolPreview(serverId, toolName, args) ??
-    grocyToolPreview(serverId, toolName, args)
-  );
+  return RENDERERS[serverId]?.(toolName, args) ?? null;
 }

--- a/haku/console/frontend/tool_previews/kubectl.test.ts
+++ b/haku/console/frontend/tool_previews/kubectl.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { kubectlToolPreview } from "./kubectl.tsx";
+
+describe("kubectlToolPreview", () => {
+  it("renders pods_delete for valid args", () => {
+    const preview = kubectlToolPreview("pods_delete", { name: "my-pod", namespace: "default" });
+    expect(preview).not.toBeNull();
+    expect(preview).not.toBe(false);
+  });
+
+  it("returns null when args don't match the tool's schema", () => {
+    expect(kubectlToolPreview("pods_delete", { namespace: "default" })).toBeNull(); // missing required name
+  });
+
+  it("returns null for a tool with no custom widget", () => {
+    expect(kubectlToolPreview("pods_list", {})).toBeNull();
+  });
+});

--- a/haku/console/frontend/tool_previews/kubectl.tsx
+++ b/haku/console/frontend/tool_previews/kubectl.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 import { Field } from "../field.tsx";
 
-const KUBECTL_SERVER_ID = "kubectl-passthrough-mcp";
+export const KUBECTL_SERVER_ID = "kubectl-passthrough-mcp";
 
 // kubectl-passthrough-mcp is a third-party binary (containers/kubernetes-mcp-server) —
 // there's no backend Pydantic model to generate these from (unlike google.tsx's
@@ -111,12 +111,7 @@ function PodsDeletePreview({ args }: { args: PodsDeleteArgs }) {
 
 /** Nice per-tool rendering for the `kubectl-passthrough-mcp` server's highest-stakes tools
  * (apply and delete); `null` for anything else, so the caller falls back to raw JSON. */
-export function kubectlToolPreview(
-  serverId: string,
-  toolName: string,
-  args: Record<string, unknown>
-): ReactNode | null {
-  if (serverId !== KUBECTL_SERVER_ID) return null;
+export function kubectlToolPreview(toolName: string, args: Record<string, unknown>): ReactNode | null {
   if (toolName === "resources_create_or_update") {
     const parsed = zResourcesCreateOrUpdateArgs.safeParse(args);
     return parsed.success ? <ResourcesApplyPreview args={parsed.data} /> : null;


### PR DESCRIPTION
Standalone frontend refactor split out of the Gmail PR (#3005), landing first.

## What changed

- **Registry dispatch.** `tool_previews/index.tsx` chained the per-server renderers with a
  hand-maintained `??` list (`googleToolPreview(...) ?? kubectlToolPreview(...) ?? …`). Replace
  it with a `serverId → renderer` registry: each per-server module now exports its `SERVER_ID`
  and a `(toolName, args) => ReactNode | null` renderer (the internal `serverId` guard is gone,
  since the registry keys on it). Adding a server is one import + one registry entry.
- **One test per module.** Split the single `index.test.ts` (which only exercised grocy) into
  `google.test.ts` / `grocy.test.ts` / `kubectl.test.ts` — each testing its module's renderer
  directly — plus an `index.test.ts` covering the registry dispatch (routing by serverId, and
  the unregistered-server / no-widget null paths). Each spec is its own `js_library` Bazel
  target so the test dep graph parallels the modules.

## What did **not** change

- No behavior change — `toolPreview(serverId, toolName, args)`'s signature and results are
  identical; callers (`tool_arguments_field.tsx`) are untouched.

## Verification

- `bbr test //haku/console/frontend/...` → 3/3 pass (`tsc_test`, `bridge_test` incl. all four
  per-module specs, `screenshots`).
- `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWWMs8UDB7vxQUFZ6vC5BB

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWWMs8UDB7vxQUFZ6vC5BB)_