### PR TITLE
haku/console: previews gallery screenshot scene + move thread-preview off the tools client

### DIFF
--- a/haku/console/frontend/AGENTS.md
+++ b/haku/console/frontend/AGENTS.md
@@ -12,13 +12,16 @@ bbr test //haku/console/frontend:screenshots
 ```
 
 It renders each surface (`screenshots/harness.tsx`) to a PNG (one per scene: `history`,
-`drawer`, `settings`, `controls`) in the test's **undeclared outputs**. Browser rendering
-runs on the RBE worker, so this is a `bbr` test, not a local `bb run`. Fetch the PNGs with the
-`buildbuddy_api` skill (download the target's undeclared test outputs), then open every one
-and actually check it looks good — spacing, alignment, contrast, truncation, that nothing
+`drawer`, `settings`, `previews`, `controls`) in the test's **undeclared outputs**. Browser
+rendering runs on the RBE worker, so this is a `bbr` test, not a local `bb run`. Fetch the PNGs
+with the `buildbuddy_api` skill (download the target's undeclared test outputs), then open every
+one and actually check it looks good — spacing, alignment, contrast, truncation, that nothing
 overflows or collides, and that both content and chrome read clearly — not merely that it
 rendered. The test is a generator, not a pixel-diff gate: it passes as long as every scene
 renders, so it never blocks CI on "looks different", but a blank/crashed scene fails it.
 
-Add a scene to `screenshots/harness.tsx` (and the `SCENES` list in `screenshots/render.mjs`)
-whenever you add a new surface.
+The `previews` scene is a gallery of **every implemented tool-call preview**, each rendered in
+both compact and detailed — when you add or change a per-server widget (`tool_previews/*.tsx`),
+add its (server, tool, sample args) to `PREVIEW_SAMPLES` in `screenshots/sample_data.ts` and
+re-check the gallery. Add a whole new scene to `screenshots/harness.tsx` (and the `SCENES` list
+in `screenshots/render.mjs`) whenever you add a new surface.

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -354,6 +354,7 @@ js_library(
         ":console_panel",
         ":settings_page",
         ":theme",
+        ":tool_arguments_field",
         ":tool_calls_page",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",

--- a/haku/console/frontend/screenshots/harness.tsx
+++ b/haku/console/frontend/screenshots/harness.tsx
@@ -7,16 +7,58 @@
 // tool_calls_page.tsx) captures `globalThis.fetch`; the history view then renders populated.
 import "./mock_api.ts";
 
-import { MantineProvider } from "@mantine/core";
+import { MantineProvider, Text } from "@mantine/core";
 import { createRoot } from "react-dom/client";
 
 import { ShellControls, ShellDrawer, type ShellDrawerProps } from "../console_panel.tsx";
 import { SettingsPage } from "../settings_page.tsx";
 import { hakuTheme } from "../theme.ts";
+import { ToolArgumentsField } from "../tool_arguments_field.tsx";
 import { ToolCallsPage } from "../tool_calls_page.tsx";
-import { SAMPLE_PENDING, SAMPLE_RECENT } from "./sample_data.ts";
+import { PREVIEW_SAMPLES, SAMPLE_PENDING, SAMPLE_RECENT } from "./sample_data.ts";
 
 const noop = () => {};
+
+// Gallery of every implemented tool-call preview, each rendered in both variants side by
+// side, so a glance covers the whole widget surface (see PREVIEW_SAMPLES / frontend/AGENTS.md).
+function PreviewGallery() {
+  return (
+    <div className="haku-page">
+      <div className="haku-page-scroll">
+        <div
+          style={{ maxWidth: 1000, margin: "0 auto", padding: 24, display: "flex", flexDirection: "column", gap: 28 }}
+        >
+          {PREVIEW_SAMPLES.map(({ serverId, toolName, args }) => {
+            const argumentsJson = JSON.stringify(args, null, 2);
+            return (
+              <div key={`${serverId}.${toolName}`} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <Text fw={700} size="sm" ff="monospace">
+                  {serverId}.{toolName}
+                </Text>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, alignItems: "start" }}>
+                  {(["compact", "detailed"] as const).map((variant) => (
+                    <section className="haku-shell-card" key={variant}>
+                      <Text size="xs" c="dimmed" fw={700} tt="uppercase" mb={6}>
+                        {variant}
+                      </Text>
+                      <ToolArgumentsField
+                        serverId={serverId}
+                        toolName={toolName}
+                        args={args}
+                        argumentsJson={argumentsJson}
+                        variant={variant}
+                      />
+                    </section>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 const drawerProps: ShellDrawerProps = {
   opened: true,
@@ -54,6 +96,8 @@ function sceneElement(scene: string) {
       );
     case "drawer":
       return <ShellDrawer {...drawerProps} />;
+    case "previews":
+      return <PreviewGallery />;
     default:
       return <ToolCallsPage onBack={noop} />;
   }

--- a/haku/console/frontend/screenshots/mock_api.ts
+++ b/haku/console/frontend/screenshots/mock_api.ts
@@ -3,7 +3,7 @@
 // module that captures `globalThis.fetch` (openapi-fetch does so when client.ts builds its
 // client) — harness.tsx imports this first. Paired with a `<base href>` in the harness page
 // (render.mjs) so the relative "/api/…" URL parses in the origin-less setContent page.
-import { SAMPLE_MCP, SAMPLE_TOOL_CALLS } from "./sample_data.ts";
+import { SAMPLE_GMAIL_THREADS, SAMPLE_MCP, SAMPLE_TOOL_CALLS } from "./sample_data.ts";
 
 function requestUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") return input;
@@ -25,6 +25,8 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promis
   // since the sample uses string names (resolveName returns those as-is).
   if (url.includes("/api/grocy-sf/reference"))
     return jsonResponse({ products: [], quantity_units: [], locations: [], product_groups: [] });
+  // The Gmail thread-labels widget looks up subjects/labels for its thread ids.
+  if (url.includes("/api/google/gmail/thread-previews")) return jsonResponse({ threads: SAMPLE_GMAIL_THREADS });
   if (url.includes("/api/tool-calls")) return jsonResponse({ tool_calls: SAMPLE_TOOL_CALLS });
   if (realFetch) return realFetch(input, init);
   return jsonResponse({});

--- a/haku/console/frontend/screenshots/render.mjs
+++ b/haku/console/frontend/screenshots/render.mjs
@@ -22,6 +22,8 @@ const SCENES = [
   { name: "history", viewport: { width: 1200, height: 1500 } },
   { name: "drawer", viewport: { width: 1200, height: 900 } },
   { name: "settings", viewport: { width: 1200, height: 900 } },
+  // Every implemented tool-call preview, compact | detailed side by side — tall, so give it room.
+  { name: "previews", viewport: { width: 1100, height: 3600 } },
   // `click` opens the location-sharing popover (its open state is internal to the control)
   // so the screenshot captures the dropdown, not just the pin.
   { name: "controls", viewport: { width: 520, height: 380 }, click: '[aria-label="Location sharing: live"]' },

--- a/haku/console/frontend/screenshots/sample_data.ts
+++ b/haku/console/frontend/screenshots/sample_data.ts
@@ -108,3 +108,128 @@ export const SAMPLE_MCP: McpOperatorAuthStatus[] = [
     scope: "read write",
   },
 ];
+
+// Subject/label lookups the Gmail thread-labels widget fetches; served by mock_api so both
+// preview variants render real subjects (compact shows the first few, detailed adds labels).
+export const SAMPLE_GMAIL_THREADS = {
+  t1: {
+    subject: "Q3 planning — notes + open questions",
+    gmail_url: "https://mail.google.com/mail/u/0/#all/t1",
+    current_label_names: ["Inbox", "Work"],
+  },
+  t2: {
+    subject: "Re: dentist appointment confirmation",
+    gmail_url: "https://mail.google.com/mail/u/0/#all/t2",
+    current_label_names: ["Inbox"],
+  },
+  t3: {
+    subject: "Your Thrive Market order shipped",
+    gmail_url: "https://mail.google.com/mail/u/0/#all/t3",
+    current_label_names: ["Inbox", "Receipts"],
+  },
+  t4: {
+    subject: "This week in your neighborhood",
+    gmail_url: "https://mail.google.com/mail/u/0/#all/t4",
+    current_label_names: ["Inbox", "Newsletters"],
+  },
+};
+
+// Every implemented tool-call preview, for the `previews` gallery scene (harness.tsx renders
+// each in both compact and detailed). Real server ids + tool names so the registry dispatches
+// to each widget; the final entry has no widget, exercising the raw-JSON fallback.
+export const PREVIEW_SAMPLES: { serverId: string; toolName: string; args: Record<string, unknown> }[] = [
+  {
+    serverId: "grocy-sf",
+    toolName: "stock_add",
+    args: {
+      items: [
+        { product: "Rolled oats", amount: 2, qu: "pack", location: "Pantry", best_before_date: "2026-12-01" },
+        { product: "Almond butter", amount: 1, qu: "jar", location: "Pantry" },
+        { product: "Frozen berries", amount: 3, qu: "bag", location: "Freezer" },
+        { product: "Oat milk", amount: 6, qu: "carton", location: "Fridge" },
+        { product: "Dark chocolate", amount: 4, qu: "bar", location: "Pantry" },
+      ],
+    },
+  },
+  {
+    serverId: "grocy-sf",
+    toolName: "stock_consume",
+    args: {
+      items: [
+        { product: "Milk", amount: 1, qu: "carton", location: "Fridge", spoiled: true },
+        { product: "Spinach", amount: 200, qu: "gram", location: "Fridge" },
+      ],
+    },
+  },
+  {
+    serverId: "grocy-sf",
+    toolName: "products_create",
+    args: {
+      items: [
+        {
+          name: "Rolled oats",
+          stock_qu: "gram",
+          location: "Pantry",
+          default_best_before_days: 270,
+          min_stock_amount: 500,
+          product_group: "Grains",
+          description: "Organic thick-cut oats.",
+        },
+        { name: "Almond butter", stock_qu: "jar", location: "Pantry", default_best_before_days: 180 },
+      ],
+    },
+  },
+  {
+    serverId: "google",
+    toolName: "create_calendar_event",
+    args: {
+      summary: "Dentist appointment",
+      start: { date_time: "2026-07-12T09:00:00", time_zone: "America/Los_Angeles" },
+      end: { date_time: "2026-07-12T10:00:00", time_zone: "America/Los_Angeles" },
+      location: "123 Market St, San Francisco",
+      description: "Routine cleaning and checkup.",
+      reminders: [{ method: "popup", minutes_before_start: 30 }],
+      attendees: ["dentist@example.com"],
+    },
+  },
+  {
+    serverId: "google",
+    toolName: "batch_modify_gmail_thread_labels",
+    args: { thread_ids: ["t1", "t2", "t3", "t4"], add: ["Follow up"], remove: ["Inbox"] },
+  },
+  {
+    serverId: "google",
+    toolName: "create_gmail_draft",
+    args: {
+      to: ["ops@allegedly.works"],
+      cc: ["rai@allegedly.works"],
+      subject: "Re: Q3 planning",
+      body: "Hi team,\n\nThanks for the notes. A few thoughts on the roadmap:\n- Ship the console settings page\n- Then the previews gallery\n- Circle back on datetime formatting\n\nBest,\nRai",
+      thread_id: "thread-42",
+    },
+  },
+  {
+    serverId: "kubectl-passthrough-mcp",
+    toolName: "resources_create_or_update",
+    args: {
+      resource:
+        "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: worker\n  namespace: haku-sandbox\nspec:\n  replicas: 3\n  selector:\n    matchLabels:\n      app: worker\n  template:\n    metadata:\n      labels:\n        app: worker\n    spec:\n      containers:\n        - name: worker\n          image: ghcr.io/agentydragon/worker:latest",
+    },
+  },
+  {
+    serverId: "kubectl-passthrough-mcp",
+    toolName: "resources_delete",
+    args: { apiVersion: "v1", kind: "Pod", name: "worker-6f9c2", namespace: "haku-sandbox", gracePeriodSeconds: 0 },
+  },
+  {
+    serverId: "kubectl-passthrough-mcp",
+    toolName: "pods_delete",
+    args: { name: "worker-6f9c2", namespace: "haku-sandbox" },
+  },
+  {
+    // No widget for this (server, tool) — the generic raw-JSON fallback (compact clamps).
+    serverId: "grocy-sf",
+    toolName: "shopping_list_items_remove",
+    args: { ids: [3, 7, 12, 15, 21, 34, 42, 55] },
+  },
+];

--- a/haku/console/tools/google.py
+++ b/haku/console/tools/google.py
@@ -38,6 +38,7 @@ from haku.console.tools.google_gmail import (
     CreateGmailDraftResult,
     GmailThreadPreviewsResponse,
     GmailToolsClient,
+    preview_gmail_threads,
 )
 
 GOOGLE_SERVER_ID = "google"
@@ -165,7 +166,7 @@ async def gmail_thread_previews(
     `batch_modify_gmail_thread_labels` approval — the tool call itself only carries thread
     IDs, so the approval UI resolves display text here rather than trusting caller-supplied
     text it can't verify. A plain HTTP read, not an MCP tool — outside `build_mcp`'s surface."""
-    return GmailThreadPreviewsResponse(threads=gmail.preview_threads(thread_id))
+    return GmailThreadPreviewsResponse(threads=preview_gmail_threads(gmail.service, thread_id))
 
 
 class GoogleToolArgumentExamples(BaseModel):

--- a/haku/console/tools/google_gmail.py
+++ b/haku/console/tools/google_gmail.py
@@ -81,10 +81,12 @@ class GmailThreadPreviewsResponse(BaseModel):
 
 
 class GmailToolsClient:
-    """Batch label modify + draft creation + thread preview, over a raw Gmail service."""
+    """The `google` server's Gmail tool operations (batch label modify + draft creation) over
+    a raw Gmail service. Thread previews are a rendering-support read, not a tool op — see the
+    module-level `preview_gmail_threads`, composed from the same lower-level service."""
 
     def __init__(self, service: Any) -> None:
-        self._service = service
+        self.service = service
         self._backend = GmailLabelBackend(service)
 
     def _user_labels(self) -> list[GmailLabel]:
@@ -118,27 +120,32 @@ class GmailToolsClient:
         body: dict[str, Any] = {"message": {"raw": raw}}
         if args.thread_id:
             body["message"]["threadId"] = args.thread_id
-        draft = self._service.users().drafts().create(userId="me", body=body).execute()
+        draft = self.service.users().drafts().create(userId="me", body=body).execute()
         return CreateGmailDraftResult(draft_id=draft["id"], message_id=draft["message"]["id"])
 
-    def preview_threads(self, thread_ids: list[str]) -> dict[str, GmailThreadPreview]:
-        id_by_name = {label.id: label.name for label in self._backend.list_labels()}
-        previews: dict[str, GmailThreadPreview] = {}
 
-        def record(thread_id: str, response: dict[str, Any] | None, exception: Exception | None) -> None:
-            if exception is not None or response is None:
-                return
-            previews[thread_id] = _preview_from_thread(thread_id, response, id_by_name)
+def preview_gmail_threads(service: Any, thread_ids: list[str]) -> dict[str, GmailThreadPreview]:
+    """Subject/snippet/current-labels for a batch of threads, for rendering a pending or past
+    `batch_modify_gmail_thread_labels` approval. Composed from lower-level Gmail reads — a
+    batched `threads().get(format=metadata)` plus a label id→name lookup — not a tool the agent
+    invokes, so it's a free function over the raw service rather than a `GmailToolsClient` method.
+    A thread absent from the returned map was inaccessible (deleted, wrong account, …)."""
+    id_by_name = {label.id: label.name for label in GmailLabelBackend(service).list_labels()}
+    previews: dict[str, GmailThreadPreview] = {}
 
-        for chunk in batched(thread_ids, _MAX_PREVIEW_BATCH_SIZE, strict=False):
-            batch_request = self._service.new_batch_http_request(callback=record)
-            for thread_id in chunk:
-                batch_request.add(
-                    self._service.users().threads().get(userId="me", id=thread_id, format="metadata"),
-                    request_id=thread_id,
-                )
-            batch_request.execute()
-        return previews
+    def record(thread_id: str, response: dict[str, Any] | None, exception: Exception | None) -> None:
+        if exception is not None or response is None:
+            return
+        previews[thread_id] = _preview_from_thread(thread_id, response, id_by_name)
+
+    for chunk in batched(thread_ids, _MAX_PREVIEW_BATCH_SIZE, strict=False):
+        batch_request = service.new_batch_http_request(callback=record)
+        for thread_id in chunk:
+            batch_request.add(
+                service.users().threads().get(userId="me", id=thread_id, format="metadata"), request_id=thread_id
+            )
+        batch_request.execute()
+    return previews
 
 
 def _preview_from_thread(

--- a/haku/console/tools/test_google.py
+++ b/haku/console/tools/test_google.py
@@ -1,7 +1,7 @@
 """Tests for the `google` in-process MCP server (build_mcp) and the thread-previews
 router endpoint."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest_bazel
 from fastmcp import Client
@@ -88,15 +88,19 @@ def test_gmail_thread_previews_endpoint_503s_when_unconfigured(make_client) -> N
         assert resp.status_code == 503
 
 
-def test_gmail_thread_previews_endpoint_returns_preview(make_client) -> None:
-    gmail = Mock()
-    gmail.preview_threads.return_value = {
+def test_gmail_thread_previews_endpoint_composes_preview_over_the_client_service(make_client) -> None:
+    previews = {
         "t1": GmailThreadPreview(subject="Test", snippet="hi", current_label_names=["haku/x"], gmail_url="https://x/t1")
     }
-    with make_client(google_gmail_client=gmail) as client:
+    gmail = Mock()  # non-None so the endpoint doesn't 503; its .service is handed to the reader
+    with (
+        patch("haku.console.tools.google.preview_gmail_threads", return_value=previews) as preview_mock,
+        make_client(google_gmail_client=gmail) as client,
+    ):
         resp = client.get("/api/google/gmail/thread-previews", params={"thread_id": ["t1"]})
-        assert resp.status_code == 200
-        assert resp.json()["threads"]["t1"]["subject"] == "Test"
+    assert resp.status_code == 200
+    assert resp.json()["threads"]["t1"]["subject"] == "Test"
+    preview_mock.assert_called_once_with(gmail.service, ["t1"])
 
 
 if __name__ == "__main__":

--- a/haku/console/tools/test_google_gmail.py
+++ b/haku/console/tools/test_google_gmail.py
@@ -1,4 +1,5 @@
-"""Tests for GmailToolsClient over a fake googleapiclient-shaped Gmail service."""
+"""Tests for GmailToolsClient and preview_gmail_threads over a fake googleapiclient-shaped
+Gmail service."""
 
 import base64
 from dataclasses import dataclass, field
@@ -12,6 +13,7 @@ from haku.console.tools.google_gmail import (
     CreateGmailDraftArgs,
     GmailLabelRef,
     GmailToolsClient,
+    preview_gmail_threads,
 )
 
 
@@ -200,8 +202,7 @@ def test_preview_threads_extracts_subject_snippet_and_labels(service: _FakeGmail
             }
         ]
     }
-    client = GmailToolsClient(service)
-    previews = client.preview_threads(["t1", "missing"])
+    previews = preview_gmail_threads(service, ["t1", "missing"])
     assert previews.keys() == {"t1"}  # "missing" has no response -> omitted
     preview = previews["t1"]
     assert preview.subject == "Test subject"
@@ -214,8 +215,7 @@ def test_preview_threads_subject_is_none_not_a_placeholder_string(service: _Fake
     # Whether/how a missing Subject renders (e.g. "(no subject)") is a frontend
     # decision; the backend passes through the raw absence.
     service.thread_responses["t1"] = {"messages": [{"snippet": "", "labelIds": [], "payload": {"headers": []}}]}
-    client = GmailToolsClient(service)
-    assert client.preview_threads(["t1"])["t1"].subject is None
+    assert preview_gmail_threads(service, ["t1"])["t1"].subject is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two related tool-preview improvements.

## `previews` gallery screenshot scene

A new screenshot scene renders **every implemented tool-call preview in both compact and detailed**, side by side — so a single glance covers the whole widget surface:

- grocy `stock_add` / `stock_consume` / `products_create`
- google `create_calendar_event` / `batch_modify_gmail_thread_labels` / `create_gmail_draft`
- kubectl `resources_create_or_update` / `resources_delete` / `pods_delete`
- the generic raw-JSON fallback (a tool with no widget)

`PREVIEW_SAMPLES` (real server ids + tool names, so the registry dispatches to each widget) lives in `screenshots/sample_data.ts`; `mock_api` serves the grocy-reference and gmail-thread-preview reads the widgets fetch. `frontend/AGENTS.md` now points here when you add or change a widget.

## `preview_gmail_threads` off the tools client

`GmailToolsClient.preview_threads` moves to a module-level `preview_gmail_threads(service, thread_ids)`. It's a rendering-support read — a batched `threads().get(format=metadata)` plus a label id→name lookup — not a tool the agent invokes, so it doesn't belong alongside the client's actual tool operations (`batch_modify_thread_labels`, `create_draft`). It's now composed from the raw Gmail service directly; the thread-previews endpoint calls it over the client's now-public `service`.

## Test

`bbr test //haku/console/tools:{test_google,test_google_gmail} //haku/console/frontend:{tsc_test,screenshots,bundle}` — all green on RBE. The endpoint test asserts it composes `preview_gmail_threads(gmail.service, ids)`; the free function keeps its own subject/snippet/label coverage. Eyeballed the `previews` gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5PSCrFPzAn61Yqr2hZE9a

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5PSCrFPzAn61Yqr2hZE9a)_