### PR TITLE
haku/console: consistent, space-frugal tool-call rendering

### DIFF
--- a/haku/console/frontend/AGENTS.md
+++ b/haku/console/frontend/AGENTS.md
@@ -11,9 +11,11 @@ screenshots before handing off:
 bbr test //haku/console/frontend:screenshots
 ```
 
-It renders each surface (`screenshots/harness.tsx`) to a PNG (one per scene: `history`,
-`drawer`, `settings`, `previews`, `controls`) in the test's **undeclared outputs**. Browser
-rendering runs on the RBE worker, so this is a `bbr` test, not a local `bb run`. Fetch the PNGs
+It renders each surface (`screenshots/harness.tsx`) to a PNG (one per scene: `history` — its
+first rows expanded into their detailed state with the Metadata disclosure open, the rest left
+compact — `drawer`, `settings`, `previews`, `controls`) in the test's **undeclared outputs**.
+Browser rendering runs on the RBE worker, so this is a `bbr` test, not a local `bb run`. Fetch
+the PNGs
 with the `buildbuddy_api` skill (download the target's undeclared test outputs), then open every
 one and actually check it looks good — spacing, alignment, contrast, truncation, that nothing
 overflows or collides, and that both content and chrome read clearly — not merely that it
@@ -25,3 +27,54 @@ both compact and detailed — when you add or change a per-server widget (`tool_
 add its (server, tool, sample args) to `PREVIEW_SAMPLES` in `screenshots/sample_data.ts` and
 re-check the gallery. Add a whole new scene to `screenshots/harness.tsx` (and the `SCENES` list
 in `screenshots/render.mjs`) whenever you add a new surface.
