### PR TITLE
devinfra/claude: self-heal CCR agent-proxy Java-truststore race for bb/bbr

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -5,14 +5,20 @@ web environments.
 
 ## Networking
 
-Current Claude Code web containers reach the internet without any per-tool
-proxy configuration: no `HTTPS_PROXY` env vars are set, and Anthropic's TLS
-inspection CA is already in the system CA bundle
-(`/etc/ssl/certs/ca-certificates.crt`) — so curl, Bazel, pip, npm, kubectl,
-git, etc. all work out of the box. We don't try to distinguish whether that
-works via a transparent network-layer MITM proxy or direct egress; as far
-as the Rust hook daemon is concerned, outbound HTTPS to known hosts reaches
-them, end of story.
+Two egress models exist across Claude Code environments:
+
+- **Transparent MITM (classic web containers).** No `HTTPS_PROXY` is set and Anthropic's
+  TLS-inspection CA is already in the system bundle (`/etc/ssl/certs/ca-certificates.crt`),
+  so curl, Bazel, pip, npm, kubectl, git, etc. work out of the box. The hook daemon doesn't
+  distinguish network-layer MITM from direct egress; outbound HTTPS to known hosts reaches
+  them, end of story.
+- **CCR agent proxy (Claude Code Remote / remote-execution sessions).** `HTTPS_PROXY`
+  points at a local relay (`http://127.0.0.1:46587`) that re-terminates TLS with its own
+  CA; every tool must trust `/root/.ccr/ca-bundle.crt` (the standard `*_CA_*` env vars and
+  system store are pre-set). See `/root/.ccr/README.md`. **Gotcha:** the proxy's boot-time
+  JVM-truststore seed races `ca-certificates-java` and often fails, so `bb`/`bbr` can't
+  verify the proxy's TLS (`bazelisk` is fine). `web_setup.sh` self-heals this; root cause +
+  detection in <docs/ccr_bazel_truststore_race.md>.
 
 ## Specification
 

--- a/devinfra/claude/claude_hook/docs/session_start_recovery.md
+++ b/devinfra/claude/claude_hook/docs/session_start_recovery.md
@@ -8,6 +8,21 @@ Do not bypass proxy or certificate failures with `--noverify`,
 `SSL_VERIFY=false`, or similar. The durable fix is to recover the session-start
 hook path.
 
+## `bb`/`bbr` TLS (PKIX) failures on CCR remote-execution sessions
+
+If `bb`/`bbr` fail every repository fetch with `PKIX path building failed` while
+`bazelisk` works, this is **not** a session-start-hook failure — it's the CCR agent
+proxy's boot-time Java-truststore seed losing a race with `ca-certificates-java`, so
+`/etc/bazel.bazelrc` never gets written and `bb`/`bbr` fall back to the JDK cacerts. Heal
+it (idempotent, already run by `web_setup.sh`):
+
+```bash
+bash devinfra/claude/heal_ccr_bazel_trust.sh
+```
+
+Root cause, detection, and the "same command succeeds now" proof:
+<../../docs/ccr_bazel_truststore_race.md>. Do not disable TLS verification.
+
 ## Check The Live Session
 
 Find the live Rust daemon session ID:

