### PR TITLE
sources/coinbase: read balances via /v2/accounts (v3 omits staked assets)

### DIFF
--- a/haku/base/sources/coinbase.md
+++ b/haku/base/sources/coinbase.md
@@ -42,7 +42,7 @@ Endpoints (all on `api.coinbase.com`):
 - `GET /v2/prices/<from>-<to>/spot` — **public, no auth** — spot price for USD marking.
 
 **Sharp edge — for balances use `/v2/accounts`, NOT `/api/v3/brokerage/accounts`.** The v3
-brokerage endpoint (`get_accounts`) returns only *tradeable* balances and **silently omits
+brokerage endpoint (`get_accounts`) returns only _tradeable_ balances and **silently omits
 staked assets** — staked ETH sits in a separate `Staked ETH` wallet that v3 never returns, so a
 v3-only read can undercount the account by a wide margin (caught against the operator's app,
 Jul 11). `/v2/accounts` lists every wallet, staked included. Keep v3 only for `fills` and

--- a/haku/base/sources/coinbase.md
+++ b/haku/base/sources/coinbase.md
@@ -30,12 +30,23 @@ header sent: Authorization: Bearer <jwt>
 omitting `nonce`, or putting the query string in `uri`) returns `401 Unauthorized`
 on every call. JWT signing needs a crypto env (`cryptography` + `pyjwt`), so run it
 from a `haku-sandbox` pod (like the Plaid `psql` pod) or a `uv run --script`
-one-liner — not a bare `curl`. Endpoints (all on `api.coinbase.com`):
+one-liner — not a bare `curl`. Easiest is `coinbase-advanced-py`'s
+`RESTClient(api_key, api_secret).get(<path>, params=…)`, which mints the JWT for you.
+Endpoints (all on `api.coinbase.com`):
 
-- `GET /api/v3/brokerage/accounts` — balances, one entry per currency (`available_balance.value`).
+- **`GET /v2/accounts` — balances; use this one.** One entry per **wallet**
+  (`balance.amount` + `currency` + `name`), **including staked assets** — a separate
+  `Staked ETH`-style wallet shows here. Paginate with `?limit=100`.
 - `GET /api/v3/brokerage/orders/historical/fills` — trade-execution history.
 - `GET /api/v3/brokerage/key_permissions` — cheap sanity check; returns `can_view=true, can_trade=false, can_transfer=false` (the key is read-only).
 - `GET /v2/prices/<from>-<to>/spot` — **public, no auth** — spot price for USD marking.
+
+**Sharp edge — for balances use `/v2/accounts`, NOT `/api/v3/brokerage/accounts`.** The v3
+brokerage endpoint (`get_accounts`) returns only *tradeable* balances and **silently omits
+staked assets** — staked ETH sits in a separate `Staked ETH` wallet that v3 never returns, so a
+v3-only read can undercount the account by a wide margin (caught against the operator's app,
+Jul 11). `/v2/accounts` lists every wallet, staked included. Keep v3 only for `fills` and
+`key_permissions`.
 
 Gotcha: there is **no** generic transactions list endpoint — top-level
 `/api/v3/brokerage/transactions` → `401` and per-account


### PR DESCRIPTION
## Why

The source doc pointed the balance read at `GET /api/v3/brokerage/accounts`, which returns
only *tradeable* balances and **silently omits staked assets** — staked ETH lives in a separate
`Staked ETH` wallet that v3 never returns, so a v3-only read can materially undercount the
account (verified against the operator's app, Jul 11).

`GET /v2/accounts` lists every wallet (staked included) and reconciles correctly.

## What changed

- Balances endpoint → **`/v2/accounts`** (was `/api/v3/brokerage/accounts`); includes staked
  wallets, paginate via `?limit=100`.
- Added a **Sharp edge** callout documenting the v3 staking blind spot so it can't be
  reintroduced.
- Kept v3 for `fills` + `key_permissions` (correct); noted `coinbase-advanced-py`'s
  `RESTClient.get(path)` as the easy JWT path.

Supersedes #3019 (closed — it quoted specific balance figures that shouldn't live in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHaayKCuSg3p8hWcC8mQbH

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHaayKCuSg3p8hWcC8mQbH)_