### PR TITLE
Extract MCP operator OAuth and config into separate modules

### DIFF
--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -132,6 +132,17 @@ has shipped on the capability tier — see the README.)
   `text`; consider adding quick buttons for common instructions (e.g. "scan Gmail now",
   "CPAP check", "triage open PRs"). Reuses the launch button's existing bearer + egress
   perimeter. Docs: code.claude.com/docs/en/routines.
+- **Fold launch-routine into the MCP tool-call mechanism.** The launch-routine capability
+  (`capabilities.py`, its own CSRF-gated bespoke tier) reinvents what the MCP approval queue
+  already provides: an operator-gated, audited, exact-arguments call that acts on the world.
+  Consider retiring the separate capability tier and exposing routine-launching as an
+  **in-process MCP server** — a "claude-code-web routine launcher", built like
+  `haku.console.tools.google` — whose one `launch_routine` tool flows through the same
+  submit → approve → execute → audit pipeline as every other tool call (the launch bearer stays
+  console-side, unread by Haku, exactly as today). That collapses two consent/audit surfaces into
+  one and gives each launch a ledger entry + result for free. Preserve the property that firing is
+  a genuine operator gesture against trusted chrome (today the shell renders its own confirm) when
+  it becomes an approval-queue item; pairs naturally with the routine-runs listing panel above.
 
 ## Managed Agents runtimes — per-runtime TODOs
 