--- a/devinfra/claude/docs/ccr_bazel_truststore_race.md
+++ b/devinfra/claude/docs/ccr_bazel_truststore_race.md
@@ -1,0 +1,87 @@
+# CCR Bazel truststore race (`bb`/`bbr` PKIX failures)
+
+**Symptom.** In a Claude Code Remote (CCR) session, `bb`/`bbr` fail every repository
+fetch with a TLS error, while `bazelisk` works:
+
+```text
+TLS error: (certificate_unknown) PKIX path building failed:
+sun.security.provider.certpath.SunCertPathBuilderException:
+unable to find valid certification path to requested target
+```
+
+**One-line fix.** Run <../heal_ccr_bazel_trust.sh> (already wired into
+<../web_setup.sh>, Step 3b — a fresh session self-heals). It writes `/etc/bazel.bazelrc`
+pointing Bazel's JVM at the system Java store.
+
+## Why it happens
+
+The CCR agent proxy (`http://127.0.0.1:46587`, `HTTPS_PROXY`) re-terminates outbound TLS
+with its own CA (`CN=CCR Upstream Proxy CA`). Every tool must trust
+`/root/.ccr/ca-bundle.crt`. For JVM tools the proxy's boot-time setup is supposed to:
+
+1. build a managed truststore `/root/.ccr/java-truststore.p12` seeded from the system
+   store, and
+2. write `/etc/bazel.bazelrc` pointing Bazel's server JVM at a store that trusts the CA.
+
+That seed **races dpkg's pending `ca-certificates-java` trigger** — both regenerate
+`/etc/ssl/certs/java/cacerts` — and usually loses. Reconstructed from a real session's
+`/tmp/claude-code.log` + `/var/log/dpkg.log`:
+
+| Time (UTC, 03:13) | Event                                                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------- |
+| :27               | CCR agent-proxy starts; begins installing its CA into system trust                                                  |
+| :34               | dpkg reprocesses the **pending `ca-certificates-java` trigger** → starts regenerating `/etc/ssl/certs/java/cacerts` |
+| :37.480           | CCR `update-ca-certificates` **exits 1** ("falling back to env-var trust") — collided with the in-flight trigger    |
+| :39.427           | `/etc/ssl/certs/java/cacerts` finally written                                                                       |
+| :39.792           | CCR `keytool -importkeystore` (copy that store into the p12) **exits 1** — read it before it settled                |
+
+Because the seed failed, CCR wrote **neither** `/root/.ccr/java-truststore.p12` **nor**
+`/etc/bazel.bazelrc`. Consequences:
+
+- **`bazelisk` still works** — the ducktape claude-hook independently points the _session_
+  bazelrc at `/etc/ssl/certs/java/cacerts` (`--host_jvm_args=-Djavax.net.ssl.trustStore=…`),
+  which post-boot is valid and carries the proxy CA.
+- **`bb`/`bbr` break** — they do not read that session bazelrc, and with no
+  `/etc/bazel.bazelrc` they fall back to the JDK-**embedded** cacerts, which lacks the
+  proxy CA → PKIX failure.
+
+**Proof it's a race, not a config error:** the exact failing commands **succeed once the
+session is usable** (the store has settled by then):
+
+```bash
+# CCR's own seed command — fails at boot, succeeds now (151 entries):
+keytool -importkeystore -noprompt -srckeystore /etc/ssl/certs/java/cacerts \
+  -srcstorepass changeit -destkeystore /tmp/probe.p12 -deststoretype PKCS12 -deststorepass changeit
+update-ca-certificates   # exit 1 at boot, exit 0 now
+```
+
+The pending `ca-certificates-java` trigger fires on first boot because the image is a
+snapshot with the trigger left pending; it runs concurrently with CCR's init. This is an
+**upstream (Anthropic/CCR) race** — worth reporting — but cheap to self-heal.
+
+## The heal
+
+Since the system store `/etc/ssl/certs/java/cacerts` is valid and carries the proxy CA by
+the time a session is usable, we complete the step CCR skipped: write `/etc/bazel.bazelrc`
+(the system bazelrc, read by every Bazel invocation including `bb`/`bbr`) pointing the JVM
+at it — the same store the session bazelrc already uses for `bazelisk`.
+
+<../heal*ccr_bazel_trust.sh> does this idempotently and only when `/etc/bazel.bazelrc` is
+absent (CCR writes it on a \_successful* seed), so a healthy session is never clobbered and a
+non-CCR machine is a no-op. It is invoked from <../web_setup.sh> so fresh sessions self-heal.
+
+**Detect** a broken session:
+
+```bash
+curl -sS http://127.0.0.1:46587/__agentproxy/status | grep java_truststore_seed_failed
+test -e /etc/bazel.bazelrc || echo "no /etc/bazel.bazelrc — bb/bbr will PKIX-fail"
+```
+
+## Scope / non-goals
+
+- **`bazelisk` is unaffected** — its session bazelrc already trusts the proxy CA.
+- **The residual `403 Forbidden`** on _direct_ `github.com` archive fetches (e.g. a local
+  `bb run` that needs an un-cached repo) is a **separate, by-design egress policy**, not
+  this TLS bug — the repo fetches through the BuildBuddy remote cache / RBE (`bbr`), which
+  is why `bbr build`/`test` pass once TLS is healed. Do not route around the 403; see
+  `/root/.ccr/README.md`.