+
+## Tool-call rendering — design requirements
+
+A tool call shows up in two places — the approval **drawer** cards (`console_panel.tsx`) and
+the **history** rows (`tool_calls_page.tsx`) — and each renders at one of two variants,
+**compact** or **detailed**, flipped per item by its `Details` toggle. The argument body is
+drawn by a per-server **preview widget** (`tool_previews/`), or the generic raw-JSON fallback
+(`tool_arguments_field.tsx`). Hold all of it to these rules so the whole surface reads as one
+thing.
+
+**Compact is for skimming.** A compact rendering answers "what is this, and do I need to look
+closer?" at a glance — nothing more. Show the action, its primary target(s), and just enough
+payload to recognize the call: the first few list items then `… +N more`, the first lines of a
+body, the couple of fields that matter. Omit provenance, secondary attributes, and raw JSON. If
+a compact card makes you expand it in the _common_ case it's showing too little; if it wraps
+well past a few lines it's showing too much.
+
+**Detailed is complete, but ranked.** Detailed shows every argument, ordered by importance,
+with the rarely-useful parts folded away:
+
+- The raw JSON is always available behind a **`Raw arguments`** disclosure — never inline once
+  a widget rendered.
+- Provenance that isn't about _what the call does_ — the **caller principal**, the **exact
+  timestamp**, the **tool-call id** — goes behind one **`Metadata`** disclosure, not inline.
+- What the call does and why — arguments, rationale, denial reason, result — stays visible.
+
+**Don't waste vertical space.**
+
+- Lead with the call's own identity as a heading (event summary, draft subject, delete target),
+  not a labelled field.
+- Use inline icon fields (`Field icon={…}`) for short labelled values; never a stacked
+  uppercase label + line break for a two-word value.
+- Collapse pairs and ranges onto one line (a start–end becomes one range; add/remove labels sit
+  together).
+- One idea per line.
+
+**Consistent vocabulary.**
+
+- The **action** is a colored `Badge` — green create/add, red destructive/remove/deny,
+  blue/gray neutral.
+- **Identity / target** is bold; secondary attributes are dimmed inline text or small outline
+  badges.
+- **Icons** replace labels only where the glyph is unambiguous (🕐 time, 📍 place, 👥 people);
+  otherwise a short inline label.
+- **Semantic color is not the accent** — reserve red for genuinely destructive or failed states.
+
+**Datetimes and durations** use the shared concise forms (relative when near, drop the
+redundant, full value on hover) — tracked in `frontend/TODO.md`.
+
+When you add or change any rendering, put it (both variants) in the `previews` gallery and check
+it against this list.

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -158,6 +158,26 @@ js_library(
 )
 
 js_library(
+    name = "tool_call_meta",
+    srcs = ["tool_call_meta.tsx"],
+    deps = [
+        ":approval_state",
+        ":field",
+        "//:node_modules/react",
+    ],
+)
+
+js_library(
+    name = "pending_tool_call_actions",
+    srcs = ["pending_tool_call_actions.tsx"],
+    deps = [
+        ":theme",
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+    ],
+)
+
+js_library(
     name = "variant_toggle",
     srcs = ["variant_toggle.tsx"],
     deps = [
@@ -175,8 +195,10 @@ js_library(
         ":client",
         ":field",
         ":icons",
+        ":pending_tool_call_actions",
         ":theme",
         ":tool_arguments_field",
+        ":tool_call_meta",
         ":variant_toggle",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
@@ -191,10 +213,11 @@ js_library(
         ":client",
         ":field",
         ":icons",
-        ":theme",
+        ":pending_tool_call_actions",
         ":toast",
         ":tool_arguments_field",
         ":tool_call_events",
+        ":tool_call_meta",
         ":variant_toggle",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
@@ -281,11 +304,13 @@ filegroup(
         "index.html",
         "main.tsx",
         "open_external.ts",
+        "pending_tool_call_actions.tsx",
         "routing.ts",
         "settings_page.tsx",
         "theme.ts",
         "toast.ts",
         "tool_arguments_field.tsx",
+        "tool_call_meta.tsx",
         "tool_calls_page.tsx",
         "variant_toggle.tsx",
         "//haku/console/frontend/tool_previews:tailwind_srcs",

--- a/haku/console/frontend/TODO.md
+++ b/haku/console/frontend/TODO.md
@@ -1,8 +1,13 @@
 # haku/console/frontend TODO
 
-- Render datetimes and durations more concisely yet human-readably across the previews.
-  Today it's scattered: `shortDate` (approval_state.ts) dumps a full locale date+time, and
-  `formatEventDateTime` (tool_previews/google_calendar.tsx) formats all-day dates but still
-  echoes the raw ISO string for timed events. Want relative/short forms ("in 2h",
-  "tomorrow 9am", "Jul 12") with the absolute value on hover, shared by every widget and
-  both preview variants, rather than each field spelling its own format.
+- Unify the action/identity header across registered and unregistered tools. A widget's
+  `ActionBadge` (e.g. grocy's "Remove stock") largely restates the `serverId.toolName` the card
+  header already shows. Want one treatment: a registered tool draws its own custom identity
+  header; an unregistered one renders `serverId.toolName` in the _same_ styling — so the header
+  reads consistently either way instead of the widget duplicating the tool name.
+
+- Let the pending tool-call note (`pending_tool_call_actions.tsx`) ride an **approve**, not just
+  a deny — a general operator remark, not only a denial reason. The agent can already read
+  decision notes back from the tool-call result DB, so this is mostly: persist a reason on the
+  approve path of the decision endpoint (`mcp_approval.py`) and give the field a neutral
+  placeholder when it applies to both outcomes.

--- a/haku/console/frontend/approval_state.ts
+++ b/haku/console/frontend/approval_state.ts
@@ -141,6 +141,33 @@ export function shortDate(value: string | null | undefined): string | null {
   return new Date(value).toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
 }
 
+const _ABS_DATETIME = new Intl.DateTimeFormat([], { dateStyle: "medium", timeStyle: "short" });
+const _TIME = new Intl.DateTimeFormat([], { hour: "numeric", minute: "2-digit" });
+const _MONTH_DAY = new Intl.DateTimeFormat([], { month: "short", day: "numeric" });
+const _MONTH_DAY_YEAR = new Intl.DateTimeFormat([], { month: "short", day: "numeric", year: "numeric" });
+
+const _MINUTE = 60_000;
+const _HOUR = 60 * _MINUTE;
+const _DAY = 24 * _HOUR;
+
+/** A timestamp in a concise, human-readable form (relative when near — "2h ago", "in 30 min",
+ * "yesterday 2:32 PM" — a short date otherwise) with the full locale date+time as `title` for
+ * the element's tooltip. Shared by every card's Requested/Metadata field so they read one way. */
+export function formatTimestamp(value: string, nowMs: number = Date.now()): { text: string; title: string } {
+  const d = new Date(value);
+  const title = _ABS_DATETIME.format(d);
+  const diffMs = d.getTime() - nowMs; // >0 future, <0 past
+  const absMs = Math.abs(diffMs);
+  const ago = (near: string): string => (diffMs < 0 ? `${near} ago` : `in ${near}`);
+  if (absMs < _MINUTE) return { text: "just now", title };
+  if (absMs < _HOUR) return { text: ago(`${Math.round(absMs / _MINUTE)} min`), title };
+  if (absMs < _DAY) return { text: ago(`${Math.round(absMs / _HOUR)}h`), title };
+  if (absMs < 2 * _DAY) return { text: `${diffMs < 0 ? "yesterday" : "tomorrow"} ${_TIME.format(d)}`, title };
+  if (absMs < 7 * _DAY) return { text: ago(`${Math.round(absMs / _DAY)} days`), title };
+  const sameYear = d.getFullYear() === new Date(nowMs).getFullYear();
+  return { text: (sameYear ? _MONTH_DAY : _MONTH_DAY_YEAR).format(d), title };
+}
+
 export function geolocationApprovalTitle(approval: GeolocationApproval): string {
   return approval.mode === "geolocationWatch" ? "Allow continuous location sharing?" : "Allow location sharing?";
 }

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -1,13 +1,13 @@
-import { ActionIcon, Badge, Button, Group, Indicator, Popover, Stack, Text, Textarea } from "@mantine/core";
+import { ActionIcon, Badge, Button, Group, Indicator, Popover, Stack, Text } from "@mantine/core";
 import { useEffect, useMemo, useState } from "react";
 
 import {
   approvalDisplayFields,
   approvalQueueItems,
+  formatTimestamp,
   geolocationApprovalBody,
   geolocationApprovalTitle,
   recentToolCallCountdown,
-  shortDate,
   statusColor,
   type GeolocationApproval,
   type RecentToolCall,
@@ -16,8 +16,10 @@ import {
 import type { PendingApproval } from "./client.ts";
 import { Field } from "./field.tsx";
 import { HistoryIcon, MapPinIcon, MenuIcon, SettingsIcon } from "./icons.tsx";
+import { PendingToolCallActions } from "./pending_tool_call_actions.tsx";
 import { ACTION_COLOR } from "./theme.ts";
 import { ToolArgumentsField } from "./tool_arguments_field.tsx";
+import { ToolCallMeta } from "./tool_call_meta.tsx";
 import { useVariant, VariantToggle } from "./variant_toggle.tsx";
 
 export interface ShellDrawerProps {
@@ -190,7 +192,6 @@ function ToolApprovalCard({
   const [variant, toggleVariant] = useVariant("compact");
   const fields = approvalDisplayFields(approval);
   const armed = useArmed(`card:${approval.tool_call_id}`);
-  const [denyReason, setDenyReason] = useState("");
   const detailed = variant === "detailed";
   return (
     <section className="haku-shell-card">
@@ -220,45 +221,13 @@ function ToolApprovalCard({
           variant={variant}
         />
         {detailed && (
-          <dl className="haku-shell-fields">
-            {(fields.callerPrincipal || fields.createdAt) && (
-              <Field label="Requested">
-                {[fields.callerPrincipal, shortDate(fields.createdAt)].filter(Boolean).join(" · ")}
-              </Field>
-            )}
-            <details className="haku-shell-disclosure">
-              <summary>Tool call id</summary>
-              <code>{fields.toolCallId}</code>
-            </details>
-          </dl>
-        )}
-        <div>
-          <Textarea
-            size="xs"
-            label="Denial reason (optional)"
-            placeholder="Why are you denying this?"
-            autosize
-            minRows={1}
-            maxRows={4}
-            disabled={deciding}
-            value={denyReason}
-            onChange={(e) => setDenyReason(e.currentTarget.value)}
+          <ToolCallMeta
+            callerPrincipal={fields.callerPrincipal}
+            createdAt={fields.createdAt}
+            toolCallId={fields.toolCallId}
           />
-          <Group justify="flex-end" gap="xs" mt="xs">
-            <Button
-              size="compact-xs"
-              variant="light"
-              color="red"
-              disabled={deciding || !armed}
-              onClick={() => onDeny(denyReason.trim() || undefined)}
-            >
-              Deny
-            </Button>
-            <Button size="compact-xs" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
-              Approve
-            </Button>
-          </Group>
-        </div>
+        )}
+        <PendingToolCallActions busy={deciding} armed={armed} onApprove={onApprove} onDeny={onDeny} />
       </Stack>
     </section>
   );
@@ -278,6 +247,7 @@ function GeolocationApprovalCard({
   const [variant, toggleVariant] = useVariant("compact");
   const armed = useArmed(`geo-card:${approval.id}`);
   const detailed = variant === "detailed";
+  const requested = formatTimestamp(approval.createdAt);
   return (
     <section className="haku-shell-card">
       <Stack gap="sm">
@@ -299,8 +269,10 @@ function GeolocationApprovalCard({
           </Group>
         </Group>
         {detailed && (
-          <dl className="haku-shell-fields">
-            <Field label="Requested">{shortDate(approval.createdAt)}</Field>
+          <div className="haku-shell-fields">
+            <Field label="Requested">
+              <span title={requested.title}>{requested.text}</span>
+            </Field>
             {approval.options && (
               <Field label="Options">
                 <pre className="haku-shell-json">{JSON.stringify(approval.options, null, 2)}</pre>
@@ -310,13 +282,13 @@ function GeolocationApprovalCard({
               <summary>Bridge request id</summary>
               <code>{approval.id}</code>
             </details>
-          </dl>
+          </div>
         )}
         <Group justify="flex-end" gap="xs">
-          <Button size="compact-xs" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
+          <Button size="compact-sm" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
             Deny
           </Button>
-          <Button size="compact-xs" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
+          <Button size="compact-sm" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
             Approve
           </Button>
         </Group>
@@ -375,17 +347,20 @@ function RecentToolCallCard({
           variant={variant}
         />
         {detailed && (
-          <dl className="haku-shell-fields">
+          <>
             {record.result && (
-              <Field label="Result">
-                <pre className="haku-shell-json">{JSON.stringify(record.result, null, 2)}</pre>
-              </Field>
+              <div className="haku-shell-fields">
+                <Field label="Result">
+                  <pre className="haku-shell-json">{JSON.stringify(record.result, null, 2)}</pre>
+                </Field>
+              </div>
             )}
-            <details className="haku-shell-disclosure">
-              <summary>Tool call id</summary>
-              <code>{fields.toolCallId}</code>
-            </details>
-          </dl>
+            <ToolCallMeta
+              callerPrincipal={fields.callerPrincipal}
+              createdAt={fields.createdAt}
+              toolCallId={fields.toolCallId}
+            />
+          </>
         )}
         <RecentCountdown recent={recent} nowMs={nowMs} />
         <Group justify="flex-end" gap="xs">

--- a/haku/console/frontend/field.tsx
+++ b/haku/console/frontend/field.tsx
@@ -1,10 +1,30 @@
 import type { ReactNode } from "react";
 
-export function Field({ label, children, mono = false }: { label: string; children: ReactNode; mono?: boolean }) {
+/** A labelled value in a preview/detail view. Both forms share one wrapper and value element —
+ * only the label differs: the default stacks a small uppercase text label over the value, while
+ * passing `icon` swaps that label for an inline icon on the value's own row (the label rides
+ * along as the icon's tooltip/aria-label), saving the whole label row for short values. */
+export function Field({
+  label,
+  children,
+  mono = false,
+  icon,
+}: {
+  label: string;
+  children: ReactNode;
+  mono?: boolean;
+  icon?: ReactNode;
+}) {
   return (
-    <div className="haku-shell-field">
-      <dt>{label}</dt>
-      <dd className={mono ? "haku-shell-mono" : ""}>{children}</dd>
+    <div className={`haku-shell-field ${icon ? "haku-shell-field-inline" : ""}`}>
+      {icon ? (
+        <span className="haku-shell-field-icon" role="img" aria-label={label} title={label}>
+          {icon}
+        </span>
+      ) : (
+        <span className="haku-shell-field-label">{label}</span>
+      )}
+      <div className={`haku-shell-field-value ${mono ? "haku-shell-mono" : ""}`}>{children}</div>
     </div>
   );
 }

--- a/haku/console/frontend/icons.tsx
+++ b/haku/console/frontend/icons.tsx
@@ -3,10 +3,15 @@
 // `.mjs` subpaths come from the ambient declaration in `tabler_icons.d.ts`. Thin wrappers keep a
 // stable local name + a consistent glyph size; callers can still override via props.
 import IconArrowLeft from "@tabler/icons-react/dist/esm/icons/IconArrowLeft.mjs";
+import IconBell from "@tabler/icons-react/dist/esm/icons/IconBell.mjs";
+import IconCalendarEvent from "@tabler/icons-react/dist/esm/icons/IconCalendarEvent.mjs";
+import IconClock from "@tabler/icons-react/dist/esm/icons/IconClock.mjs";
 import IconHistory from "@tabler/icons-react/dist/esm/icons/IconHistory.mjs";
+import IconMail from "@tabler/icons-react/dist/esm/icons/IconMail.mjs";
 import IconMapPin from "@tabler/icons-react/dist/esm/icons/IconMapPin.mjs";
 import IconMenu2 from "@tabler/icons-react/dist/esm/icons/IconMenu2.mjs";
 import IconSettings from "@tabler/icons-react/dist/esm/icons/IconSettings.mjs";
+import IconUsers from "@tabler/icons-react/dist/esm/icons/IconUsers.mjs";
 import type { ComponentProps } from "react";
 
 type TablerIconProps = ComponentProps<typeof IconMenu2>;
@@ -31,7 +36,32 @@ export function SettingsIcon(props: TablerIconProps) {
   return <IconSettings size={20} {...props} />;
 }
 
-/** Map pin — the shell's location-sharing control. */
+/** Map pin — the shell's location-sharing control, and a preview's location field. */
 export function MapPinIcon(props: TablerIconProps) {
   return <IconMapPin size={20} {...props} />;
+}
+
+/** Clock — a calendar event's when/time field. */
+export function ClockIcon(props: TablerIconProps) {
+  return <IconClock size={20} {...props} />;
+}
+
+/** Bell — a calendar event's reminders field. */
+export function BellIcon(props: TablerIconProps) {
+  return <IconBell size={20} {...props} />;
+}
+
+/** People — a calendar event's attendees field. */
+export function UsersIcon(props: TablerIconProps) {
+  return <IconUsers size={20} {...props} />;
+}
+
+/** Calendar — a non-primary target calendar. */
+export function CalendarIcon(props: TablerIconProps) {
+  return <IconCalendarEvent size={20} {...props} />;
+}
+
+/** Envelope — a Gmail draft's recipients / a thread list. */
+export function MailIcon(props: TablerIconProps) {
+  return <IconMail size={20} {...props} />;
 }

--- a/haku/console/frontend/pending_tool_call_actions.tsx
+++ b/haku/console/frontend/pending_tool_call_actions.tsx
@@ -1,0 +1,57 @@
+import { Button, Group, Textarea } from "@mantine/core";
+import { useState } from "react";
+
+import { ACTION_COLOR } from "./theme.ts";
+
+// The approve/deny control for a pending tool call, shared by the drawer approval card and the
+// history row so both spell it one way. The optional free-text reason sits to the LEFT of the
+// buttons on one row, its purpose carried by the placeholder rather than a stacked label.
+//
+// TODO(remarks-on-approve): let the same note ride an *approve* too, not only a deny — a general
+// operator remark the agent can read back from the tool-call result DB. Needs the decision
+// endpoint to persist a reason on approve (mcp_approval.py) and a neutral placeholder here.
+export function PendingToolCallActions({
+  busy,
+  // The drawer arms its buttons after a short delay to guard against a misclick on a card that
+  // just appeared; the history page has no such delay, so it defaults to armed.
+  armed = true,
+  onApprove,
+  onDeny,
+}: {
+  busy: boolean;
+  armed?: boolean;
+  onApprove: () => void;
+  onDeny: (reason?: string) => void;
+}) {
+  const [reason, setReason] = useState("");
+  const disabled = busy || !armed;
+  return (
+    <Group gap="xs" align="flex-end" wrap="nowrap">
+      <Textarea
+        size="xs"
+        placeholder="Denial reason (optional)"
+        aria-label="Denial reason"
+        autosize
+        minRows={1}
+        maxRows={4}
+        disabled={busy}
+        value={reason}
+        onChange={(e) => setReason(e.currentTarget.value)}
+        style={{ flex: 1 }}
+      />
+      <Button
+        size="compact-sm"
+        variant="light"
+        color="red"
+        loading={busy}
+        disabled={disabled}
+        onClick={() => onDeny(reason.trim() || undefined)}
+      >
+        Deny
+      </Button>
+      <Button size="compact-sm" color={ACTION_COLOR} loading={busy} disabled={disabled} onClick={onApprove}>
+        Approve
+      </Button>
+    </Group>
+  );
+}

--- a/haku/console/frontend/screenshots/harness.tsx
+++ b/haku/console/frontend/screenshots/harness.tsx
@@ -98,6 +98,8 @@ function sceneElement(scene: string) {
       return <ShellDrawer {...drawerProps} />;
     case "previews":
       return <PreviewGallery />;
+    // The history page; render.mjs expands its first rows into their detailed state (opening the
+    // Metadata disclosure) with a click sequence, so one shot shows both compact and detailed rows.
     default:
       return <ToolCallsPage onBack={noop} />;
   }

--- a/haku/console/frontend/screenshots/render.mjs
+++ b/haku/console/frontend/screenshots/render.mjs
@@ -19,7 +19,15 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 // viewport screenshot — not an #app element shot — is what captures them. Each scene is a
 // separate page load driven by window.__SCENE__ (see harness.tsx).
 const SCENES = [
-  { name: "history", viewport: { width: 1200, height: 1500 } },
+  // The history page, showing both row states in one shot: expand the first row and open its
+  // Metadata disclosure, then expand the next row (whose first "Details" button the prior expand
+  // walked us onto) so a completed call's Result field shows too, leaving the rest compact.
+  // `::-p-text` walks each subsequent "Details" as prior rows flip their label to "Compact".
+  {
+    name: "history",
+    viewport: { width: 1200, height: 1500 },
+    clicks: ["button::-p-text(Details)", "summary::-p-text(Metadata)", "button::-p-text(Details)"],
+  },
   { name: "drawer", viewport: { width: 1200, height: 900 } },
   { name: "settings", viewport: { width: 1200, height: 900 } },
   // Every implemented tool-call preview, compact | detailed side by side — tall, so give it room.
@@ -84,7 +92,7 @@ const browser = await launchPuppeteerBrowser({
   ],
 });
 try {
-  for (const { name, viewport, click } of SCENES) {
+  for (const { name, viewport, click, clicks } of SCENES) {
     const page = await browser.newPage();
     await page.setViewport({ ...viewport, deviceScaleFactor: 2 });
     await page.emulateMediaFeatures([{ name: "prefers-reduced-motion", value: "reduce" }]);
@@ -93,10 +101,11 @@ try {
     // Let Mantine mount and layout settle, and outlast the approval buttons' 400ms arm
     // delay so they render enabled (animations are reduced above).
     await new Promise((r) => setTimeout(r, 700));
-    // Some scenes need a click to reveal a popover whose open state is internal to the
-    // component (e.g. the location-sharing control); do it, then let the dropdown settle.
-    if (click) {
-      await page.click(click);
+    // Some scenes need clicks to reveal state internal to a component: a popover's open state
+    // (location-sharing control) or history rows toggled into their detailed view.
+    // Each click re-renders the DOM, so re-settle before the next one.
+    for (const selector of clicks ?? (click ? [click] : [])) {
+      await page.click(selector);
       await new Promise((r) => setTimeout(r, 300));
     }
     const dest = join(outDir, `${name}.png`);

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -221,17 +221,12 @@
   margin: 0;
 }
 
-.haku-shell-field-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 0.65rem;
-}
-
 .haku-shell-field {
   min-width: 0;
 }
 
-.haku-shell-field dt {
+.haku-shell-field-label {
+  display: block;
   margin: 0 0 0.18rem;
   font-size: 0.72rem;
   font-weight: 700;
@@ -239,8 +234,23 @@
   text-transform: uppercase;
 }
 
-.haku-shell-field dd {
-  margin: 0;
+/* Inline (icon) form: the icon stands in for the label on the value's own line. */
+.haku-shell-field-inline {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+}
+
+.haku-shell-field-icon {
+  flex: 0 0 auto;
+  align-self: flex-start;
+  margin-top: 0.1rem;
+  color: var(--mantine-color-dimmed);
+  display: inline-flex;
+}
+
+.haku-shell-field-value {
+  min-width: 0;
   overflow-wrap: anywhere;
 }
 
@@ -276,14 +286,15 @@
   font-weight: 600;
 }
 
+/* Fields revealed under a disclosure (e.g. the Metadata block) need room below the summary. */
+.haku-shell-disclosure-body {
+  margin-top: 0.55rem;
+}
+
 @media (max-width: 520px) {
   .haku-shell-drawer {
     width: calc(100vw - 0.5rem);
     height: calc(100dvh - 0.5rem);
     margin: 0.25rem;
-  }
-
-  .haku-shell-field-grid {
-    grid-template-columns: 1fr;
   }
 }

--- a/haku/console/frontend/tabler_icons.d.ts
+++ b/haku/console/frontend/tabler_icons.d.ts
@@ -9,6 +9,31 @@ declare module "@tabler/icons-react/dist/esm/icons/IconMenu2.mjs" {
   const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
   export default Icon;
 }
+declare module "@tabler/icons-react/dist/esm/icons/IconClock.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}
+declare module "@tabler/icons-react/dist/esm/icons/IconBell.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}
+declare module "@tabler/icons-react/dist/esm/icons/IconUsers.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}
+declare module "@tabler/icons-react/dist/esm/icons/IconCalendarEvent.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}
+declare module "@tabler/icons-react/dist/esm/icons/IconMail.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}
 declare module "@tabler/icons-react/dist/esm/icons/IconHistory.mjs" {
   import type { FC, SVGProps } from "react";
   const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;

--- a/haku/console/frontend/tool_arguments_field.tsx
+++ b/haku/console/frontend/tool_arguments_field.tsx
@@ -6,11 +6,11 @@ import { clampBlock, type PreviewVariant } from "./tool_previews/variant.tsx";
 // widget); the detailed view shows it in full.
 const COMPACT_JSON_LINES = 6;
 
-/** Arguments field for a tool-call approval/result: a per-tool-type widget (the tool_previews/
- * per-server modules) when one matches, else the generic raw-JSON view. `variant` picks the
- * compact form (a scannable summary for drawer cards) or the detailed form (the expanded view,
- * which also offers the raw JSON behind a disclosure even when a custom widget rendered it).
- * Shared by the approval drawer and the past-tool-calls history view. */
+/** The arguments of a tool call: a per-tool-type widget (the tool_previews/ per-server modules)
+ * when one matches — rendered directly, since it's self-describing — else the generic raw-JSON
+ * view, which keeps an "Arguments" label so it isn't mistaken for a result. `variant` picks the
+ * compact (skim) or detailed form; detailed always offers the raw JSON behind a disclosure even
+ * when a widget rendered. Shared by the approval drawer and the past-tool-calls history view. */
 export function ToolArgumentsField({
   serverId,
   toolName,
@@ -25,21 +25,24 @@ export function ToolArgumentsField({
   variant: PreviewVariant;
 }) {
   const nice = toolPreview(serverId, toolName, args, variant);
-  return (
-    <Field label="Arguments">
-      {nice ?? (
+  if (!nice) {
+    return (
+      <Field label="Arguments">
         <pre className="haku-shell-json">
           {variant === "compact" ? clampBlock(argumentsJson, COMPACT_JSON_LINES) : argumentsJson}
         </pre>
-      )}
-      {/* When a custom widget rendered, the detailed view still offers the raw JSON behind a
-          disclosure; the raw-JSON fallback above already is the JSON, so it needs none. */}
-      {nice && variant === "detailed" && (
+      </Field>
+    );
+  }
+  return (
+    <>
+      {nice}
+      {variant === "detailed" && (
         <details className="haku-shell-disclosure">
           <summary>Raw arguments</summary>
           <pre className="haku-shell-json">{argumentsJson}</pre>
         </details>
       )}
-    </Field>
+    </>
   );
 }

--- a/haku/console/frontend/tool_call_meta.tsx
+++ b/haku/console/frontend/tool_call_meta.tsx
@@ -1,0 +1,34 @@
+import { formatTimestamp } from "./approval_state.ts";
+import { Field } from "./field.tsx";
+
+/** The provenance a tool call carries that isn't about *what it does* — who asked, the exact
+ * request time, and the canonical id. Rarely needed while triaging, so it rides behind one
+ * collapsed "Metadata" disclosure in the detailed drawer cards and history rows, keeping the
+ * detailed body focused on the arguments/result. */
+export function ToolCallMeta({
+  callerPrincipal,
+  createdAt,
+  toolCallId,
+}: {
+  callerPrincipal: string | null;
+  createdAt: string | null;
+  toolCallId: string;
+}) {
+  const requested = createdAt ? formatTimestamp(createdAt) : null;
+  return (
+    <details className="haku-shell-disclosure">
+      <summary>Metadata</summary>
+      <div className="haku-shell-fields haku-shell-disclosure-body">
+        {callerPrincipal && <Field label="Caller">{callerPrincipal}</Field>}
+        {requested && (
+          <Field label="Requested">
+            <span title={requested.title}>{requested.text}</span>
+          </Field>
+        )}
+        <Field label="Tool call id" mono>
+          {toolCallId}
+        </Field>
+      </div>
+    </details>
+  );
+}

--- a/haku/console/frontend/tool_calls_page.tsx
+++ b/haku/console/frontend/tool_calls_page.tsx
@@ -1,59 +1,19 @@
-import { Badge, Button, Group, Loader, Stack, Text, Textarea } from "@mantine/core";
+import { Badge, Button, Group, Loader, Stack, Text } from "@mantine/core";
 import { useCallback, useState } from "react";
 
-import { approvalDisplayFields, shortDate, statusColor, terminalStatusLabel } from "./approval_state.ts";
+import { approvalDisplayFields, statusColor, terminalStatusLabel } from "./approval_state.ts";
 import { approveToolCall, denyToolCall, fetchToolCalls, type ToolCallRecord } from "./client.ts";
 import { Field } from "./field.tsx";
 import { ArrowLeftIcon } from "./icons.tsx";
-import { ACTION_COLOR } from "./theme.ts";
+import { PendingToolCallActions } from "./pending_tool_call_actions.tsx";
 import { toastError, toastSuccess } from "./toast.ts";
 import { ToolArgumentsField } from "./tool_arguments_field.tsx";
+import { ToolCallMeta } from "./tool_call_meta.tsx";
 import { useToolCallEvents } from "./tool_call_events.ts";
 import { useVariant, VariantToggle } from "./variant_toggle.tsx";
 
 // Matches the backend's `le=500` cap on GET /api/tool-calls (mcp_approval.py).
 const HISTORY_LIMIT = 500;
-
-function PendingActions({
-  deciding,
-  onApprove,
-  onDeny,
-}: {
-  deciding: boolean;
-  onApprove: () => void;
-  onDeny: (reason?: string) => void;
-}) {
-  const [denyReason, setDenyReason] = useState("");
-  return (
-    <div>
-      <Textarea
-        size="xs"
-        label="Denial reason (optional)"
-        placeholder="Why are you denying this?"
-        autosize
-        minRows={1}
-        maxRows={4}
-        disabled={deciding}
-        value={denyReason}
-        onChange={(e) => setDenyReason(e.currentTarget.value)}
-      />
-      <Group justify="flex-end" gap="xs" mt="xs">
-        <Button
-          size="compact-sm"
-          variant="light"
-          color="red"
-          loading={deciding}
-          onClick={() => onDeny(denyReason.trim() || undefined)}
-        >
-          Deny
-        </Button>
-        <Button size="compact-sm" color={ACTION_COLOR} loading={deciding} onClick={onApprove}>
-          Approve
-        </Button>
-      </Group>
-    </div>
-  );
-}
 
 function ToolCallRow({
   record,
@@ -94,16 +54,8 @@ function ToolCallRow({
             {record.error}
           </Text>
         )}
-        <dl className="haku-shell-fields">
-          {detailed && (
-            <>
-              <div className="haku-shell-field-grid">
-                <Field label="Caller">{fields.callerPrincipal ?? "—"}</Field>
-                <Field label="Requested">{shortDate(fields.createdAt) ?? "—"}</Field>
-              </div>
-              {fields.rationale && <Field label="Rationale">{fields.rationale}</Field>}
-            </>
-          )}
+        <div className="haku-shell-fields">
+          {detailed && fields.rationale && <Field label="Rationale">{fields.rationale}</Field>}
           {fields.denialReason && <Field label="Denial reason">{fields.denialReason}</Field>}
           <ToolArgumentsField
             serverId={fields.serverId}
@@ -113,19 +65,19 @@ function ToolCallRow({
             variant={variant}
           />
           {detailed && record.result && (
-            <details className="haku-shell-disclosure">
-              <summary>Result</summary>
+            <Field label="Result">
               <pre className="haku-shell-json">{JSON.stringify(record.result, null, 2)}</pre>
-            </details>
+            </Field>
           )}
           {detailed && (
-            <details className="haku-shell-disclosure">
-              <summary>Tool call id</summary>
-              <code>{fields.toolCallId}</code>
-            </details>
+            <ToolCallMeta
+              callerPrincipal={fields.callerPrincipal}
+              createdAt={fields.createdAt}
+              toolCallId={fields.toolCallId}
+            />
           )}
-        </dl>
-        {pending && <PendingActions deciding={deciding} onApprove={onApprove} onDeny={onDeny} />}
+        </div>
+        {pending && <PendingToolCallActions busy={deciding} onApprove={onApprove} onDeny={onDeny} />}
       </Stack>
     </section>
   );

--- a/haku/console/frontend/tool_previews/BUILD.bazel
+++ b/haku/console/frontend/tool_previews/BUILD.bazel
@@ -41,6 +41,7 @@ js_library(
         "//:node_modules/zod",
         "//haku/console/frontend:field",
         "//haku/console/frontend:gmail_client",
+        "//haku/console/frontend:icons",
         "//haku/console/frontend:schema_zod",
     ],
 )
@@ -52,11 +53,11 @@ js_library(
         ":entry",
         ":variant",
         "//:node_modules/@mantine/core",
-        "//:node_modules/date-fns",
         "//:node_modules/react",
         "//:node_modules/zod",
         "//haku/console/frontend:calendar_client",
         "//haku/console/frontend:field",
+        "//haku/console/frontend:icons",
         "//haku/console/frontend:schema_zod",
     ],
 )
@@ -70,7 +71,6 @@ js_library(
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
         "//:node_modules/zod",
-        "//haku/console/frontend:field",
         "//haku/console/frontend:grocy_client",
     ],
 )
@@ -84,7 +84,6 @@ js_library(
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
         "//:node_modules/zod",
-        "//haku/console/frontend:field",
     ],
 )
 

--- a/haku/console/frontend/tool_previews/gmail.tsx
+++ b/haku/console/frontend/tool_previews/gmail.tsx
@@ -14,6 +14,7 @@ import type { z } from "zod";
 import { zBatchModifyGmailThreadLabelsArgs, zCreateGmailDraftArgs } from "../api/schema.zod.ts";
 import { Field } from "../field.tsx";
 import { fetchGmailThreadPreviews, type GmailThreadPreview } from "../gmail_client.ts";
+import { MailIcon } from "../icons.tsx";
 import { definePreview, type ToolPreview } from "./entry.tsx";
 import { COMPACT_ITEM_LIMIT, firstLines, MoreLine, type PreviewProps } from "./variant.tsx";
 
@@ -21,6 +22,12 @@ export const GMAIL_SERVER_ID = "gmail";
 
 type BatchModifyGmailThreadLabelsArgs = z.infer<typeof zBatchModifyGmailThreadLabelsArgs>;
 type CreateGmailDraftArgs = z.infer<typeof zCreateGmailDraftArgs>;
+
+// A Gmail API thread id resolves directly in the web UI's `#all/` view — the same link the
+// backend builds for thread previews (haku/console/tools/gmail.py `_THREAD_URL`).
+function gmailThreadUrl(threadId: string): string {
+  return `https://mail.google.com/mail/u/0/#all/${threadId}`;
+}
 
 function GmailThreadRow({
   threadId,
@@ -39,45 +46,39 @@ function GmailThreadRow({
     );
   }
   return (
-    <Stack gap={0}>
+    <Stack gap={2}>
       <Anchor href={preview.gmail_url} target="_blank" rel="noreferrer" size="sm">
         {preview.subject ?? "(no subject)"}
       </Anchor>
       {showLabels && preview.current_label_names.length > 0 && (
-        <Text size="xs" c="dimmed">
-          Current labels: {preview.current_label_names.join(", ")}
-        </Text>
+        <Group gap={4}>
+          {preview.current_label_names.map((name) => (
+            <Badge key={name} variant="outline" color="gray" size="sm">
+              {name}
+            </Badge>
+          ))}
+        </Group>
       )}
     </Stack>
   );
 }
 
 function ThreadLabelChanges({ args }: { args: BatchModifyGmailThreadLabelsArgs }) {
+  // One row of pills; each pill's sign + color says which way its label goes — green `+ added`,
+  // red `− removed` — so no separate "Add"/"Remove" heading is needed.
   return (
-    <>
-      {(args.add?.length ?? 0) > 0 && (
-        <Field label="Add labels">
-          <Group gap={4}>
-            {args.add?.map((name) => (
-              <Badge key={name} variant="light" color="teal">
-                {name}
-              </Badge>
-            ))}
-          </Group>
-        </Field>
-      )}
-      {(args.remove?.length ?? 0) > 0 && (
-        <Field label="Remove labels">
-          <Group gap={4}>
-            {args.remove?.map((name) => (
-              <Badge key={name} variant="light" color="red">
-                {name}
-              </Badge>
-            ))}
-          </Group>
-        </Field>
-      )}
-    </>
+    <Group gap={6} align="center">
+      {args.add?.map((name) => (
+        <Badge key={`+${name}`} variant="light" color="teal">
+          + {name}
+        </Badge>
+      ))}
+      {args.remove?.map((name) => (
+        <Badge key={`-${name}`} variant="light" color="red">
+          − {name}
+        </Badge>
+      ))}
+    </Group>
   );
 }
 
@@ -86,7 +87,7 @@ function BatchModifyGmailThreadLabelsPreview({ args, variant }: PreviewProps<Bat
   const [error, setError] = useState<string | null>(null);
 
   // Both variants fetch the thread subjects (and labels) — they're the important human-
-  // readable bit; compact just shows fewer rows and drops the current-label sublines.
+  // readable bit; compact just shows fewer rows and drops the current-label pills.
   useEffect(() => {
     let alive = true;
     setPreviews(null);
@@ -111,22 +112,22 @@ function BatchModifyGmailThreadLabelsPreview({ args, variant }: PreviewProps<Bat
   return (
     <Stack gap="xs">
       <ThreadLabelChanges args={args} />
-      <Field label={`Threads (${args.thread_ids.length})`}>
-        {error ? (
-          <Text size="sm" c="red">
-            {error}
-          </Text>
-        ) : previews === null ? (
-          <Loader size="xs" />
-        ) : (
-          <Stack gap="xs">
+      {error ? (
+        <Text size="sm" c="red">
+          {error}
+        </Text>
+      ) : previews === null ? (
+        <Loader size="xs" />
+      ) : (
+        <Field icon={<MailIcon size={15} />} label={`${args.thread_ids.length} threads`}>
+          <Stack gap={4}>
             {shownIds.map((threadId) => (
               <GmailThreadRow key={threadId} threadId={threadId} preview={previews[threadId]} showLabels={!compact} />
             ))}
             <MoreLine count={args.thread_ids.length - shownIds.length} />
           </Stack>
-        )}
-      </Field>
+        </Field>
+      )}
     </Stack>
   );
 }
@@ -142,18 +143,24 @@ function CompactBody({ body }: { body: string }) {
 }
 
 function CreateGmailDraftPreview({ args, variant }: PreviewProps<CreateGmailDraftArgs>) {
-  // Common trunk: To → Subject → Body; compact clamps the body and drops Cc/thread, detailed
-  // shows the full body plus them.
+  // Subject leads as the draft's title; recipients ride one mail-icon line (cc folded in when
+  // detailed); the body follows unlabelled — clamped compact, full detailed. A reply draft
+  // links to the thread it lands in (useful in both variants) rather than printing the raw
+  // thread id, which is noise — the link's href carries the id for anyone who needs it.
   const detailed = variant === "detailed";
   return (
-    <Stack gap="xs">
-      <Field label="To">{args.to.join(", ")}</Field>
-      {detailed && args.cc && args.cc.length > 0 && <Field label="Cc">{args.cc.join(", ")}</Field>}
-      <Field label="Subject">{args.subject}</Field>
-      <Field label="Body">
-        {detailed ? <pre className="haku-shell-json">{args.body}</pre> : <CompactBody body={args.body} />}
+    <Stack gap={6}>
+      <Text fw={600}>{args.subject}</Text>
+      <Field icon={<MailIcon size={15} />} label="Recipients">
+        {args.to.join(", ")}
+        {detailed && args.cc && args.cc.length > 0 && <Text span c="dimmed">{` · cc ${args.cc.join(", ")}`}</Text>}
       </Field>
-      {detailed && args.thread_id && <Field label="Replying within thread">{args.thread_id}</Field>}
+      {detailed ? <pre className="haku-shell-json">{args.body}</pre> : <CompactBody body={args.body} />}
+      {args.thread_id && (
+        <Anchor href={gmailThreadUrl(args.thread_id)} target="_blank" rel="noreferrer" size="xs">
+          Reply in thread ↗
+        </Anchor>
+      )}
     </Stack>
   );
 }

--- a/haku/console/frontend/tool_previews/google_calendar.test.ts
+++ b/haku/console/frontend/tool_previews/google_calendar.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { renderPreview } from "./entry.tsx";
-import { googleCalendarPreviews } from "./google_calendar.tsx";
+import { formatEventDateTimeRange, googleCalendarPreviews } from "./google_calendar.tsx";
 
 describe("googleCalendarPreviews", () => {
   it("renders create_calendar_event for a valid all-day event, in both variants", () => {
@@ -19,5 +19,40 @@ describe("googleCalendarPreviews", () => {
     expect(
       renderPreview(googleCalendarPreviews.create_calendar_event, { summary: "no start/end" }, "detailed")
     ).toBeNull();
+  });
+});
+
+describe("formatEventDateTimeRange", () => {
+  it("collapses a same-day timed event to one line (24h, weekday), full date on hover", () => {
+    const { text, title } = formatEventDateTimeRange(
+      { date_time: "2026-07-12T18:00:00" },
+      { date_time: "2026-07-12T19:00:00" }
+    );
+    expect(text).toContain("18:00–19:00"); // one range, not two stamps
+    expect(text).not.toContain("T"); // no raw ISO leaking through
+    expect(title).toContain("2026"); // hover keeps the full precision incl. year
+  });
+
+  it("keeps both ends when the event spans days", () => {
+    const { text } = formatEventDateTimeRange(
+      { date_time: "2026-07-12T22:00:00" },
+      { date_time: "2026-07-13T06:00:00" }
+    );
+    expect(text).toContain("22:00");
+    expect(text).toContain("06:00");
+  });
+
+  it("shows a single all-day event inclusively", () => {
+    const { text } = formatEventDateTimeRange({ date: "2026-07-12" }, { date: "2026-07-13" });
+    expect(text).toContain("all day");
+  });
+
+  it("shows a multi-day all-day span with Google's exclusive end pulled back a day", () => {
+    // Google's end date 07-15 is exclusive → the span is 12–14 inclusive.
+    const { text } = formatEventDateTimeRange({ date: "2026-07-12" }, { date: "2026-07-15" });
+    expect(text).toContain("all day");
+    expect(text).toContain("12");
+    expect(text).toContain("14");
+    expect(text).not.toContain("15");
   });
 });

--- a/haku/console/frontend/tool_previews/google_calendar.tsx
+++ b/haku/console/frontend/tool_previews/google_calendar.tsx
@@ -5,13 +5,13 @@
 // (:schema_zod), so this file's shape checks can never drift from the backend's.
 
 import { Anchor, Loader, Stack, Text } from "@mantine/core";
-import { format, formatDuration, intervalToDuration, parseISO } from "date-fns";
 import { useEffect, useState } from "react";
 import type { z } from "zod";
 
 import { zCalendarReminder, zCreateCalendarEventArgs, zEventDateTime } from "../api/schema.zod.ts";
 import { fetchCalendarSummary, type CalendarSummary } from "../calendar_client.ts";
 import { Field } from "../field.tsx";
+import { BellIcon, CalendarIcon, ClockIcon, MapPinIcon, UsersIcon } from "../icons.tsx";
 import { definePreview, type ToolPreview } from "./entry.tsx";
 import type { PreviewProps } from "./variant.tsx";
 
@@ -22,21 +22,111 @@ type CalendarReminder = z.infer<typeof zCalendarReminder>;
 type CreateCalendarEventArgs = z.infer<typeof zCreateCalendarEventArgs>;
 
 function formatEventDateTime(value: EventDateTime): string {
-  // All-day dates carry no zone ambiguity, so render them nicely. Timed events keep their
-  // RFC3339 string verbatim (it already encodes the exact instant + offset) plus the IANA
-  // zone the caller gave — reformatting to the viewer's local zone would misstate the
-  // operator's intent, and zone-correct display would need date-fns-tz, which we don't pull in.
-  if (value.date) return format(parseISO(value.date), "EEE, d MMM yyyy");
+  if (value.date) return value.date;
   if (value.date_time) return value.time_zone ? `${value.date_time} (${value.time_zone})` : value.date_time;
   return "(unset)";
 }
 
+// A Google Calendar `date_time` ("2026-07-12T18:00:00") is a wall-clock time in the event's
+// own `time_zone` (the string carries no offset), so we read the date and time straight off
+// the string rather than parsing to an instant — no accidental shift into the viewer's zone.
+type ParsedEventDate =
+  | { allDay: true; y: number; mo: number; d: number }
+  | { allDay: false; y: number; mo: number; d: number; time: string };
+
+function parseEventDate(value: EventDateTime): ParsedEventDate | null {
+  const source = value.date ?? value.date_time;
+  if (!source) return null;
+  const [datePart, timePart] = source.split("T");
+  const [y, mo, d] = datePart.split("-").map(Number);
+  if (!y || !mo || !d) return null;
+  if (value.date) return { allDay: true, y, mo, d };
+  if (!timePart) return null;
+  return { allDay: false, y, mo, d, time: timePart.slice(0, 5) };
+}
+
+// Formatters over a UTC-normalized calendar date, so the weekday/month names are locale-aware
+// but the date itself is read as the event's own (already-local) wall-clock, never converted.
+const _WEEKDAY_LONG = new Intl.DateTimeFormat(undefined, { weekday: "long", timeZone: "UTC" });
+const _WEEKDAY_SHORT = new Intl.DateTimeFormat(undefined, { weekday: "short", timeZone: "UTC" });
+const _MONTH_DAY = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", timeZone: "UTC" });
+const _FULL_DATE = new Intl.DateTimeFormat(undefined, {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  timeZone: "UTC",
+});
+
+const asUtc = (p: ParsedEventDate): Date => new Date(Date.UTC(p.y, p.mo - 1, p.d));
+const sameDay = (a: ParsedEventDate, b: ParsedEventDate): boolean => a.y === b.y && a.mo === b.mo && a.d === b.d;
+
+function zoneSuffix(timeZone: string | null | undefined, at: Date): { short: string; full: string } {
+  if (!timeZone) return { short: "", full: "" };
+  const viewer = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const full = ` (${timeZone})`;
+  if (timeZone === viewer) return { short: "", full }; // same zone as the reader → not worth showing
+  const part = new Intl.DateTimeFormat("en-US", { timeZone, timeZoneName: "short" })
+    .formatToParts(at)
+    .find((p) => p.type === "timeZoneName");
+  return { short: ` ${part ? part.value : timeZone}`, full };
+}
+
+/** Collapse an event's start–end into one line: same-day timed → "Thursday 18:00–19:00"; a
+ * span of days keeps both ends; all-day reads "… · all day" (Google's exclusive end shown
+ * inclusively). Zone is appended only when it isn't the viewer's. Returns the concise `text`
+ * plus a full-precision `title` (with year + IANA zone) for the element's tooltip. */
+export function formatEventDateTimeRange(start: EventDateTime, end: EventDateTime): { text: string; title: string } {
+  const s = parseEventDate(start);
+  const e = parseEventDate(end);
+  if (!s || !e || s.allDay !== e.allDay) {
+    const raw = `${formatEventDateTime(start)} – ${formatEventDateTime(end)}`;
+    return { text: raw, title: raw };
+  }
+  if (s.allDay && e.allDay) {
+    // Google's all-day end date is exclusive; show it inclusively (one day back).
+    const endIncl = new Date(Date.UTC(e.y, e.mo - 1, e.d - 1));
+    const startUtc = asUtc(s);
+    if (endIncl.getTime() <= startUtc.getTime()) {
+      return {
+        text: `${_WEEKDAY_LONG.format(startUtc)}, ${_MONTH_DAY.format(startUtc)} · all day`,
+        title: `${_FULL_DATE.format(startUtc)} — all day`,
+      };
+    }
+    return {
+      text: `${_MONTH_DAY.format(startUtc)} – ${_MONTH_DAY.format(endIncl)} · all day`,
+      title: `${_FULL_DATE.format(startUtc)} – ${_FULL_DATE.format(endIncl)} — all day`,
+    };
+  }
+  if (!s.allDay && !e.allDay) {
+    const zone = zoneSuffix(start.time_zone, new Date(`${asUtc(s).toISOString().slice(0, 11)}${s.time}:00Z`));
+    if (sameDay(s, e)) {
+      return {
+        text: `${_WEEKDAY_LONG.format(asUtc(s))} ${s.time}–${e.time}${zone.short}`,
+        title: `${_FULL_DATE.format(asUtc(s))} · ${s.time}–${e.time}${zone.full}`,
+      };
+    }
+    return {
+      text: `${_WEEKDAY_SHORT.format(asUtc(s))} ${s.time} – ${_WEEKDAY_SHORT.format(asUtc(e))} ${e.time}${zone.short}`,
+      title: `${_FULL_DATE.format(asUtc(s))} ${s.time} – ${_FULL_DATE.format(asUtc(e))} ${e.time}${zone.full}`,
+    };
+  }
+  const raw = `${formatEventDateTime(start)} – ${formatEventDateTime(end)}`;
+  return { text: raw, title: raw };
+}
+
+// Compact reminder offset — just the lead time, no method: "30 min before", "1h 30m before",
+// "1 day before", "1 week before", "at start". Largest whole unit down; "min" alone, "h"/"m"
+// when combined.
 function formatReminder(reminder: CalendarReminder): string {
-  const timing =
-    reminder.minutes_before_start === 0
-      ? "at event start"
-      : `${formatDuration(intervalToDuration({ start: 0, end: reminder.minutes_before_start * 60_000 }))} before`;
-  return `${reminder.method === "popup" ? "Popup" : "Email"}, ${timing}`;
+  const m = reminder.minutes_before_start;
+  if (m === 0) return "at start";
+  if (m % 10080 === 0) return `${m / 10080} week${m === 10080 ? "" : "s"} before`;
+  if (m % 1440 === 0) return `${m / 1440} day${m === 1440 ? "" : "s"} before`;
+  if (m < 60) return `${m} min before`;
+  const h = Math.floor(m / 60);
+  const mins = m % 60;
+  return `${mins ? `${h}h ${mins}m` : `${h}h`} before`;
 }
 
 // A non-primary calendar's id is opaque; resolve its display name (linked into Google Calendar)
@@ -63,7 +153,7 @@ function CalendarField({ calendarId }: { calendarId: string }) {
   }, [calendarId]);
 
   return (
-    <Field label="Calendar">
+    <Field icon={<CalendarIcon size={15} />} label="Calendar">
       {summary ? (
         <Anchor href={summary.html_link} target="_blank" rel="noreferrer">
           {summary.summary}
@@ -79,34 +169,38 @@ function CalendarField({ calendarId }: { calendarId: string }) {
 }
 
 function CreateCalendarEventPreview({ args, variant }: PreviewProps<CreateCalendarEventArgs>) {
-  // Common trunk: the wrapper + event summary; compact stops at the start time, detailed
-  // expands the full when/where/who.
+  // The summary is the event's own name, so it leads as a heading (no label); the rest use the
+  // inline icon fields (🕐 time, 📍 location, …) — denser than a stacked uppercase label per row.
+  const when = formatEventDateTimeRange(args.start, args.end);
   return (
-    <Stack gap="xs">
-      <Field label="Event">{args.summary}</Field>
-      {variant === "compact" ? (
-        <Field label="When">{formatEventDateTime(args.start)}</Field>
-      ) : (
+    <Stack gap={6}>
+      <Text fw={600}>{args.summary}</Text>
+      <Field icon={<ClockIcon size={15} />} label="When">
+        <span title={when.title}>{when.text}</span>
+      </Field>
+      {variant === "detailed" && (
         <>
-          <div className="haku-shell-field-grid">
-            <Field label="Start">{formatEventDateTime(args.start)}</Field>
-            <Field label="End">{formatEventDateTime(args.end)}</Field>
-          </div>
-          {args.location && <Field label="Location">{args.location}</Field>}
-          {args.description && <Field label="Description">{args.description}</Field>}
-          {args.calendar_id && args.calendar_id !== "primary" && <CalendarField calendarId={args.calendar_id} />}
-          {args.reminders && args.reminders.length > 0 && (
-            <Field label="Reminders">
-              <Stack gap={2}>
-                {args.reminders.map((reminder, i) => (
-                  <Text size="sm" key={i}>
-                    {formatReminder(reminder)}
-                  </Text>
-                ))}
-              </Stack>
+          {args.location && (
+            <Field icon={<MapPinIcon size={15} />} label="Location">
+              {args.location}
             </Field>
           )}
-          {args.attendees && args.attendees.length > 0 && <Field label="Attendees">{args.attendees.join(", ")}</Field>}
+          {args.description && (
+            <Text size="sm" c="dimmed">
+              {args.description}
+            </Text>
+          )}
+          {args.calendar_id && args.calendar_id !== "primary" && <CalendarField calendarId={args.calendar_id} />}
+          {args.reminders && args.reminders.length > 0 && (
+            <Field icon={<BellIcon size={15} />} label="Reminders">
+              {args.reminders.map(formatReminder).join(" · ")}
+            </Field>
+          )}
+          {args.attendees && args.attendees.length > 0 && (
+            <Field icon={<UsersIcon size={15} />} label="Attendees">
+              {args.attendees.join(", ")}
+            </Field>
+          )}
         </>
       )}
     </Stack>

--- a/haku/console/frontend/tool_previews/grocy.tsx
+++ b/haku/console/frontend/tool_previews/grocy.tsx
@@ -20,9 +20,8 @@ import { useEffect, useState } from "react";
 import { z } from "zod";
 
 import { fetchGrocyReference, type GrocyReferenceResponse } from "../grocy_client.ts";
-import { Field } from "../field.tsx";
 import { definePreview, type ToolPreview } from "./entry.tsx";
-import { COMPACT_ITEM_LIMIT, MoreLine, type PreviewProps, type PreviewVariant } from "./variant.tsx";
+import { ActionBadge, COMPACT_ITEM_LIMIT, MoreLine, type PreviewProps, type PreviewVariant } from "./variant.tsx";
 
 export const GROCY_SERVER_ID = "grocy-sf";
 
@@ -151,11 +150,7 @@ function StockAddPreview({ args, variant }: PreviewProps<StockAddArgs>) {
   const shown = variant === "compact" ? args.items.slice(0, COMPACT_ITEM_LIMIT) : args.items;
   return (
     <Stack gap="xs">
-      <Field label="Action">
-        <Badge color="green" variant="light">
-          Add stock
-        </Badge>
-      </Field>
+      <ActionBadge color="green">Add stock</ActionBadge>
       <Stack gap={4}>
         {shown.map((item, i) => (
           <StockAddRow key={i} item={item} reference={reference} />
@@ -192,11 +187,7 @@ function StockConsumePreview({ args, variant }: PreviewProps<StockConsumeArgs>) 
   const shown = variant === "compact" ? args.items.slice(0, COMPACT_ITEM_LIMIT) : args.items;
   return (
     <Stack gap="xs">
-      <Field label="Action">
-        <Badge color="red" variant="light">
-          Remove stock
-        </Badge>
-      </Field>
+      <ActionBadge color="red">Remove stock</ActionBadge>
       <Stack gap={4}>
         {shown.map((item, i) => (
           <StockConsumeRow key={i} item={item} reference={reference} />
@@ -286,11 +277,7 @@ function ProductsCreatePreview({ args, variant }: PreviewProps<ProductsCreateArg
   const shown = variant === "compact" ? args.items.slice(0, COMPACT_ITEM_LIMIT) : args.items;
   return (
     <Stack gap="xs">
-      <Field label="Action">
-        <Badge color="blue" variant="light">
-          Create product{args.items.length > 1 ? "s" : ""}
-        </Badge>
-      </Field>
+      <ActionBadge color="blue">Create product{args.items.length > 1 ? "s" : ""}</ActionBadge>
       <Stack gap={6}>
         {shown.map((item, i) => (
           <ProductsCreateRow key={i} item={item} reference={reference} variant={variant} />

--- a/haku/console/frontend/tool_previews/kubectl.tsx
+++ b/haku/console/frontend/tool_previews/kubectl.tsx
@@ -6,12 +6,11 @@
 // identity (cluster_auth_mode=passthrough) once approved, so rendering the exact target
 // unambiguously matters more than for narrower-scoped tools.
 
-import { Badge, Group, Stack, Text } from "@mantine/core";
+import { Group, Stack, Text } from "@mantine/core";
 import { z } from "zod";
 
-import { Field } from "../field.tsx";
 import { definePreview, type ToolPreview } from "./entry.tsx";
-import { clampBlock, type PreviewProps } from "./variant.tsx";
+import { ActionBadge, clampBlock, type PreviewProps } from "./variant.tsx";
 
 export const KUBECTL_SERVER_ID = "kubectl-passthrough-mcp";
 
@@ -44,14 +43,8 @@ function ResourcesApplyPreview({ args, variant }: PreviewProps<ResourcesCreateOr
   const resource = variant === "compact" ? clampBlock(args.resource, 3) : args.resource;
   return (
     <Stack gap="xs">
-      <Field label="Action">
-        <Badge color="blue" variant="light">
-          Apply
-        </Badge>
-      </Field>
-      <Field label="Resource">
-        <pre className="haku-shell-json">{resource}</pre>
-      </Field>
+      <ActionBadge color="blue">Apply</ActionBadge>
+      <pre className="haku-shell-json">{resource}</pre>
     </Stack>
   );
 }
@@ -69,24 +62,18 @@ function DeleteTargetPreview({
 }) {
   return (
     <Stack gap="xs">
-      <Field label="Action">
-        <Badge color="red" variant="filled">
-          Delete
-        </Badge>
-      </Field>
-      <Field label="Target" mono>
-        <Group gap={4}>
-          <Text span fw={600}>
-            {kind}
+      <ActionBadge color="red">Delete</ActionBadge>
+      <Group gap={4} className="haku-shell-mono">
+        <Text span fw={600}>
+          {kind}
+        </Text>
+        <Text span>{name}</Text>
+        {namespace && (
+          <Text span c="dimmed">
+            in {namespace}
           </Text>
-          <Text span>{name}</Text>
-          {namespace && (
-            <Text span c="dimmed">
-              in {namespace}
-            </Text>
-          )}
-        </Group>
-      </Field>
+        )}
+      </Group>
       {gracePeriodSeconds === 0 && (
         <Text size="sm" c="red">
           Immediate deletion (grace period 0) — no termination grace.

--- a/haku/console/frontend/tool_previews/variant.tsx
+++ b/haku/console/frontend/tool_previews/variant.tsx
@@ -4,7 +4,8 @@
 // first few lines. A **detailed** preview is the full form shown in the expanded detail
 // view. Leaf module (no widget deps) so index.tsx and every widget can import the type
 // without a cycle.
-import { Text } from "@mantine/core";
+import { Badge, Text } from "@mantine/core";
+import type { ReactNode } from "react";
 
 export type PreviewVariant = "compact" | "detailed";
 
@@ -15,6 +16,17 @@ export type PreviewProps<Args> = { args: Args; variant: PreviewVariant };
 // In compact previews, list-shaped arguments show only the first few items; the rest
 // collapse to a single "… +N more" line so a card stays scannable.
 export const COMPACT_ITEM_LIMIT = 3;
+
+/** The action a widget performs, as one colored badge — the house form for every preview's
+ * verb (green create/add, red destructive/remove, blue/gray neutral). No label above it: the
+ * badge *is* the label. */
+export function ActionBadge({ color, children }: { color: string; children: ReactNode }) {
+  return (
+    <Badge color={color} variant="light">
+      {children}
+    </Badge>
+  );
+}
 
 /** A dimmed "… +N more" line for the items a compact preview elided; renders nothing at 0. */
 export function MoreLine({ count }: { count: number }) {


### PR DESCRIPTION
A consistency pass over **every** tool-call rendering — the approval **drawer** cards (`console_panel.tsx`), the **history** rows (`tool_calls_page.tsx`), and the per-server **preview widgets** (`tool_previews/`) — plus a written design contract in `frontend/AGENTS.md` so the whole surface reads as one thing. Rebased onto devel after #3005 split Gmail/Calendar into their own MCP servers; the widgets are re-expressed on that new `gmail.tsx` / `google_calendar.tsx` split.

## Design requirements (frontend/AGENTS.md)

New "Tool-call rendering — design requirements" section: compact is for skimming (action + primary targets + a little payload); detailed is complete but **ranked**, with the rarely-useful parts folded away; don't waste vertical space (lead with the call's identity as a heading, inline icon fields, one-line ranges); one consistent vocabulary (colored action badge, bold identity, icons only where unambiguous, semantic color ≠ accent).

## What changed

**Provenance behind one `Metadata` disclosure.** Caller principal, exact request time, and tool-call id move behind one collapsed `Metadata` disclosure (`tool_call_meta.tsx`) in the detailed drawer cards and history rows. What the call *does* (arguments, rationale, denial reason, result) stays visible.

**Approve/deny control, shared and inline.** A shared `PendingToolCallActions` (`pending_tool_call_actions.tsx`) drives both the drawer card and the history row: the optional reason sits to the **left** of the buttons on one row, its purpose carried by the **placeholder** rather than a stacked label. (TODO left to let the note ride an *approve* too, as a general operator remark.)

**One action vocabulary.** The action is a colored `ActionBadge` (green add/create, red destructive/remove, blue/gray neutral); grocy and kubectl drop their `Field`-wrapped action labels for it.

**Calendar event range on one line.** `formatEventDateTimeRange`: same-day timed → **`Sunday 09:00–10:00`** (24h, weekday); a span of days keeps both ends; all-day → `Sun Jul 12 · all day` (Google's exclusive end shown inclusively). Zone appended only when it isn't the viewer's; full date + IANA zone on hover. A Google `date_time` is wall-clock in the event's own zone, so it's read off the string, never parsed to an instant. Inline icon fields (🕐 when, 📍 location, 🔔 reminders, 👥 attendees, 📅 calendar); reminders read as a plain lead time (`30 min before`).

**Gmail label + draft rendering.** Thread-label changes render as one row of pills — green `+ added`, red `− removed` — no separate Add/Remove heading; each thread's current labels render as pills too. A draft reply **links to its thread** (both variants) instead of printing the raw thread id.

**`Field` unified.** Both the stacked-label and inline-icon forms now share one wrapper and value element, differing only in the label (drops the `dt/dd` vs `div` split); dead `.haku-shell-field-grid` CSS removed.

**Concise timestamps.** A shared `formatTimestamp` gives the Requested/Metadata times a relative form ("yesterday 2:32 PM", "2h ago") with the absolute value on hover.

## Screenshots

The `history` scene expands its first rows into their detailed state (Metadata disclosure open), so one shot shows both compact and detailed rows. Every widget's compact|detailed pair is in the `previews` gallery.

## Test

`bbr test //haku/console/...` — all 11 green on RBE (tsc, vitest, screenshots, backend). `formatEventDateTimeRange` gets same-day / multi-day / all-day (inclusive-end) unit tests; eyeballed the `previews`, `drawer`, and `history` scenes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5PSCrFPzAn61Yqr2hZE9a