--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -29,6 +29,18 @@ py_library(
 )
 
 py_library(
+    name = "mcp_config",
+    srcs = ["mcp_config.py"],
+    deps = [
+        ":config",
+        "@pypi//fastapi",
+        "@pypi//fastmcp",
+        "@pypi//pydantic",
+        "@pypi//pyyaml",
+    ],
+)
+
+py_library(
     name = "deps",
     srcs = ["deps.py"],
     deps = [
@@ -72,6 +84,25 @@ py_library(
 )
 
 py_library(
+    name = "mcp_operator_oauth",
+    srcs = ["mcp_operator_oauth.py"],
+    data = ["mcp_operator_auth_callback.html"],
+    deps = [
+        ":config",
+        ":database_migrate",
+        ":database_schema",
+        ":deps",
+        ":mcp_config",
+        "@pypi//fastapi",
+        "@pypi//fastapi_csrf_protect",
+        "@pypi//httpx",
+        "@pypi//mcp",
+        "@pypi//pydantic",
+        "@pypi//sqlalchemy",
+    ],
+)
+
+py_library(
     name = "mcp_approval",
     srcs = ["mcp_approval.py"],
     deps = [
@@ -79,15 +110,15 @@ py_library(
         ":database_migrate",
         ":database_schema",
         ":deps",
+        ":mcp_config",
+        ":mcp_operator_oauth",
         "@ducktape_haku//haku/console:tool_calls",
         "@pypi//fastapi",
         "@pypi//fastapi_csrf_protect",
         "@pypi//fastmcp",
-        "@pypi//httpx",
         "@pypi//mcp",
         "@pypi//psycopg",
         "@pypi//pydantic",
-        "@pypi//pyyaml",
         "@pypi//sqlalchemy",
     ],
 )
@@ -99,6 +130,7 @@ py_library(
         ":capabilities",
         ":config",
         ":mcp_approval",
+        ":mcp_operator_oauth",
         ":models",
         "//haku/console/tools:gmail",
         "//haku/console/tools:google_calendar",
@@ -189,6 +221,7 @@ py_test(
         ":config",
         ":conftest",
         ":mcp_approval",
+        ":mcp_config",
         "//:conftest",
         "//third_party/containers:rlocations",
         "//util:net",

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -62,9 +62,10 @@ Core endpoints:
   names reachable servers, and each live MCP server remains the tool schema source.
 - `GET /api/mcp/operator-auth`, `POST /api/mcp/operator-auth/{server_id}/start`,
   `DELETE /api/mcp/operator-auth/{server_id}`, and `GET /api/mcp/operator-auth/callback` —
-  operator account association for MCP servers whose config enables `operator_oauth`. The catalog
-  stays in the console YAML/ConfigMap; Postgres stores only short-lived DCR/PKCE flow state and
-  per-operator token associations.
+  operator account association for MCP servers whose config enables `operator_oauth` (this flow
+  lives in `mcp_operator_oauth.py`, not the approval router). The catalog stays in the console
+  YAML/ConfigMap; Postgres stores only short-lived DCR/PKCE flow state and per-operator token
+  associations.
 - `POST /api/tool-calls` — submit a call with `server_id`, `tool_name`, exact
   `arguments`, and explicit `wait_for_ms`. The console mints the canonical `tool_call_id`.
 - `GET /api/approvals/pending`, `GET /api/approvals/events?after_event_id=...`, and
@@ -165,16 +166,18 @@ non-asset/API path; `app.py`'s dev fallback mirrors that so deep links work loca
 
 ## Layout
 
-| Path               | Role                                                                                                                                                                                                                                |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `app.py`           | FastAPI `create_app`. `GET /api/config`, `GET /healthz`, CSRF config, mounts the capability router. It can serve the SPA for local/direct fallback when `HAKU_CONSOLE_STATIC_DIR` is set.                                           |
-| `capabilities.py`  | Capability-tier router (`/api/capabilities/*`): CSRF-gated, audited privileged actions. `POST /launch-routine` fires the routine with the server-side bearer and optional per-run text; `GET /csrf` issues the double-submit token. |
-| `mcp_approval.py`  | MCP approval queue router: MCP server reflection, tool-call submit/list/result endpoints, trusted approval decisions, WebSocket notifications, and Postgres-backed audit state in deploy.                                           |
-| `migrations/`      | Alembic migrations for the deployed haku-console database; the console applies them at app startup before serving the API.                                                                                                          |
-| `models.py`        | Pydantic `ConfigResponse` — the `/api/config` response model.                                                                                                                                                                       |
-| `config.py`        | Env settings (`HAKU_CONSOLE_*`).                                                                                                                                                                                                    |
-| `export_schema.py` | Prints the OpenAPI schema; the frontend generates its TypeScript types from it.                                                                                                                                                     |
-| `frontend/`        | React SPA (esbuild bundle) — see `frontend/README.md`.                                                                                                                                                                              |
+| Path                    | Role                                                                                                                                                                                                                                |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `app.py`                | FastAPI `create_app`. `GET /api/config`, `GET /healthz`, CSRF config, mounts the capability router. It can serve the SPA for local/direct fallback when `HAKU_CONSOLE_STATIC_DIR` is set.                                           |
+| `capabilities.py`       | Capability-tier router (`/api/capabilities/*`): CSRF-gated, audited privileged actions. `POST /launch-routine` fires the routine with the server-side bearer and optional per-run text; `GET /csrf` issues the double-submit token. |
+| `mcp_approval.py`       | MCP approval queue router: MCP server reflection, tool-call submit/list/result endpoints, trusted approval decisions, WebSocket notifications, and Postgres-backed audit state in deploy.                                           |
+| `mcp_config.py`         | The connected-MCP-server catalog (deploy-time YAML model) plus how to reach each entry: in-process/remote transport and static bearer credential. Shared by `mcp_approval` and `mcp_operator_oauth`.                                |
+| `mcp_operator_oauth.py` | Operator OAuth account linkage for servers that execute as the operator's own account: the DCR/PKCE flow, Postgres token storage/refresh, and the `/api/mcp/operator-auth/*` connect/disconnect/callback endpoints.                 |
+| `migrations/`           | Alembic migrations for the deployed haku-console database; the console applies them at app startup before serving the API.                                                                                                          |
+| `models.py`             | Pydantic `ConfigResponse` — the `/api/config` response model.                                                                                                                                                                       |
+| `config.py`             | Env settings (`HAKU_CONSOLE_*`).                                                                                                                                                                                                    |
+| `export_schema.py`      | Prints the OpenAPI schema; the frontend generates its TypeScript types from it.                                                                                                                                                     |
+| `frontend/`             | React SPA (esbuild bundle) — see `frontend/README.md`.                                                                                                                                                                              |
 
 ## Perimeter / deploy
 

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -24,7 +24,7 @@ from fastapi_csrf_protect import CsrfProtect
 from fastapi_csrf_protect.exceptions import CsrfProtectError
 from fastmcp import FastMCP
 
-from haku.console import capabilities, mcp_approval
+from haku.console import capabilities, mcp_approval, mcp_operator_oauth
 from haku.console.config import Settings
 from haku.console.models import ConfigResponse
 from haku.console.tools import gmail as gmail_tools, google_calendar as google_calendar_tools, grocy as grocy_tools
@@ -69,7 +69,7 @@ def create_app(settings: Settings) -> FastAPI:
     app.state.settings = settings
     app.state.tool_call_ledger = mcp_approval.PostgresToolCallLedger(database_url) if database_url is not None else None
     app.state.mcp_operator_oauth_store = (
-        mcp_approval.PostgresMcpOperatorOAuthStore(database_url) if database_url is not None else None
+        mcp_operator_oauth.PostgresMcpOperatorOAuthStore(database_url) if database_url is not None else None
     )
     # Two in-process MCP servers (gmail, google_calendar) built from the one mounted
     # haku_console_google token; each client is also exposed on app.state for its
@@ -130,6 +130,7 @@ def create_app(settings: Settings) -> FastAPI:
 
     app.include_router(capabilities.router)
     app.include_router(mcp_approval.router)
+    app.include_router(mcp_operator_oauth.router)
     app.include_router(gmail_tools.router)
     app.include_router(google_calendar_tools.router)
     app.include_router(grocy_tools.router)

--- a/haku/console/frontend/client.ts
+++ b/haku/console/frontend/client.ts
@@ -14,7 +14,9 @@ export type ApprovalDecisionResponse = components["schemas"]["ApprovalDecisionRe
 type ApprovalDecisionRequest = components["schemas"]["ApprovalDecisionRequest"];
 export type PendingApproval = components["schemas"]["PendingApproval"];
 export type ToolCallRecord = components["schemas"]["ToolCallRecord"];
-export type McpOperatorAuthStatus = components["schemas"]["McpOperatorAuthStatus"];
+export type McpOperatorAuthStatus =
+  | components["schemas"]["McpOperatorAuthConnected"]
+  | components["schemas"]["McpOperatorAuthUnconnected"];
 export type McpOperatorAuthStartResponse = components["schemas"]["McpOperatorAuthStartResponse"];
 
 // FastAPI error responses are `{detail: string}`; surface that real reason rather

--- a/haku/console/frontend/settings_page.tsx
+++ b/haku/console/frontend/settings_page.tsx
@@ -26,7 +26,7 @@ function McpAccountCard({
   onDisconnect: () => void;
 }) {
   const connected = status.status === "connected";
-  const until = shortDate(status.token_expires_at);
+  const until = status.status === "connected" ? shortDate(status.token_expires_at) : null;
   return (
     <section className="haku-shell-card">
       <Group justify="space-between" align="flex-start" gap="sm" wrap="nowrap">

--- a/haku/console/mcp_approval.py
+++ b/haku/console/mcp_approval.py
@@ -3,69 +3,50 @@
 This router is the privileged tool-call ledger: callers can discover connected MCP
 servers, submit exact calls against any reflected tool, and read the console-owned
 result/audit state. In v1 every execution waits for an operator decision in trusted
-console chrome.
+console chrome. The connected-server catalog lives in `mcp_config`; operator OAuth account
+linkage (used when a server executes as the operator's own account) lives in
+`mcp_operator_oauth`.
 """
 
 from __future__ import annotations
 
 import asyncio
-import base64
 import contextlib
-import datetime as dt
-import html
+import datetime
 import json
 import logging
-import os
-import re
 import secrets
 from collections.abc import Iterable
-from typing import Annotated, Any, Literal, Protocol, cast
-from urllib.parse import quote, urlencode, urljoin
+from typing import Annotated, Any, Literal, cast
 
-import httpx
 import psycopg
-import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
-from fastapi.responses import HTMLResponse
 from fastapi_csrf_protect import CsrfProtect
-from fastmcp import FastMCP
 from fastmcp.client import Client
 from mcp import types as mcp_types
-from mcp.client.auth.oauth2 import PKCEParameters
-from mcp.client.auth.utils import (
-    build_oauth_authorization_server_metadata_discovery_urls,
-    build_protected_resource_metadata_discovery_urls,
-    extract_resource_metadata_from_www_auth,
-    extract_scope_from_www_auth,
-    get_client_metadata_scopes,
-    handle_auth_metadata_response,
-    handle_protected_resource_response,
-    handle_registration_response,
-    handle_token_response_scopes,
-)
-from mcp.client.streamable_http import MCP_PROTOCOL_VERSION
-from mcp.shared.auth import (
-    OAuthClientInformationFull,
-    OAuthClientMetadata,
-    OAuthMetadata,
-    OAuthToken,
-    ProtectedResourceMetadata,
-)
-from mcp.shared.auth_utils import check_resource_allowed, resource_url_from_server_url
-from mcp.types import LATEST_PROTOCOL_VERSION
-from pydantic import BaseModel, Field, ValidationError
-from sqlalchemy import create_engine, delete, select
+from pydantic import BaseModel, Field
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from haku.console.config import Settings
 from haku.console.database_migrate import run_migrations_for_connection
-from haku.console.database_schema import (
-    McpOperatorOAuthAssociation,
-    McpOperatorOAuthFlow,
-    McpToolCall,
-    McpToolCallEvent,
-)
+from haku.console.database_schema import McpToolCall, McpToolCallEvent
 from haku.console.deps import SettingsDep
+from haku.console.mcp_config import (
+    InProcessServers,
+    McpServerEntry,
+    _credential_token,
+    _load_servers,
+    _operator_oauth_enabled,
+    _server_entry,
+    _transport,
+)
+from haku.console.mcp_operator_oauth import (
+    OAuthStoreDep,
+    PostgresMcpOperatorOAuthStore,
+    _maybe_oauth_store,
+    _operator_principal,
+)
 from haku.console.tool_calls import (
     ApprovalDecisionRequest,
     SubmitToolCallRequest,
@@ -82,42 +63,6 @@ Csrf = Annotated[CsrfProtect, Depends()]
 
 
 TERMINAL_STATUSES = {ToolCallStatus.OK, ToolCallStatus.ERROR, ToolCallStatus.DENIED}
-MCP_OPERATOR_AUTH_CALLBACK_PATH = "/api/mcp/operator-auth/callback"
-MCP_OPERATOR_AUTH_FLOW_TTL = dt.timedelta(minutes=10)
-MCP_OPERATOR_AUTH_REFRESH_SKEW = dt.timedelta(seconds=60)
-
-
-class McpOperatorOAuthConfig(BaseModel):
-    enabled: bool = True
-    client_name: str = "Haku Console"
-    scopes: list[str] | None = None
-    # For an authorization server with no open Dynamic Client Registration (RFC 7591) —
-    # e.g. Authentik, which has no /register endpoint, so the server-metadata-declared
-    # registration_endpoint is absent and DCR would otherwise 401 against a guessed
-    # {server}/register fallback. A pre-registered public/PKCE client_id shared across
-    # every OAuth caller of that authorization server, skipping registration entirely.
-    # Safe to share: PKCE plus per-request redirect_uri validation secure each caller's
-    # auth code exchange independently even though the client_id is the same for all.
-    static_client_id: str | None = None
-
-
-class McpServerEntry(BaseModel):
-    id: str
-    # None for a server reached via an in-process FastMCP instance instead of a remote
-    # URL (see McpToolExecutor/McpMetadataProvider's `in_process_servers` registry,
-    # e.g. haku.console.tools.gmail's `gmail` server) — resolved at runtime by id,
-    # not by anything in this config model.
-    server_url: str | None = None
-    bearer_token_secret: str | None = None
-    operator_oauth: McpOperatorOAuthConfig | None = None
-
-
-class ConsoleMcpConfig(BaseModel):
-    servers: list[McpServerEntry] = Field(default_factory=list)
-
-
-class ConsoleConfigFile(BaseModel):
-    mcp: ConsoleMcpConfig = Field(default_factory=ConsoleMcpConfig)
 
 
 class ToolMetadataBase(BaseModel):
@@ -160,25 +105,6 @@ class ToolCapabilitiesResponse(BaseModel):
     servers: list[ServerMetadata] = Field(default_factory=list)
 
 
-class McpOperatorAuthStatus(BaseModel):
-    server_id: str
-    status: Literal["connected", "unconnected"]
-    operator_principal: str
-    connected_at: dt.datetime | None = None
-    token_expires_at: dt.datetime | None = None
-    scope: str | None = None
-
-
-class McpOperatorAuthStatusResponse(BaseModel):
-    associations: list[McpOperatorAuthStatus] = Field(default_factory=list)
-
-
-class McpOperatorAuthStartResponse(BaseModel):
-    server_id: str
-    authorization_url: str
-    expires_at: dt.datetime
-
-
 class PendingApproval(BaseModel):
     tool_call_id: str
     server_id: str
@@ -187,7 +113,7 @@ class PendingApproval(BaseModel):
     caller_principal: str
     rationale: str
     arguments: dict[str, Any]
-    created_at: dt.datetime
+    created_at: datetime.datetime
 
 
 class PendingApprovalsResponse(BaseModel):
@@ -206,49 +132,6 @@ class ApprovalDecisionResponse(BaseModel):
     tool_call: ToolCallRecord
 
 
-class ToolCallLedgerProtocol(Protocol):
-    def submit(
-        self, *, server: McpServerEntry, req: SubmitToolCallRequest, caller_principal: str
-    ) -> tuple[ToolCallRecord, list[ToolCallEvent], bool]: ...
-
-    def get(self, tool_call_id: str) -> ToolCallRecord: ...
-
-    def list(
-        self,
-        *,
-        statuses: list[ToolCallStatus] | None = None,
-        since: dt.datetime | None = None,
-        limit: int = 100,
-        newest_first: bool = False,
-    ) -> ToolCallListResponse: ...
-
-    def events_after_id(self, after_event_id: int = 0) -> ToolCallEventsResponse: ...
-
-    def mark_running(self, tool_call_id: str) -> tuple[ToolCallRecord, ToolCallEvent]: ...
-
-    def deny(self, tool_call_id: str, reason: str | None) -> tuple[ToolCallRecord, ToolCallEvent]: ...
-
-    def finish(
-        self, tool_call_id: str, *, result: dict[str, Any] | None, error: str | None
-    ) -> tuple[ToolCallRecord, ToolCallEvent]: ...
-
-
-class McpOperatorOAuthStoreProtocol(Protocol):
-    def list_statuses(
-        self, *, servers: list[McpServerEntry], operator_principal: str
-    ) -> McpOperatorAuthStatusResponse: ...
-
-    async def start_flow(
-        self, *, server: McpServerEntry, operator_principal: str, public_base_url: str
-    ) -> McpOperatorAuthStartResponse: ...
-
-    async def complete_callback(self, *, state: str, code: str) -> McpOperatorAuthStatus: ...
-
-    def disconnect(self, *, server_id: str, operator_principal: str) -> None: ...
-
-    async def access_token_for(self, *, server: McpServerEntry, operator_principal: str) -> str | None: ...
-
-
 class PostgresToolCallLedger:
     """Postgres-backed approval ledger for the deployed console."""
 
@@ -262,7 +145,7 @@ class PostgresToolCallLedger:
         self, *, server: McpServerEntry, req: SubmitToolCallRequest, caller_principal: str
     ) -> tuple[ToolCallRecord, list[ToolCallEvent], bool]:
         with self._sessions.begin() as session:
-            now = dt.datetime.now(dt.UTC)
+            now = datetime.datetime.now(datetime.UTC)
             record = ToolCallRecord(
                 tool_call_id=f"tc_{secrets.token_hex(12)}",
                 server_id=server.id,
@@ -293,7 +176,7 @@ class PostgresToolCallLedger:
         self,
         *,
         statuses: list[ToolCallStatus] | None = None,
-        since: dt.datetime | None = None,
+        since: datetime.datetime | None = None,
         limit: int = 100,
         newest_first: bool = False,
     ) -> ToolCallListResponse:
@@ -335,7 +218,7 @@ class PostgresToolCallLedger:
             row = self._row_by_tool_call_id(session, tool_call_id)
             status = ToolCallStatus.OK if error is None else ToolCallStatus.ERROR
             row.status = status
-            row.updated_at = dt.datetime.now(dt.UTC)
+            row.updated_at = datetime.datetime.now(datetime.UTC)
             row.result_json = result
             row.error = error
             updated = row.to_record()
@@ -353,14 +236,14 @@ class PostgresToolCallLedger:
                     status_code=409, detail=f"tool call is not pending approval; status={record.status}"
                 )
             row.status = status
-            row.updated_at = dt.datetime.now(dt.UTC)
+            row.updated_at = datetime.datetime.now(datetime.UTC)
             row.denial_reason = denial_reason
             updated = row.to_record()
             event = self._insert_event(session, ToolCallEventType.TOOL_CALL_UPDATED, updated)
             return updated, event
 
     def _insert_event(self, session: Session, event_type: ToolCallEventType, record: ToolCallRecord) -> ToolCallEvent:
-        created_at = dt.datetime.now(dt.UTC)
+        created_at = datetime.datetime.now(datetime.UTC)
         row = McpToolCallEvent(
             event_type=event_type, tool_call_id=record.tool_call_id, status=record.status, created_at=created_at
         )
@@ -375,154 +258,6 @@ class PostgresToolCallLedger:
         if row is None:
             raise HTTPException(status_code=404, detail="tool call not found")
         return row
-
-
-class PostgresMcpOperatorOAuthStore:
-    """Postgres-backed operator OAuth association store for connected MCP servers."""
-
-    def __init__(self, database_url: str) -> None:
-        self._engine = create_engine(database_url, pool_pre_ping=True)
-        with self._engine.begin() as conn:
-            run_migrations_for_connection(conn)
-        self._sessions = sessionmaker(self._engine, expire_on_commit=False)
-
-    def list_statuses(self, *, servers: list[McpServerEntry], operator_principal: str) -> McpOperatorAuthStatusResponse:
-        oauth_servers = [server for server in servers if _operator_oauth_enabled(server)]
-        if not oauth_servers:
-            return McpOperatorAuthStatusResponse()
-        server_ids = [server.id for server in oauth_servers]
-        with self._sessions.begin() as session:
-            rows = session.scalars(
-                select(McpOperatorOAuthAssociation)
-                .where(McpOperatorOAuthAssociation.operator_principal == operator_principal)
-                .where(McpOperatorOAuthAssociation.server_id.in_(server_ids))
-            ).all()
-        by_server = {row.server_id: row for row in rows}
-        return McpOperatorAuthStatusResponse(
-            associations=[
-                _oauth_status_from_row(server.id, operator_principal, by_server.get(server.id))
-                for server in oauth_servers
-            ]
-        )
-
-    async def start_flow(
-        self, *, server: McpServerEntry, operator_principal: str, public_base_url: str
-    ) -> McpOperatorAuthStartResponse:
-        if not _operator_oauth_enabled(server):
-            raise HTTPException(status_code=404, detail=f"MCP server {server.id} does not use operator OAuth")
-        flow = await _build_operator_oauth_flow(server, operator_principal, public_base_url.rstrip("/"))
-        with self._sessions.begin() as session:
-            now = dt.datetime.now(dt.UTC)
-            session.execute(delete(McpOperatorOAuthFlow).where(McpOperatorOAuthFlow.expires_at < now))
-            session.execute(
-                delete(McpOperatorOAuthFlow)
-                .where(McpOperatorOAuthFlow.server_id == server.id)
-                .where(McpOperatorOAuthFlow.operator_principal == operator_principal)
-            )
-            session.add(
-                McpOperatorOAuthFlow(
-                    state=flow.state,
-                    server_id=server.id,
-                    operator_principal=operator_principal,
-                    created_at=now,
-                    expires_at=flow.expires_at,
-                    redirect_uri=flow.redirect_uri,
-                    code_verifier=flow.code_verifier,
-                    client_id=flow.client_info.client_id or "",
-                    client_secret=flow.client_info.client_secret,
-                    client_secret_expires_at=flow.client_info.client_secret_expires_at,
-                    token_endpoint_auth_method=flow.client_info.token_endpoint_auth_method,
-                    token_endpoint=flow.token_endpoint,
-                    resource=flow.resource,
-                    scope=flow.scope,
-                )
-            )
-        return McpOperatorAuthStartResponse(
-            server_id=server.id, authorization_url=flow.authorization_url, expires_at=flow.expires_at
-        )
-
-    async def complete_callback(self, *, state: str, code: str) -> McpOperatorAuthStatus:
-        with self._sessions.begin() as session:
-            row = session.get(McpOperatorOAuthFlow, state)
-            if row is None:
-                raise HTTPException(status_code=404, detail="OAuth flow not found or already used")
-            session.delete(row)
-            flow = _oauth_flow_snapshot(row)
-        now = dt.datetime.now(dt.UTC)
-        if flow["expires_at"] < now:
-            raise HTTPException(status_code=410, detail="OAuth flow expired; start connection again")
-        token = await _exchange_operator_oauth_code(flow, code)
-        token_expires_at = _token_expires_at(token, now)
-        with self._sessions.begin() as session:
-            existing = session.get(
-                McpOperatorOAuthAssociation, (flow["server_id"], flow["operator_principal"]), with_for_update=True
-            )
-            if existing is None:
-                existing = McpOperatorOAuthAssociation(
-                    server_id=flow["server_id"],
-                    operator_principal=flow["operator_principal"],
-                    created_at=now,
-                    updated_at=now,
-                    client_id=flow["client_id"],
-                    client_secret=flow["client_secret"],
-                    client_secret_expires_at=flow["client_secret_expires_at"],
-                    token_endpoint_auth_method=flow["token_endpoint_auth_method"],
-                    token_endpoint=flow["token_endpoint"],
-                    resource=flow["resource"],
-                    access_token=token.access_token,
-                    refresh_token=token.refresh_token,
-                    token_type=token.token_type,
-                    scope=token.scope or flow["scope"],
-                    token_expires_at=token_expires_at,
-                )
-                session.add(existing)
-            else:
-                existing.updated_at = now
-                existing.client_id = flow["client_id"]
-                existing.client_secret = flow["client_secret"]
-                existing.client_secret_expires_at = flow["client_secret_expires_at"]
-                existing.token_endpoint_auth_method = flow["token_endpoint_auth_method"]
-                existing.token_endpoint = flow["token_endpoint"]
-                existing.resource = flow["resource"]
-                existing.access_token = token.access_token
-                existing.refresh_token = token.refresh_token
-                existing.token_type = token.token_type
-                existing.scope = token.scope or flow["scope"]
-                existing.token_expires_at = token_expires_at
-            return _oauth_status_from_row(flow["server_id"], flow["operator_principal"], existing)
-
-    def disconnect(self, *, server_id: str, operator_principal: str) -> None:
-        with self._sessions.begin() as session:
-            row = session.get(McpOperatorOAuthAssociation, (server_id, operator_principal), with_for_update=True)
-            if row is not None:
-                session.delete(row)
-
-    async def access_token_for(self, *, server: McpServerEntry, operator_principal: str) -> str | None:
-        if not _operator_oauth_enabled(server):
-            return None
-        with self._sessions.begin() as session:
-            row = session.get(McpOperatorOAuthAssociation, (server.id, operator_principal), with_for_update=True)
-            if row is None:
-                return None
-            now = dt.datetime.now(dt.UTC)
-            if row.token_expires_at is None or row.token_expires_at > now + MCP_OPERATOR_AUTH_REFRESH_SKEW:
-                return row.access_token
-            if not row.refresh_token:
-                return None
-            snapshot = _oauth_association_snapshot(row)
-        refreshed = await _refresh_operator_oauth_token(snapshot)
-        token_expires_at = _token_expires_at(refreshed, dt.datetime.now(dt.UTC))
-        with self._sessions.begin() as session:
-            row = session.get(McpOperatorOAuthAssociation, (server.id, operator_principal), with_for_update=True)
-            if row is None:
-                return None
-            row.updated_at = dt.datetime.now(dt.UTC)
-            row.access_token = refreshed.access_token
-            row.refresh_token = refreshed.refresh_token or row.refresh_token
-            row.token_type = refreshed.token_type
-            row.scope = refreshed.scope or row.scope
-            row.token_expires_at = token_expires_at
-            return row.access_token
 
 
 def _psycopg_dsn(database_url: str) -> str:
@@ -613,22 +348,6 @@ class ToolCallEventHub:
                 await asyncio.sleep(1)
 
 
-# A server reached over an in-process FastMCP instance instead of a remote URL (see
-# McpServerEntry.server_url). `fastmcp.client.Client` accepts a `FastMCP` instance
-# directly and opens an in-memory `FastMCPTransport` — so both `McpToolExecutor` and
-# `McpMetadataProvider` run the exact same `Client(...)` calls either way; only this
-# lookup differs.
-InProcessServers = dict[str, FastMCP]
-
-
-def _transport(server: McpServerEntry, in_process: InProcessServers) -> FastMCP | str:
-    if in_process_server := in_process.get(server.id):
-        return in_process_server
-    if server.server_url is not None:
-        return server.server_url
-    raise RuntimeError(f"MCP server {server.id!r} has no server_url and no in-process registration")
-
-
 class McpToolExecutor:
     def __init__(self, in_process_servers: InProcessServers | None = None) -> None:
         self._in_process = in_process_servers or {}
@@ -662,11 +381,11 @@ class McpMetadataProvider:
         return AliveServerMetadata(server_id=server.id, title=server.id, tools=reflected)
 
 
-def _ledger(request: Request) -> ToolCallLedgerProtocol:
+def _ledger(request: Request) -> PostgresToolCallLedger:
     ledger = request.app.state.tool_call_ledger
     if ledger is None:
         raise HTTPException(status_code=503, detail="MCP approval database is not configured")
-    return cast(ToolCallLedgerProtocol, ledger)
+    return cast(PostgresToolCallLedger, ledger)
 
 
 def _hub(request: Request) -> ToolCallEventHub:
@@ -681,339 +400,10 @@ def _metadata_provider(request: Request) -> McpMetadataProvider:
     return cast(McpMetadataProvider, request.app.state.tool_call_metadata_provider)
 
 
-def _oauth_store(request: Request) -> McpOperatorOAuthStoreProtocol:
-    store = request.app.state.mcp_operator_oauth_store
-    if store is None:
-        raise HTTPException(status_code=503, detail="MCP operator OAuth database is not configured")
-    return cast(McpOperatorOAuthStoreProtocol, store)
-
-
-def _maybe_oauth_store(request: Request) -> McpOperatorOAuthStoreProtocol | None:
-    return cast(McpOperatorOAuthStoreProtocol | None, request.app.state.mcp_operator_oauth_store)
-
-
-LedgerDep = Annotated[ToolCallLedgerProtocol, Depends(_ledger)]
+LedgerDep = Annotated[PostgresToolCallLedger, Depends(_ledger)]
 HubDep = Annotated[ToolCallEventHub, Depends(_hub)]
 ExecutorDep = Annotated[McpToolExecutor, Depends(_executor)]
 MetadataProviderDep = Annotated[McpMetadataProvider, Depends(_metadata_provider)]
-OAuthStoreDep = Annotated[McpOperatorOAuthStoreProtocol, Depends(_oauth_store)]
-
-
-class _BuiltOperatorOAuthFlow(BaseModel):
-    state: str
-    authorization_url: str
-    expires_at: dt.datetime
-    redirect_uri: str
-    code_verifier: str
-    client_info: OAuthClientInformationFull
-    token_endpoint: str
-    resource: str | None = None
-    scope: str | None = None
-
-
-def _operator_oauth_enabled(server: McpServerEntry) -> bool:
-    return bool(server.operator_oauth and server.operator_oauth.enabled)
-
-
-def _oauth_status_from_row(
-    server_id: str, operator_principal: str, row: McpOperatorOAuthAssociation | None
-) -> McpOperatorAuthStatus:
-    if row is None:
-        return McpOperatorAuthStatus(server_id=server_id, status="unconnected", operator_principal=operator_principal)
-    return McpOperatorAuthStatus(
-        server_id=server_id,
-        status="connected",
-        operator_principal=operator_principal,
-        connected_at=row.created_at,
-        token_expires_at=row.token_expires_at,
-        scope=row.scope,
-    )
-
-
-def _token_expires_at(token: OAuthToken, now: dt.datetime) -> dt.datetime | None:
-    if token.expires_in is None:
-        return None
-    return now + dt.timedelta(seconds=token.expires_in)
-
-
-def _oauth_flow_snapshot(row: McpOperatorOAuthFlow) -> dict[str, Any]:
-    return {
-        "state": row.state,
-        "server_id": row.server_id,
-        "operator_principal": row.operator_principal,
-        "expires_at": row.expires_at,
-        "redirect_uri": row.redirect_uri,
-        "code_verifier": row.code_verifier,
-        "client_id": row.client_id,
-        "client_secret": row.client_secret,
-        "client_secret_expires_at": row.client_secret_expires_at,
-        "token_endpoint_auth_method": row.token_endpoint_auth_method,
-        "token_endpoint": row.token_endpoint,
-        "resource": row.resource,
-        "scope": row.scope,
-    }
-
-
-def _oauth_association_snapshot(row: McpOperatorOAuthAssociation) -> dict[str, Any]:
-    return {
-        "server_id": row.server_id,
-        "operator_principal": row.operator_principal,
-        "client_id": row.client_id,
-        "client_secret": row.client_secret,
-        "token_endpoint_auth_method": row.token_endpoint_auth_method,
-        "token_endpoint": row.token_endpoint,
-        "resource": row.resource,
-        "refresh_token": row.refresh_token,
-    }
-
-
-def _metadata_request_headers() -> dict[str, str]:
-    return {MCP_PROTOCOL_VERSION: LATEST_PROTOCOL_VERSION}
-
-
-async def _discover_protected_resource(
-    client: httpx.AsyncClient, server_url: str, auth_probe: httpx.Response
-) -> ProtectedResourceMetadata | None:
-    metadata_url = extract_resource_metadata_from_www_auth(auth_probe)
-    for url in build_protected_resource_metadata_discovery_urls(metadata_url, server_url):
-        response = await client.get(url, headers=_metadata_request_headers())
-        metadata = await handle_protected_resource_response(response)
-        if metadata:
-            return metadata
-    return None
-
-
-async def _discover_oauth_metadata(
-    client: httpx.AsyncClient, server_url: str, resource_metadata: ProtectedResourceMetadata | None
-) -> OAuthMetadata | None:
-    auth_server_url = str(resource_metadata.authorization_servers[0]) if resource_metadata else None
-    for url in build_oauth_authorization_server_metadata_discovery_urls(auth_server_url, server_url):
-        response = await client.get(url, headers=_metadata_request_headers())
-        ok, metadata = await handle_auth_metadata_response(response)
-        if metadata:
-            return metadata
-        if not ok:
-            break
-    return None
-
-
-def _resource_for_oauth(server_url: str, resource_metadata: ProtectedResourceMetadata | None) -> str | None:
-    if resource_metadata is None:
-        return None
-    requested = resource_url_from_server_url(server_url)
-    configured = str(resource_metadata.resource)
-    if check_resource_allowed(requested_resource=requested, configured_resource=configured):
-        return configured
-    return requested
-
-
-async def _register_oauth_client(
-    client: httpx.AsyncClient,
-    server_url: str,
-    oauth_metadata: OAuthMetadata | None,
-    client_metadata: OAuthClientMetadata,
-) -> OAuthClientInformationFull:
-    if oauth_metadata and oauth_metadata.registration_endpoint:
-        registration_url = str(oauth_metadata.registration_endpoint)
-    else:
-        registration_url = urljoin(_authorization_base_url(server_url), "/register")
-    response = await client.post(
-        registration_url,
-        json=client_metadata.model_dump(by_alias=True, mode="json", exclude_none=True),
-        headers={"Content-Type": "application/json"},
-    )
-    return await handle_registration_response(response)
-
-
-def _authorization_base_url(server_url: str) -> str:
-    parsed = httpx.URL(server_url)
-    return f"{parsed.scheme}://{parsed.host}{f':{parsed.port}' if parsed.port else ''}"
-
-
-async def _build_operator_oauth_flow(
-    server: McpServerEntry, operator_principal: str, public_base_url: str
-) -> _BuiltOperatorOAuthFlow:
-    assert server.operator_oauth is not None
-    # operator_oauth is meaningless for an in-process server (there's no remote
-    # authorization server to run DCR/metadata discovery against), so this is always
-    # set in practice; bind it to a local for stable mypy narrowing across the awaits.
-    assert server.server_url is not None
-    server_url = server.server_url
-    redirect_uri = f"{public_base_url}{MCP_OPERATOR_AUTH_CALLBACK_PATH}"
-    try:
-        async with httpx.AsyncClient(follow_redirects=False, timeout=10.0) as client:
-            auth_probe = await client.get(server_url, headers=_metadata_request_headers())
-            resource_metadata = await _discover_protected_resource(client, server_url, auth_probe)
-            oauth_metadata = await _discover_oauth_metadata(client, server_url, resource_metadata)
-            scope = (
-                " ".join(server.operator_oauth.scopes)
-                if server.operator_oauth.scopes is not None
-                else get_client_metadata_scopes(
-                    extract_scope_from_www_auth(auth_probe), resource_metadata, oauth_metadata
-                )
-            )
-            client_metadata = OAuthClientMetadata(
-                client_name=server.operator_oauth.client_name,
-                redirect_uris=[redirect_uri],
-                grant_types=["authorization_code", "refresh_token"],
-                response_types=["code"],
-                scope=scope,
-            )
-            if server.operator_oauth.static_client_id:
-                client_info = OAuthClientInformationFull(
-                    client_id=server.operator_oauth.static_client_id,
-                    redirect_uris=client_metadata.redirect_uris,
-                    grant_types=client_metadata.grant_types,
-                    response_types=client_metadata.response_types,
-                    scope=client_metadata.scope,
-                    client_name=client_metadata.client_name,
-                )
-            else:
-                client_info = await _register_oauth_client(client, server_url, oauth_metadata, client_metadata)
-    except Exception as e:
-        raise HTTPException(status_code=502, detail=f"failed to start MCP OAuth flow for {server.id}: {e}") from e
-
-    if not client_info.client_id:
-        raise HTTPException(status_code=502, detail=f"MCP OAuth registration for {server.id} did not return client_id")
-    pkce = PKCEParameters.generate()
-    state = secrets.token_urlsafe(32)
-    if oauth_metadata and oauth_metadata.authorization_endpoint:
-        auth_endpoint = str(oauth_metadata.authorization_endpoint)
-    else:
-        auth_endpoint = urljoin(_authorization_base_url(server_url), "/authorize")
-    if oauth_metadata and oauth_metadata.token_endpoint:
-        token_endpoint = str(oauth_metadata.token_endpoint)
-    else:
-        token_endpoint = urljoin(_authorization_base_url(server_url), "/token")
-    resource = _resource_for_oauth(server_url, resource_metadata)
-    params = {
-        "response_type": "code",
-        "client_id": client_info.client_id,
-        "redirect_uri": redirect_uri,
-        "state": state,
-        "code_challenge": pkce.code_challenge,
-        "code_challenge_method": "S256",
-    }
-    if resource:
-        params["resource"] = resource
-    if scope:
-        params["scope"] = scope
-    return _BuiltOperatorOAuthFlow(
-        state=state,
-        authorization_url=f"{auth_endpoint}?{urlencode(params)}",
-        expires_at=dt.datetime.now(dt.UTC) + MCP_OPERATOR_AUTH_FLOW_TTL,
-        redirect_uri=redirect_uri,
-        code_verifier=pkce.code_verifier,
-        client_info=client_info,
-        token_endpoint=token_endpoint,
-        resource=resource,
-        scope=scope,
-    )
-
-
-def _token_request_auth(
-    data: dict[str, str], *, client_id: str, client_secret: str | None, token_endpoint_auth_method: str | None
-) -> tuple[dict[str, str], dict[str, str]]:
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-    if token_endpoint_auth_method == "client_secret_basic" and client_secret:
-        encoded_id = quote(client_id, safe="")
-        encoded_secret = quote(client_secret, safe="")
-        credentials = base64.b64encode(f"{encoded_id}:{encoded_secret}".encode()).decode()
-        headers["Authorization"] = f"Basic {credentials}"
-    elif token_endpoint_auth_method == "client_secret_post" and client_secret:
-        data["client_secret"] = client_secret
-    return data, headers
-
-
-async def _exchange_operator_oauth_code(flow: dict[str, Any], code: str) -> OAuthToken:
-    data: dict[str, str] = {
-        "grant_type": "authorization_code",
-        "code": code,
-        "redirect_uri": flow["redirect_uri"],
-        "client_id": flow["client_id"],
-        "code_verifier": flow["code_verifier"],
-    }
-    if flow["resource"]:
-        data["resource"] = flow["resource"]
-    data, headers = _token_request_auth(
-        data,
-        client_id=flow["client_id"],
-        client_secret=flow["client_secret"],
-        token_endpoint_auth_method=flow["token_endpoint_auth_method"],
-    )
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.post(flow["token_endpoint"], data=data, headers=headers)
-    if response.status_code != 200:
-        raise HTTPException(status_code=502, detail=f"MCP OAuth token exchange failed: {response.status_code}")
-    try:
-        return await handle_token_response_scopes(response)
-    except ValidationError as e:
-        raise HTTPException(status_code=502, detail=f"MCP OAuth token response was invalid: {e}") from e
-
-
-async def _refresh_operator_oauth_token(association: dict[str, Any]) -> OAuthToken:
-    refresh_token = association["refresh_token"]
-    if not refresh_token:
-        raise RuntimeError("MCP OAuth association has no refresh token; reconnect in the console")
-    data: dict[str, str] = {
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token,
-        "client_id": association["client_id"],
-    }
-    if association["resource"]:
-        data["resource"] = association["resource"]
-    data, headers = _token_request_auth(
-        data,
-        client_id=association["client_id"],
-        client_secret=association["client_secret"],
-        token_endpoint_auth_method=association["token_endpoint_auth_method"],
-    )
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.post(association["token_endpoint"], data=data, headers=headers)
-    if response.status_code != 200:
-        raise RuntimeError(f"MCP OAuth token refresh failed: {response.status_code}")
-    try:
-        return await handle_token_response_scopes(response)
-    except ValidationError as e:
-        raise RuntimeError(f"MCP OAuth refresh response was invalid: {e}") from e
-
-
-def _oauth_callback_response(ok: bool, message: str, *, status_code: int = 200) -> HTMLResponse:
-    title = "MCP account connected" if ok else "MCP account connection failed"
-    safe_title = html.escape(title)
-    safe_message = html.escape(message)
-    payload = "mcpAuthChanged" if ok else "mcpAuthFailed"
-    return HTMLResponse(
-        status_code=status_code,
-        content=f"""<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>{safe_title}</title>
-    <style>
-      body {{
-        color-scheme: light dark;
-        font: 16px system-ui, sans-serif;
-        margin: 3rem auto;
-        max-width: 36rem;
-        line-height: 1.4;
-      }}
-      code {{
-        overflow-wrap: anywhere;
-      }}
-    </style>
-  </head>
-  <body>
-    <h1>{safe_title}</h1>
-    <p><code>{safe_message}</code></p>
-    <script>
-      try {{
-        new BroadcastChannel("haku-console-mcp-auth").postMessage({{ type: "{payload}" }});
-      }} catch (_) {{}}
-    </script>
-  </body>
-</html>""",
-    )
 
 
 def _mcp_result_to_json(result: mcp_types.CallToolResult) -> dict[str, Any]:
@@ -1023,36 +413,6 @@ def _mcp_result_to_json(result: mcp_types.CallToolResult) -> dict[str, Any]:
 def _mcp_error_message(result: mcp_types.CallToolResult) -> str:
     text_blocks = [block.text for block in result.content if isinstance(block, mcp_types.TextContent)]
     return "\n".join(text_blocks) or "MCP tool returned isError=true"
-
-
-def _credential_env_name(bearer_token_secret: str) -> str:
-    suffix = re.sub(r"[^A-Za-z0-9]+", "_", bearer_token_secret).strip("_").upper()
-    return f"HAKU_CONSOLE_MCP_CREDENTIAL_{suffix}"
-
-
-def _credential_token(server: McpServerEntry) -> str | None:
-    if server.bearer_token_secret is None:
-        return None
-    env_name = _credential_env_name(server.bearer_token_secret)
-    token = os.environ.get(env_name)
-    if not token:
-        raise RuntimeError(f"missing MCP bearer token env var {env_name} for MCP server {server.id}")
-    return token
-
-
-def _load_servers(settings: Settings) -> list[McpServerEntry]:
-    path = settings.config_file
-    if path is None or not path.exists():
-        return []
-    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    return ConsoleConfigFile.model_validate(raw).mcp.servers
-
-
-def _server_entry(settings: Settings, server_id: str) -> McpServerEntry:
-    for server in _load_servers(settings):
-        if server.id == server_id:
-            return server
-    raise HTTPException(status_code=404, detail=f"unknown MCP server: {server_id}")
 
 
 def _pending_approval_from_record(record: ToolCallRecord) -> PendingApproval:
@@ -1081,24 +441,8 @@ def _caller_principal(request: Request, settings: Settings) -> str:
     return "operator"
 
 
-def _operator_principal(request: Request) -> str:
-    return request.headers.get("x-authentik-username") or "operator"
-
-
-def _public_base_url(request: Request, settings: Settings) -> str:
-    if settings.public_base_url:
-        return settings.public_base_url.rstrip("/")
-    proto = (request.headers.get("x-forwarded-proto") or request.url.scheme).split(",", 1)[0].strip()
-    host = (
-        (request.headers.get("x-forwarded-host") or request.headers.get("host") or request.url.netloc)
-        .split(",", 1)[0]
-        .strip()
-    )
-    return f"{proto}://{host}"
-
-
 async def _execution_auth(
-    server: McpServerEntry, operator_principal: str, oauth_store: McpOperatorOAuthStoreProtocol
+    server: McpServerEntry, operator_principal: str, oauth_store: PostgresMcpOperatorOAuthStore
 ) -> str | None:
     if _operator_oauth_enabled(server):
         token = await oauth_store.access_token_for(server=server, operator_principal=operator_principal)
@@ -1112,7 +456,7 @@ async def _execution_auth(
 
 
 async def operator_authenticated_client(
-    server_id: str, request: Request, settings: Settings, oauth_store: McpOperatorOAuthStoreProtocol
+    server_id: str, request: Request, settings: Settings, oauth_store: PostgresMcpOperatorOAuthStore
 ) -> Client:
     """Open a `fastmcp` client for `server_id`, authenticated exactly as an approved tool call
     for that server would be (the requesting operator's own `operator_oauth` token, or the
@@ -1130,7 +474,7 @@ async def operator_authenticated_client(
 async def _maybe_execute(
     record: ToolCallRecord,
     server: McpServerEntry,
-    ledger: ToolCallLedgerProtocol,
+    ledger: PostgresToolCallLedger,
     hub: ToolCallEventHub,
     executor: McpToolExecutor,
     auth_token: str | None,
@@ -1154,7 +498,7 @@ async def _maybe_execute(
     return updated
 
 
-async def _wait_terminal(ledger: ToolCallLedgerProtocol, tool_call_id: str, wait_for_ms: int) -> ToolCallRecord:
+async def _wait_terminal(ledger: PostgresToolCallLedger, tool_call_id: str, wait_for_ms: int) -> ToolCallRecord:
     deadline = asyncio.get_running_loop().time() + (wait_for_ms / 1000)
     while True:
         record = ledger.get(tool_call_id)
@@ -1239,7 +583,7 @@ async def submit_tool_call(
 async def list_tool_calls(
     ledger: LedgerDep,
     status: Annotated[list[ToolCallStatus] | None, Query()] = None,
-    since: dt.datetime | None = None,
+    since: datetime.datetime | None = None,
     limit: Annotated[int, Query(ge=1, le=500)] = 100,
     newest_first: bool = False,
 ) -> ToolCallListResponse:
@@ -1260,52 +604,6 @@ async def pending_approvals(ledger: LedgerDep) -> PendingApprovalsResponse:
 @router.get("/api/approvals/events")
 async def approval_events(ledger: LedgerDep, after_event_id: int = 0) -> ToolCallEventsResponse:
     return ledger.events_after_id(after_event_id)
-
-
-@router.get("/api/mcp/operator-auth")
-async def mcp_operator_auth_statuses(
-    request: Request, settings: SettingsDep, oauth_store: OAuthStoreDep
-) -> McpOperatorAuthStatusResponse:
-    return oauth_store.list_statuses(servers=_load_servers(settings), operator_principal=_operator_principal(request))
-
-
-@router.post("/api/mcp/operator-auth/{server_id}/start")
-async def start_mcp_operator_auth(
-    server_id: str, request: Request, csrf_protect: Csrf, settings: SettingsDep, oauth_store: OAuthStoreDep
-) -> McpOperatorAuthStartResponse:
-    await csrf_protect.validate_csrf(request)
-    server = _server_entry(settings, server_id)
-    return await oauth_store.start_flow(
-        server=server,
-        operator_principal=_operator_principal(request),
-        public_base_url=_public_base_url(request, settings),
-    )
-
-
-@router.delete("/api/mcp/operator-auth/{server_id}")
-async def disconnect_mcp_operator_auth(
-    server_id: str, request: Request, csrf_protect: Csrf, oauth_store: OAuthStoreDep
-) -> McpOperatorAuthStatus:
-    await csrf_protect.validate_csrf(request)
-    operator_principal = _operator_principal(request)
-    oauth_store.disconnect(server_id=server_id, operator_principal=operator_principal)
-    return McpOperatorAuthStatus(server_id=server_id, status="unconnected", operator_principal=operator_principal)
-
-
-@router.get(MCP_OPERATOR_AUTH_CALLBACK_PATH)
-async def mcp_operator_auth_callback(
-    oauth_store: OAuthStoreDep, state: str | None = None, code: str | None = None, error: str | None = None
-) -> HTMLResponse:
-    if error:
-        return _oauth_callback_response(False, f"MCP OAuth authorization failed: {error}", status_code=400)
-    if not state or not code:
-        return _oauth_callback_response(False, "MCP OAuth callback is missing state or code.", status_code=400)
-    try:
-        status = await oauth_store.complete_callback(state=state, code=code)
-    except HTTPException as e:
-        detail = e.detail if isinstance(e.detail, str) else "MCP OAuth callback failed."
-        return _oauth_callback_response(False, detail, status_code=e.status_code)
-    return _oauth_callback_response(True, f"Connected {status.server_id} for {status.operator_principal}.")
 
 
 @router.post("/api/tool-calls/{tool_call_id}/decision")

--- a/haku/console/mcp_config.py
+++ b/haku/console/mcp_config.py
@@ -1,0 +1,103 @@
+"""The connected-MCP-server catalog and how to reach each entry.
+
+The console's deploy-time YAML names the MCP servers Haku may drive through the approval
+queue; this module models that config, looks entries up by id, and resolves how to reach
+each one — the in-process `FastMCP` transport or remote URL, and the static bearer
+credential where one applies. Both the approval router (`mcp_approval`) and the operator
+OAuth linkage (`mcp_operator_oauth`) build on this shared substrate.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import yaml
+from fastapi import HTTPException
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+from haku.console.config import Settings
+
+
+class McpOperatorOAuthConfig(BaseModel):
+    enabled: bool = True
+    client_name: str = "Haku Console"
+    scopes: list[str] | None = None
+    # For an authorization server with no open Dynamic Client Registration (RFC 7591) —
+    # e.g. Authentik, which has no /register endpoint, so the server-metadata-declared
+    # registration_endpoint is absent and DCR would otherwise 401 against a guessed
+    # {server}/register fallback. A pre-registered public/PKCE client_id shared across
+    # every OAuth caller of that authorization server, skipping registration entirely.
+    # Safe to share: PKCE plus per-request redirect_uri validation secure each caller's
+    # auth code exchange independently even though the client_id is the same for all.
+    static_client_id: str | None = None
+
+
+class McpServerEntry(BaseModel):
+    id: str
+    # None for a server reached via an in-process FastMCP instance instead of a remote
+    # URL (see McpToolExecutor/McpMetadataProvider's `in_process_servers` registry,
+    # e.g. haku.console.tools.gmail's `gmail` server) — resolved at runtime by id,
+    # not by anything in this config model.
+    server_url: str | None = None
+    bearer_token_secret: str | None = None
+    operator_oauth: McpOperatorOAuthConfig | None = None
+
+
+class ConsoleMcpConfig(BaseModel):
+    servers: list[McpServerEntry] = Field(default_factory=list)
+
+
+class ConsoleConfigFile(BaseModel):
+    mcp: ConsoleMcpConfig = Field(default_factory=ConsoleMcpConfig)
+
+
+def _load_servers(settings: Settings) -> list[McpServerEntry]:
+    path = settings.config_file
+    if path is None or not path.exists():
+        return []
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return ConsoleConfigFile.model_validate(raw).mcp.servers
+
+
+def _server_entry(settings: Settings, server_id: str) -> McpServerEntry:
+    for server in _load_servers(settings):
+        if server.id == server_id:
+            return server
+    raise HTTPException(status_code=404, detail=f"unknown MCP server: {server_id}")
+
+
+def _operator_oauth_enabled(server: McpServerEntry) -> bool:
+    return bool(server.operator_oauth and server.operator_oauth.enabled)
+
+
+def _credential_env_name(bearer_token_secret: str) -> str:
+    suffix = re.sub(r"[^A-Za-z0-9]+", "_", bearer_token_secret).strip("_").upper()
+    return f"HAKU_CONSOLE_MCP_CREDENTIAL_{suffix}"
+
+
+def _credential_token(server: McpServerEntry) -> str | None:
+    if server.bearer_token_secret is None:
+        return None
+    env_name = _credential_env_name(server.bearer_token_secret)
+    token = os.environ.get(env_name)
+    if not token:
+        raise RuntimeError(f"missing MCP bearer token env var {env_name} for MCP server {server.id}")
+    return token
+
+
+# A server reached over an in-process FastMCP instance instead of a remote URL (see
+# McpServerEntry.server_url). `fastmcp.client.Client` accepts a `FastMCP` instance
+# directly and opens an in-memory `FastMCPTransport` — so both `McpToolExecutor` and
+# `McpMetadataProvider` run the exact same `Client(...)` calls either way; only this
+# lookup differs.
+InProcessServers = dict[str, FastMCP]
+
+
+def _transport(server: McpServerEntry, in_process: InProcessServers) -> FastMCP | str:
+    if in_process_server := in_process.get(server.id):
+        return in_process_server
+    if server.server_url is not None:
+        return server.server_url
+    raise RuntimeError(f"MCP server {server.id!r} has no server_url and no in-process registration")

--- a/haku/console/mcp_operator_auth_callback.html
+++ b/haku/console/mcp_operator_auth_callback.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>$title</title>
+    <style>
+      body {
+        color-scheme: light dark;
+        font:
+          16px system-ui,
+          sans-serif;
+        margin: 3rem auto;
+        max-width: 36rem;
+        line-height: 1.4;
+      }
+      code {
+        overflow-wrap: anywhere;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>$title</h1>
+    <p><code>$message</code></p>
+    <!-- Notify any open console tab (the Settings page listens on this channel) that the
+         operator's MCP account linkage changed, so it refetches without a manual reload. -->
+    <script>
+      try {
+        new BroadcastChannel("haku-console-mcp-auth").postMessage({ type: "$payload" });
+      } catch (_) {}
+    </script>
+  </body>
+</html>

--- a/haku/console/mcp_operator_oauth.py
+++ b/haku/console/mcp_operator_oauth.py
@@ -1,0 +1,661 @@
+"""Operator OAuth account linkage for connected MCP servers.
+
+Some MCP servers execute a tool call as *the operator's own account* rather than under a
+static console-held bearer (e.g. `kubectl-passthrough-mcp`, which runs kubectl as the
+approving operator's cluster-admin identity). For those, the operator links their account
+once through an OAuth authorization-code + PKCE flow; the console runs Dynamic Client
+Registration (or uses a pre-registered `static_client_id`), stores the resulting token
+association, and refreshes it as needed. This module owns that flow, its Postgres-backed
+storage, and the connect/disconnect/callback endpoints. The approval router
+(`mcp_approval`) consumes the linked token via `access_token_for` when it executes an
+approved call; the catalog of which servers use operator OAuth lives in `mcp_config`.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import html
+import secrets
+from pathlib import Path
+from string import Template
+from typing import Annotated, Literal, cast
+from urllib.parse import quote, urlencode, urljoin
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi_csrf_protect import CsrfProtect
+from mcp.client.auth.oauth2 import PKCEParameters
+from mcp.client.auth.utils import (
+    build_oauth_authorization_server_metadata_discovery_urls,
+    build_protected_resource_metadata_discovery_urls,
+    extract_resource_metadata_from_www_auth,
+    extract_scope_from_www_auth,
+    get_client_metadata_scopes,
+    handle_auth_metadata_response,
+    handle_protected_resource_response,
+    handle_registration_response,
+    handle_token_response_scopes,
+)
+from mcp.client.streamable_http import MCP_PROTOCOL_VERSION
+from mcp.shared.auth import (
+    OAuthClientInformationFull,
+    OAuthClientMetadata,
+    OAuthMetadata,
+    OAuthToken,
+    ProtectedResourceMetadata,
+)
+from mcp.shared.auth_utils import check_resource_allowed, resource_url_from_server_url
+from mcp.types import LATEST_PROTOCOL_VERSION
+from pydantic import BaseModel, Field, ValidationError
+from sqlalchemy import create_engine, delete, select
+from sqlalchemy.orm import sessionmaker
+
+from haku.console.config import Settings
+from haku.console.database_migrate import run_migrations_for_connection
+from haku.console.database_schema import McpOperatorOAuthAssociation, McpOperatorOAuthFlow
+from haku.console.deps import SettingsDep
+from haku.console.mcp_config import McpServerEntry, _load_servers, _operator_oauth_enabled, _server_entry
+
+Csrf = Annotated[CsrfProtect, Depends()]
+
+MCP_OPERATOR_AUTH_CALLBACK_PATH = "/api/mcp/operator-auth/callback"
+MCP_OPERATOR_AUTH_FLOW_TTL = datetime.timedelta(minutes=10)
+MCP_OPERATOR_AUTH_REFRESH_SKEW = datetime.timedelta(seconds=60)
+
+router = APIRouter(tags=["mcp-operator-oauth"])
+
+
+class McpOperatorAuthStatusBase(BaseModel):
+    server_id: str
+    operator_principal: str
+
+
+class McpOperatorAuthConnected(McpOperatorAuthStatusBase):
+    status: Literal["connected"] = "connected"
+    connected_at: datetime.datetime
+    # None when the linked token declares no expiry (OAuth `expires_in` absent).
+    token_expires_at: datetime.datetime | None = None
+    scope: str | None = None
+
+
+class McpOperatorAuthUnconnected(McpOperatorAuthStatusBase):
+    status: Literal["unconnected"] = "unconnected"
+
+
+# Discriminated on `status`, so the connected-only fields (connected_at/token_expires_at/
+# scope) exist exactly when connected — no "unconnected with a connected_at" nonsense state.
+type McpOperatorAuthStatus = Annotated[
+    McpOperatorAuthConnected | McpOperatorAuthUnconnected, Field(discriminator="status")
+]
+
+
+class McpOperatorAuthStatusResponse(BaseModel):
+    associations: list[McpOperatorAuthStatus] = Field(default_factory=list)
+
+
+class McpOperatorAuthStartResponse(BaseModel):
+    server_id: str
+    authorization_url: str
+    expires_at: datetime.datetime
+
+
+class _OperatorOAuthTokenClient(BaseModel):
+    """Token-endpoint call parameters shared by the auth-code exchange and the refresh.
+    Detached from the ORM row so the network call runs with no DB session held open."""
+
+    client_id: str
+    client_secret: str | None = None
+    token_endpoint_auth_method: str | None = None
+    token_endpoint: str
+    resource: str | None = None
+
+
+class OperatorOAuthFlowState(_OperatorOAuthTokenClient):
+    """An `McpOperatorOAuthFlow` row read out before its session closes, carried across the
+    authorization-code → token exchange (which must not hold a DB session open)."""
+
+    server_id: str
+    operator_principal: str
+    expires_at: datetime.datetime
+    redirect_uri: str
+    code_verifier: str
+    client_secret_expires_at: int | None = None
+    scope: str | None = None
+
+    @classmethod
+    def from_row(cls, row: McpOperatorOAuthFlow) -> OperatorOAuthFlowState:
+        return cls(
+            client_id=row.client_id,
+            client_secret=row.client_secret,
+            token_endpoint_auth_method=row.token_endpoint_auth_method,
+            token_endpoint=row.token_endpoint,
+            resource=row.resource,
+            server_id=row.server_id,
+            operator_principal=row.operator_principal,
+            expires_at=row.expires_at,
+            redirect_uri=row.redirect_uri,
+            code_verifier=row.code_verifier,
+            client_secret_expires_at=row.client_secret_expires_at,
+            scope=row.scope,
+        )
+
+
+class OperatorOAuthRefreshState(_OperatorOAuthTokenClient):
+    """An `McpOperatorOAuthAssociation` row's refresh inputs read out before its session
+    closes, carried across the token-refresh network call."""
+
+    refresh_token: str | None = None
+
+    @classmethod
+    def from_row(cls, row: McpOperatorOAuthAssociation) -> OperatorOAuthRefreshState:
+        return cls(
+            client_id=row.client_id,
+            client_secret=row.client_secret,
+            token_endpoint_auth_method=row.token_endpoint_auth_method,
+            token_endpoint=row.token_endpoint,
+            resource=row.resource,
+            refresh_token=row.refresh_token,
+        )
+
+
+class _BuiltOperatorOAuthFlow(BaseModel):
+    state: str
+    authorization_url: str
+    expires_at: datetime.datetime
+    redirect_uri: str
+    code_verifier: str
+    client_info: OAuthClientInformationFull
+    token_endpoint: str
+    resource: str | None = None
+    scope: str | None = None
+
+
+class PostgresMcpOperatorOAuthStore:
+    """Postgres-backed operator OAuth association store for connected MCP servers."""
+
+    def __init__(self, database_url: str) -> None:
+        self._engine = create_engine(database_url, pool_pre_ping=True)
+        with self._engine.begin() as conn:
+            run_migrations_for_connection(conn)
+        self._sessions = sessionmaker(self._engine, expire_on_commit=False)
+
+    def list_statuses(self, *, servers: list[McpServerEntry], operator_principal: str) -> McpOperatorAuthStatusResponse:
+        oauth_servers = [server for server in servers if _operator_oauth_enabled(server)]
+        if not oauth_servers:
+            return McpOperatorAuthStatusResponse()
+        server_ids = [server.id for server in oauth_servers]
+        with self._sessions.begin() as session:
+            rows = session.scalars(
+                select(McpOperatorOAuthAssociation)
+                .where(McpOperatorOAuthAssociation.operator_principal == operator_principal)
+                .where(McpOperatorOAuthAssociation.server_id.in_(server_ids))
+            ).all()
+        by_server = {row.server_id: row for row in rows}
+        return McpOperatorAuthStatusResponse(
+            associations=[
+                _oauth_status_from_row(server.id, operator_principal, by_server.get(server.id))
+                for server in oauth_servers
+            ]
+        )
+
+    async def start_flow(
+        self, *, server: McpServerEntry, operator_principal: str, public_base_url: str
+    ) -> McpOperatorAuthStartResponse:
+        if not _operator_oauth_enabled(server):
+            raise HTTPException(status_code=404, detail=f"MCP server {server.id} does not use operator OAuth")
+        flow = await _build_operator_oauth_flow(server, public_base_url.rstrip("/"))
+        with self._sessions.begin() as session:
+            now = datetime.datetime.now(datetime.UTC)
+            session.execute(delete(McpOperatorOAuthFlow).where(McpOperatorOAuthFlow.expires_at < now))
+            session.execute(
+                delete(McpOperatorOAuthFlow)
+                .where(McpOperatorOAuthFlow.server_id == server.id)
+                .where(McpOperatorOAuthFlow.operator_principal == operator_principal)
+            )
+            session.add(
+                McpOperatorOAuthFlow(
+                    state=flow.state,
+                    server_id=server.id,
+                    operator_principal=operator_principal,
+                    created_at=now,
+                    expires_at=flow.expires_at,
+                    redirect_uri=flow.redirect_uri,
+                    code_verifier=flow.code_verifier,
+                    client_id=flow.client_info.client_id or "",
+                    client_secret=flow.client_info.client_secret,
+                    client_secret_expires_at=flow.client_info.client_secret_expires_at,
+                    token_endpoint_auth_method=flow.client_info.token_endpoint_auth_method,
+                    token_endpoint=flow.token_endpoint,
+                    resource=flow.resource,
+                    scope=flow.scope,
+                )
+            )
+        return McpOperatorAuthStartResponse(
+            server_id=server.id, authorization_url=flow.authorization_url, expires_at=flow.expires_at
+        )
+
+    async def complete_callback(self, *, state: str, code: str) -> McpOperatorAuthStatus:
+        with self._sessions.begin() as session:
+            if (row := session.get(McpOperatorOAuthFlow, state)) is None:
+                raise HTTPException(status_code=404, detail="OAuth flow not found or already used")
+            session.delete(row)
+            flow = OperatorOAuthFlowState.from_row(row)
+        now = datetime.datetime.now(datetime.UTC)
+        if flow.expires_at < now:
+            raise HTTPException(status_code=410, detail="OAuth flow expired; start connection again")
+        token = await _exchange_operator_oauth_code(flow, code)
+        token_expires_at = _token_expires_at(token, now)
+        with self._sessions.begin() as session:
+            existing = session.get(
+                McpOperatorOAuthAssociation, (flow.server_id, flow.operator_principal), with_for_update=True
+            )
+            if existing is None:
+                existing = McpOperatorOAuthAssociation(
+                    server_id=flow.server_id,
+                    operator_principal=flow.operator_principal,
+                    created_at=now,
+                    updated_at=now,
+                    client_id=flow.client_id,
+                    client_secret=flow.client_secret,
+                    client_secret_expires_at=flow.client_secret_expires_at,
+                    token_endpoint_auth_method=flow.token_endpoint_auth_method,
+                    token_endpoint=flow.token_endpoint,
+                    resource=flow.resource,
+                    access_token=token.access_token,
+                    refresh_token=token.refresh_token,
+                    token_type=token.token_type,
+                    scope=token.scope or flow.scope,
+                    token_expires_at=token_expires_at,
+                )
+                session.add(existing)
+            else:
+                existing.updated_at = now
+                existing.client_id = flow.client_id
+                existing.client_secret = flow.client_secret
+                existing.client_secret_expires_at = flow.client_secret_expires_at
+                existing.token_endpoint_auth_method = flow.token_endpoint_auth_method
+                existing.token_endpoint = flow.token_endpoint
+                existing.resource = flow.resource
+                existing.access_token = token.access_token
+                existing.refresh_token = token.refresh_token
+                existing.token_type = token.token_type
+                existing.scope = token.scope or flow.scope
+                existing.token_expires_at = token_expires_at
+            return _oauth_status_from_row(flow.server_id, flow.operator_principal, existing)
+
+    def disconnect(self, *, server_id: str, operator_principal: str) -> None:
+        with self._sessions.begin() as session:
+            row = session.get(McpOperatorOAuthAssociation, (server_id, operator_principal), with_for_update=True)
+            if row is not None:
+                session.delete(row)
+
+    async def access_token_for(self, *, server: McpServerEntry, operator_principal: str) -> str | None:
+        if not _operator_oauth_enabled(server):
+            return None
+        with self._sessions.begin() as session:
+            row = session.get(McpOperatorOAuthAssociation, (server.id, operator_principal), with_for_update=True)
+            if row is None:
+                return None
+            now = datetime.datetime.now(datetime.UTC)
+            if row.token_expires_at is None or row.token_expires_at > now + MCP_OPERATOR_AUTH_REFRESH_SKEW:
+                return row.access_token
+            if not row.refresh_token:
+                return None
+            snapshot = OperatorOAuthRefreshState.from_row(row)
+        refreshed = await _refresh_operator_oauth_token(snapshot)
+        token_expires_at = _token_expires_at(refreshed, datetime.datetime.now(datetime.UTC))
+        with self._sessions.begin() as session:
+            row = session.get(McpOperatorOAuthAssociation, (server.id, operator_principal), with_for_update=True)
+            if row is None:
+                return None
+            row.updated_at = datetime.datetime.now(datetime.UTC)
+            row.access_token = refreshed.access_token
+            row.refresh_token = refreshed.refresh_token or row.refresh_token
+            row.token_type = refreshed.token_type
+            row.scope = refreshed.scope or row.scope
+            row.token_expires_at = token_expires_at
+            return row.access_token
+
+
+def _oauth_store(request: Request) -> PostgresMcpOperatorOAuthStore:
+    store = request.app.state.mcp_operator_oauth_store
+    if store is None:
+        raise HTTPException(status_code=503, detail="MCP operator OAuth database is not configured")
+    return cast(PostgresMcpOperatorOAuthStore, store)
+
+
+def _maybe_oauth_store(request: Request) -> PostgresMcpOperatorOAuthStore | None:
+    return cast(PostgresMcpOperatorOAuthStore | None, request.app.state.mcp_operator_oauth_store)
+
+
+OAuthStoreDep = Annotated[PostgresMcpOperatorOAuthStore, Depends(_oauth_store)]
+
+
+def _operator_principal(request: Request) -> str:
+    return request.headers.get("x-authentik-username") or "operator"
+
+
+def _public_base_url(request: Request, settings: Settings) -> str:
+    if settings.public_base_url:
+        return settings.public_base_url.rstrip("/")
+    proto = (request.headers.get("x-forwarded-proto") or request.url.scheme).split(",", 1)[0].strip()
+    host = (
+        (request.headers.get("x-forwarded-host") or request.headers.get("host") or request.url.netloc)
+        .split(",", 1)[0]
+        .strip()
+    )
+    return f"{proto}://{host}"
+
+
+def _oauth_status_from_row(
+    server_id: str, operator_principal: str, row: McpOperatorOAuthAssociation | None
+) -> McpOperatorAuthStatus:
+    if row is None:
+        return McpOperatorAuthUnconnected(server_id=server_id, operator_principal=operator_principal)
+    return McpOperatorAuthConnected(
+        server_id=server_id,
+        operator_principal=operator_principal,
+        connected_at=row.created_at,
+        token_expires_at=row.token_expires_at,
+        scope=row.scope,
+    )
+
+
+def _token_expires_at(token: OAuthToken, now: datetime.datetime) -> datetime.datetime | None:
+    if token.expires_in is None:
+        return None
+    return now + datetime.timedelta(seconds=token.expires_in)
+
+
+def _metadata_request_headers() -> dict[str, str]:
+    return {MCP_PROTOCOL_VERSION: LATEST_PROTOCOL_VERSION}
+
+
+async def _discover_protected_resource(
+    client: httpx.AsyncClient, server_url: str, auth_probe: httpx.Response
+) -> ProtectedResourceMetadata | None:
+    metadata_url = extract_resource_metadata_from_www_auth(auth_probe)
+    for url in build_protected_resource_metadata_discovery_urls(metadata_url, server_url):
+        response = await client.get(url, headers=_metadata_request_headers())
+        if metadata := await handle_protected_resource_response(response):
+            return metadata
+    return None
+
+
+async def _discover_oauth_metadata(
+    client: httpx.AsyncClient, server_url: str, resource_metadata: ProtectedResourceMetadata | None
+) -> OAuthMetadata | None:
+    auth_server_url = str(resource_metadata.authorization_servers[0]) if resource_metadata else None
+    for url in build_oauth_authorization_server_metadata_discovery_urls(auth_server_url, server_url):
+        response = await client.get(url, headers=_metadata_request_headers())
+        ok, metadata = await handle_auth_metadata_response(response)
+        if metadata:
+            return metadata
+        if not ok:
+            break
+    return None
+
+
+def _resource_for_oauth(server_url: str, resource_metadata: ProtectedResourceMetadata | None) -> str | None:
+    if resource_metadata is None:
+        return None
+    requested = resource_url_from_server_url(server_url)
+    configured = str(resource_metadata.resource)
+    if check_resource_allowed(requested_resource=requested, configured_resource=configured):
+        return configured
+    return requested
+
+
+async def _register_oauth_client(
+    client: httpx.AsyncClient,
+    server_url: str,
+    oauth_metadata: OAuthMetadata | None,
+    client_metadata: OAuthClientMetadata,
+) -> OAuthClientInformationFull:
+    if oauth_metadata and oauth_metadata.registration_endpoint:
+        registration_url = str(oauth_metadata.registration_endpoint)
+    else:
+        registration_url = urljoin(_authorization_base_url(server_url), "/register")
+    response = await client.post(
+        registration_url,
+        json=client_metadata.model_dump(by_alias=True, mode="json", exclude_none=True),
+        headers={"Content-Type": "application/json"},
+    )
+    return await handle_registration_response(response)
+
+
+def _authorization_base_url(server_url: str) -> str:
+    parsed = httpx.URL(server_url)
+    return f"{parsed.scheme}://{parsed.host}{f':{parsed.port}' if parsed.port else ''}"
+
+
+class _ResolvedOAuthClient(BaseModel):
+    """The authorization-server metadata and registered client obtained by probing an MCP
+    server — everything `_build_operator_oauth_flow` needs to assemble the auth request."""
+
+    client_info: OAuthClientInformationFull
+    oauth_metadata: OAuthMetadata | None = None
+    resource_metadata: ProtectedResourceMetadata | None = None
+    scope: str | None = None
+
+
+async def _resolve_operator_oauth_client(
+    server: McpServerEntry, server_url: str, redirect_uri: str
+) -> _ResolvedOAuthClient:
+    """Probe the MCP server, discover its authorization-server metadata, and obtain a client
+    registration — a configured `static_client_id`, or Dynamic Client Registration. All the
+    network I/O of starting an operator OAuth flow lives here."""
+    assert server.operator_oauth is not None
+    try:
+        async with httpx.AsyncClient(follow_redirects=False, timeout=10.0) as client:
+            auth_probe = await client.get(server_url, headers=_metadata_request_headers())
+            resource_metadata = await _discover_protected_resource(client, server_url, auth_probe)
+            oauth_metadata = await _discover_oauth_metadata(client, server_url, resource_metadata)
+            scope = (
+                " ".join(server.operator_oauth.scopes)
+                if server.operator_oauth.scopes is not None
+                else get_client_metadata_scopes(
+                    extract_scope_from_www_auth(auth_probe), resource_metadata, oauth_metadata
+                )
+            )
+            client_metadata = OAuthClientMetadata(
+                client_name=server.operator_oauth.client_name,
+                redirect_uris=[redirect_uri],
+                grant_types=["authorization_code", "refresh_token"],
+                response_types=["code"],
+                scope=scope,
+            )
+            if server.operator_oauth.static_client_id:
+                client_info = OAuthClientInformationFull(
+                    client_id=server.operator_oauth.static_client_id,
+                    redirect_uris=client_metadata.redirect_uris,
+                    grant_types=client_metadata.grant_types,
+                    response_types=client_metadata.response_types,
+                    scope=client_metadata.scope,
+                    client_name=client_metadata.client_name,
+                )
+            else:
+                client_info = await _register_oauth_client(client, server_url, oauth_metadata, client_metadata)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"failed to start MCP OAuth flow for {server.id}: {e}") from e
+    if not client_info.client_id:
+        raise HTTPException(status_code=502, detail=f"MCP OAuth registration for {server.id} did not return client_id")
+    return _ResolvedOAuthClient(
+        client_info=client_info, oauth_metadata=oauth_metadata, resource_metadata=resource_metadata, scope=scope
+    )
+
+
+async def _build_operator_oauth_flow(server: McpServerEntry, public_base_url: str) -> _BuiltOperatorOAuthFlow:
+    assert server.operator_oauth is not None
+    # operator_oauth is meaningless for an in-process server (there's no remote authorization
+    # server to run DCR/metadata discovery against); bind server_url to a local for stable
+    # mypy narrowing across the awaits.
+    assert server.server_url is not None
+    server_url = server.server_url
+    redirect_uri = f"{public_base_url}{MCP_OPERATOR_AUTH_CALLBACK_PATH}"
+    resolved = await _resolve_operator_oauth_client(server, server_url, redirect_uri)
+    client_info = resolved.client_info
+    oauth_metadata = resolved.oauth_metadata
+    resource_metadata = resolved.resource_metadata
+    scope = resolved.scope
+    pkce = PKCEParameters.generate()
+    state = secrets.token_urlsafe(32)
+    if oauth_metadata and oauth_metadata.authorization_endpoint:
+        auth_endpoint = str(oauth_metadata.authorization_endpoint)
+    else:
+        auth_endpoint = urljoin(_authorization_base_url(server_url), "/authorize")
+    if oauth_metadata and oauth_metadata.token_endpoint:
+        token_endpoint = str(oauth_metadata.token_endpoint)
+    else:
+        token_endpoint = urljoin(_authorization_base_url(server_url), "/token")
+    resource = _resource_for_oauth(server_url, resource_metadata)
+    params = {
+        "response_type": "code",
+        "client_id": client_info.client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "code_challenge": pkce.code_challenge,
+        "code_challenge_method": "S256",
+    }
+    if resource:
+        params["resource"] = resource
+    if scope:
+        params["scope"] = scope
+    return _BuiltOperatorOAuthFlow(
+        state=state,
+        authorization_url=f"{auth_endpoint}?{urlencode(params)}",
+        expires_at=datetime.datetime.now(datetime.UTC) + MCP_OPERATOR_AUTH_FLOW_TTL,
+        redirect_uri=redirect_uri,
+        code_verifier=pkce.code_verifier,
+        client_info=client_info,
+        token_endpoint=token_endpoint,
+        resource=resource,
+        scope=scope,
+    )
+
+
+def _token_request_auth(
+    data: dict[str, str], client: _OperatorOAuthTokenClient
+) -> tuple[dict[str, str], dict[str, str]]:
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    if client.token_endpoint_auth_method == "client_secret_basic" and client.client_secret:
+        encoded_id = quote(client.client_id, safe="")
+        encoded_secret = quote(client.client_secret, safe="")
+        credentials = base64.b64encode(f"{encoded_id}:{encoded_secret}".encode()).decode()
+        headers["Authorization"] = f"Basic {credentials}"
+    elif client.token_endpoint_auth_method == "client_secret_post" and client.client_secret:
+        data["client_secret"] = client.client_secret
+    return data, headers
+
+
+async def _exchange_operator_oauth_code(flow: OperatorOAuthFlowState, code: str) -> OAuthToken:
+    data: dict[str, str] = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": flow.redirect_uri,
+        "client_id": flow.client_id,
+        "code_verifier": flow.code_verifier,
+    }
+    if flow.resource:
+        data["resource"] = flow.resource
+    data, headers = _token_request_auth(data, flow)
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(flow.token_endpoint, data=data, headers=headers)
+    if response.status_code != 200:
+        raise HTTPException(status_code=502, detail=f"MCP OAuth token exchange failed: {response.status_code}")
+    try:
+        return await handle_token_response_scopes(response)
+    except ValidationError as e:
+        raise HTTPException(status_code=502, detail=f"MCP OAuth token response was invalid: {e}") from e
+
+
+async def _refresh_operator_oauth_token(association: OperatorOAuthRefreshState) -> OAuthToken:
+    refresh_token = association.refresh_token
+    if not refresh_token:
+        raise RuntimeError("MCP OAuth association has no refresh token; reconnect in the console")
+    data: dict[str, str] = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": association.client_id,
+    }
+    if association.resource:
+        data["resource"] = association.resource
+    data, headers = _token_request_auth(data, association)
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(association.token_endpoint, data=data, headers=headers)
+    if response.status_code != 200:
+        raise RuntimeError(f"MCP OAuth token refresh failed: {response.status_code}")
+    try:
+        return await handle_token_response_scopes(response)
+    except ValidationError as e:
+        raise RuntimeError(f"MCP OAuth refresh response was invalid: {e}") from e
+
+
+# The callback page is served here (not from the SPA) because the OAuth provider redirects
+# straight to this backend endpoint, where the code→token exchange runs; the page's only job
+# is to report the outcome and nudge any open console tab. The markup lives in a sibling
+# .html file (loaded once at import) so it stays lintable rather than a Python blob;
+# `string.Template` `$` placeholders avoid colliding with the CSS/JS braces.
+# TODO: make this a SPA-style page instead of a backend-served .html template — have the
+# callback run the token exchange, then redirect to a frontend SPA route (e.g.
+# /mcp-auth-complete?status=…) that renders the outcome and posts the BroadcastChannel nudge,
+# so all markup lives in the frontend rather than this .html + Python pair.
+_CALLBACK_TEMPLATE = Template((Path(__file__).parent / "mcp_operator_auth_callback.html").read_text(encoding="utf-8"))
+
+
+def _oauth_callback_response(ok: bool, message: str, *, status_code: int = 200) -> HTMLResponse:
+    title = "MCP account connected" if ok else "MCP account connection failed"
+    return HTMLResponse(
+        status_code=status_code,
+        content=_CALLBACK_TEMPLATE.substitute(
+            title=html.escape(title), message=html.escape(message), payload="mcpAuthChanged" if ok else "mcpAuthFailed"
+        ),
+    )
+
+
+@router.get("/api/mcp/operator-auth")
+async def mcp_operator_auth_statuses(
+    request: Request, settings: SettingsDep, oauth_store: OAuthStoreDep
+) -> McpOperatorAuthStatusResponse:
+    return oauth_store.list_statuses(servers=_load_servers(settings), operator_principal=_operator_principal(request))
+
+
+@router.post("/api/mcp/operator-auth/{server_id}/start")
+async def start_mcp_operator_auth(
+    server_id: str, request: Request, csrf_protect: Csrf, settings: SettingsDep, oauth_store: OAuthStoreDep
+) -> McpOperatorAuthStartResponse:
+    await csrf_protect.validate_csrf(request)
+    server = _server_entry(settings, server_id)
+    return await oauth_store.start_flow(
+        server=server,
+        operator_principal=_operator_principal(request),
+        public_base_url=_public_base_url(request, settings),
+    )
+
+
+@router.delete("/api/mcp/operator-auth/{server_id}")
+async def disconnect_mcp_operator_auth(
+    server_id: str, request: Request, csrf_protect: Csrf, oauth_store: OAuthStoreDep
+) -> McpOperatorAuthUnconnected:
+    await csrf_protect.validate_csrf(request)
+    operator_principal = _operator_principal(request)
+    oauth_store.disconnect(server_id=server_id, operator_principal=operator_principal)
+    return McpOperatorAuthUnconnected(server_id=server_id, operator_principal=operator_principal)
+
+
+@router.get(MCP_OPERATOR_AUTH_CALLBACK_PATH)
+async def mcp_operator_auth_callback(
+    oauth_store: OAuthStoreDep, state: str | None = None, code: str | None = None, error: str | None = None
+) -> HTMLResponse:
+    if error:
+        return _oauth_callback_response(False, f"MCP OAuth authorization failed: {error}", status_code=400)
+    if not state or not code:
+        return _oauth_callback_response(False, "MCP OAuth callback is missing state or code.", status_code=400)
+    try:
+        status = await oauth_store.complete_callback(state=state, code=code)
+    except HTTPException as e:
+        detail = e.detail if isinstance(e.detail, str) else "MCP OAuth callback failed."
+        return _oauth_callback_response(False, detail, status_code=e.status_code)
+    return _oauth_callback_response(True, f"Connected {status.server_id} for {status.operator_principal}.")

--- a/haku/console/test_mcp_approval.py
+++ b/haku/console/test_mcp_approval.py
@@ -24,13 +24,8 @@ from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 from testcontainers.postgres import PostgresContainer
 
-from haku.console.mcp_approval import (
-    AliveServerMetadata,
-    McpMetadataProvider,
-    McpServerEntry,
-    McpToolExecutor,
-    _mcp_result_to_json,
-)
+from haku.console.mcp_approval import AliveServerMetadata, McpMetadataProvider, McpToolExecutor, _mcp_result_to_json
+from haku.console.mcp_config import McpServerEntry
 from third_party.containers.rlocations import POSTGRES_18, RYUK
 from util.net import pick_free_port, wait_for_port
 from util.oci import load_oci_image
@@ -516,14 +511,7 @@ def test_operator_oauth_association_drives_approved_tool_execution(make_client, 
     ):
         before = client.get("/api/mcp/operator-auth", headers={"X-authentik-username": "operator@example.com"}).json()
         assert before["associations"] == [
-            {
-                "server_id": "grocy-sf",
-                "status": "unconnected",
-                "operator_principal": "operator@example.com",
-                "connected_at": None,
-                "token_expires_at": None,
-                "scope": None,
-            }
+            {"server_id": "grocy-sf", "status": "unconnected", "operator_principal": "operator@example.com"}
         ]
 
         started = client.post(

--- a/haku/console/tools/BUILD.bazel
+++ b/haku/console/tools/BUILD.bazel
@@ -56,6 +56,7 @@ py_library(
     deps = [
         "//haku/console:deps",
         "//haku/console:mcp_approval",
+        "//haku/console:mcp_operator_oauth",
         "@pypi//fastapi",
         "@pypi//pydantic",
     ],

--- a/haku/console/tools/grocy.py
+++ b/haku/console/tools/grocy.py
@@ -22,7 +22,8 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from haku.console.deps import SettingsDep
-from haku.console.mcp_approval import OAuthStoreDep, operator_authenticated_client
+from haku.console.mcp_approval import operator_authenticated_client
+from haku.console.mcp_operator_oauth import OAuthStoreDep
 
 GROCY_SF_SERVER_ID = "grocy-sf"
 


### PR DESCRIPTION
## Summary

Refactors the MCP approval router by extracting operator OAuth account linkage and server configuration management into dedicated modules. This improves code organization and separation of concerns without changing functionality.

## Key Changes

- **New `mcp_config.py` module**: Centralizes MCP server catalog management, including:
  - `McpServerEntry`, `ConsoleMcpConfig`, and `ConsoleConfigFile` models
  - Server loading and lookup functions (`_load_servers`, `_server_entry`)
  - Bearer token credential resolution (`_credential_token`, `_credential_env_name`)
  - Server transport resolution (`_transport`, `InProcessServers`)
  - OAuth enablement checks (`_operator_oauth_enabled`)

- **New `mcp_operator_oauth.py` module**: Isolates operator OAuth flow implementation:
  - `PostgresMcpOperatorOAuthStore` class for Postgres-backed token storage
  - OAuth flow models (`McpOperatorAuthStatus`, `McpOperatorAuthStartResponse`, etc.)
  - `McpOperatorOAuthStoreProtocol` for dependency injection
  - All OAuth discovery, registration, and token exchange logic
  - New FastAPI router with `/api/mcp/operator-auth/*` endpoints
  - HTML callback template for OAuth completion feedback

- **Refactored `mcp_approval.py`**:
  - Removed ~400 lines of OAuth and config code
  - Now imports shared types and functions from `mcp_config` and `mcp_operator_oauth`
  - Simplified imports and reduced module responsibilities
  - Maintains all approval ledger and tool execution logic

- **Updated `app.py`**: Registers the new `mcp_operator_oauth` router alongside existing routers

- **Updated `BUILD.bazel`**: Added build targets for new modules with appropriate dependencies

## Implementation Details

- OAuth flow state is captured in `OperatorOAuthFlowState` and `OperatorOAuthRefreshState` models to safely carry data across async network calls without holding database sessions
- Server configuration remains in the console YAML/ConfigMap; only OAuth flow state and token associations are stored in Postgres
- The `_operator_principal` function extracts operator identity from `x-authentik-username` header with fallback to "operator"
- Public base URL resolution supports both explicit config and header-based detection for reverse proxy scenarios

https://claude.ai/code/session_01QMYAWMN5SYhrn8PQcwUajU