--- a/devinfra/claude/heal_ccr_bazel_trust.sh
+++ b/devinfra/claude/heal_ccr_bazel_trust.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Heal CCR's failed Java-truststore seed so Bazel (bb/bbr) trusts the agent proxy.
+#
+# The Claude Code Remote (CCR) agent proxy re-terminates outbound TLS with its own CA. At
+# container boot it seeds a JVM truststore and writes /etc/bazel.bazelrc so Bazel's server
+# JVM trusts that CA. That seed RACES dpkg's pending ca-certificates-java trigger — both
+# regenerate /etc/ssl/certs/java/cacerts — and often loses: CCR's `update-ca-certificates`
+# and `keytool -importkeystore` exit 1, /etc/bazel.bazelrc is never written, and bb/bbr fall
+# back to the JDK-embedded cacerts (no proxy CA) -> PKIX TLS failures on fetches. `bazelisk`
+# is unaffected because the claude-hook points the *session* bazelrc at the system store,
+# which bb/bbr do not read. By the time a session is usable the system store has settled and
+# carries the proxy CA, so this completes the step CCR skipped: point every Bazel server JVM
+# at it. Root-cause writeup: devinfra/claude/docs/ccr_bazel_truststore_race.md
+#
+# Idempotent + non-clobbering: writes only when /etc/bazel.bazelrc is absent (CCR writes it on
+# a successful seed), so a healthy session — or a machine that isn't a CCR session at all — is
+# left untouched.
+set -euo pipefail
+
+SYSTEM_BAZELRC=/etc/bazel.bazelrc
+JAVA_TRUSTSTORE=/etc/ssl/certs/java/cacerts
+CCR_MARKER=/root/.ccr/ca-bundle.crt
+
+log() {
+  printf '[%s] heal_ccr_bazel_trust: %s\n' "$(date -Iseconds)" "$*"
+}
+
+if [ -e "$SYSTEM_BAZELRC" ]; then
+  log "$SYSTEM_BAZELRC already present (healthy seed or prior heal); leaving it untouched."
+  exit 0
+fi
+
+if [ ! -e "$CCR_MARKER" ]; then
+  log "no CCR agent-proxy marker ($CCR_MARKER); not a CCR session — nothing to heal."
+  exit 0
+fi
+
+if [ ! -r "$JAVA_TRUSTSTORE" ]; then
+  log "WARNING: $CCR_MARKER present but $JAVA_TRUSTSTORE is not readable; cannot heal Bazel trust."
+  exit 0
+fi
+
+cat >"$SYSTEM_BAZELRC" <<EOF
+# Managed by devinfra/claude/heal_ccr_bazel_trust.sh.
+# CCR's boot-time JVM-truststore seed lost a race with ca-certificates-java and never wrote
+# this file, so bb/bbr could not verify the agent proxy's re-terminated TLS. Point every Bazel
+# server JVM at the system Java store, which (post-boot) carries the proxy CA.
+# See devinfra/claude/docs/ccr_bazel_truststore_race.md.
+startup --host_jvm_args=-Djavax.net.ssl.trustStore=$JAVA_TRUSTSTORE
+startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=changeit
+EOF
+log "wrote $SYSTEM_BAZELRC pointing Bazel's JVM at $JAVA_TRUSTSTORE (CCR truststore-seed heal)."

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -338,6 +338,15 @@ PROJECT_DIR="${FLAKE#path:}"
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/reconcile_bbr_remote.sh"
 reconcile_bbr_remote "$PROJECT_DIR"
 
+# --- Step 3b: Heal CCR's failed Java-truststore seed for Bazel (bb/bbr) ---
+# The Claude Code Remote (CCR) agent proxy's boot-time truststore seed races dpkg's
+# ca-certificates-java trigger and often loses, leaving bb/bbr unable to verify the
+# proxy's re-terminated TLS (PKIX errors on repository fetches). Idempotent and
+# non-clobbering — no-op on a healthy CCR seed or a non-CCR machine. See the script
+# header and <devinfra/claude/docs/ccr_bazel_truststore_race.md>.
+bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/heal_ccr_bazel_trust.sh" \
+  || warn "CCR bazel-trust heal failed (non-fatal)"
+
 # --- Step 4: Symlink skills into ~/.claude/skills/ ---
 # Per-skill symlinks instead of replacing the directory, so Anthropic's
 # pre-landed default skills are preserved.


### PR DESCRIPTION
## What

In **Claude Code Remote (CCR)** sessions, `bb`/`bbr` fail every repository fetch with a TLS `PKIX path building failed` error while `bazelisk` works. This adds an idempotent self-heal (run automatically by `web_setup.sh`), plus the root-cause writeup, and corrects the stale networking docs.

## Root cause (a boot-time race, not a config error)

The CCR agent proxy re-terminates outbound TLS with its own CA. At boot it's supposed to seed a JVM truststore and write `/etc/bazel.bazelrc` so Bazel's server JVM trusts that CA. That seed **races dpkg's pending `ca-certificates-java` trigger** — both regenerate `/etc/ssl/certs/java/cacerts` — and usually loses. Reconstructed from a real session's logs:

| Time (03:13 UTC) | Event |
| --- | --- |
| :34 | dpkg reprocesses the pending `ca-certificates-java` trigger → regenerating the Java store |
| :37 | CCR `update-ca-certificates` **exits 1** ("falling back to env-var trust") |
| :39 | CCR `keytool -importkeystore` (seed the p12) **exits 1** |

So CCR wrote neither `/root/.ccr/java-truststore.p12` nor `/etc/bazel.bazelrc`. `bazelisk` still works because the claude-hook independently points the *session* bazelrc at the system store; `bb`/`bbr` don't read that and fall back to the JDK-embedded cacerts (no proxy CA) → PKIX.

**Proof it's a race:** the exact failing commands (`update-ca-certificates`, `keytool -importkeystore`) **succeed once the session settles**. So the heal just completes the step CCR skipped: point Bazel's JVM at the now-valid system store.

## Changes

- **`heal_ccr_bazel_trust.sh`** — idempotent, non-clobbering: writes `/etc/bazel.bazelrc` only when absent (CCR writes it on a successful seed) and only on a CCR session; no-op elsewhere.
- **`web_setup.sh`** — invokes the heal (Step 3b) so a fresh session self-heals.
- **`docs/ccr_bazel_truststore_race.md`** — root-cause writeup, boot timeline, detection, and scope notes.
- **`README.md` / `session_start_recovery.md`** — replace the stale "Bazel works out of the box" claim (it assumed the old transparent-MITM model, where no `HTTPS_PROXY` is set) with the two egress models, and add the CCR recovery pointer.

## Testing

Validated in this live CCR session by resetting the broken state and re-deriving:
- `rm /etc/bazel.bazelrc` → `bb` fetch fails PKIX.
- Run the heal → `/etc/bazel.bazelrc` written; re-run → idempotent skip.
- `bb` fetch now passes TLS (the residual `403` on direct github archive fetches is the separate, by-design egress policy — `bbr` fetches through the BuildBuddy cache and is unaffected).

## Upstream

The race lives in CCR's own init (Anthropic-side) and is worth reporting; this change makes ducktape sessions self-heal in the meantime rather than papering over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMYAWMN5SYhrn8PQcwUajU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMYAWMN5SYhrn8PQcwUajU)_