### PR TITLE
haku/console: fold the tool action into the card's identity line; share one ToolCallCard

### DIFF
--- a/haku/console/frontend/AGENTS.md
+++ b/haku/console/frontend/AGENTS.md
@@ -31,11 +31,13 @@ in `screenshots/render.mjs`) whenever you add a new surface.
 ## Tool-call rendering — design requirements
 
 A tool call shows up in two places — the approval **drawer** cards (`console_panel.tsx`) and
-the **history** rows (`tool_calls_page.tsx`) — and each renders at one of two variants,
-**compact** or **detailed**, flipped per item by its `Details` toggle. The argument body is
-drawn by a per-server **preview widget** (`tool_previews/`), or the generic raw-JSON fallback
-(`tool_arguments_field.tsx`). Hold all of it to these rules so the whole surface reads as one
-thing.
+the **history** rows (`tool_calls_page.tsx`) — but both render through one shared component,
+`tool_call_card.tsx` (identity header + action line + status badge + `Details` toggle, the
+arguments body, and the detailed Result/Metadata); only the status badge and footer actions
+differ per surface. Each renders at one of two variants, **compact** or **detailed**, flipped
+per item by its toggle. The argument body is drawn by a per-server **preview widget**
+(`tool_previews/`), or the generic raw-JSON fallback (`tool_arguments_field.tsx`). Hold all of
+it to these rules so the whole surface reads as one thing.
 
 **Compact is for skimming.** A compact rendering answers "what is this, and do I need to look
 closer?" at a glance — nothing more. Show the action, its primary target(s), and just enough
@@ -65,16 +67,19 @@ with the rarely-useful parts folded away:
 
 **Consistent vocabulary.**
 
-- The **action** is a colored `Badge` — green create/add, red destructive/remove/deny,
-  blue/gray neutral.
+- The **action** is a one-line description on the card's identity line (`tool_action_line.tsx`),
+  not a badge in the body: a registered tool supplies its own via `definePreview`'s third arg
+  (`"Gmail: Draft email"`, `"Grocy: Add 5 items to stock"`; destructive ones flagged red), and a
+  tool with no widget falls back to `serverId.toolName`. The widget body must not restate it.
 - **Identity / target** is bold; secondary attributes are dimmed inline text or small outline
   badges.
 - **Icons** replace labels only where the glyph is unambiguous (🕐 time, 📍 place, 👥 people);
   otherwise a short inline label.
 - **Semantic color is not the accent** — reserve red for genuinely destructive or failed states.
 
-**Datetimes and durations** use the shared concise forms (relative when near, drop the
-redundant, full value on hover) — tracked in `frontend/TODO.md`.
+**Datetimes and durations** use the shared concise forms — `formatTimestamp` (relative when
+near, full value on hover) for a wall-clock instant, `formatEventDateTimeRange` for a calendar
+start–end — rather than each field spelling its own format.
 
 When you add or change any rendering, put it (both variants) in the `previews` gallery and check
 it against this list.

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -168,6 +168,32 @@ js_library(
 )
 
 js_library(
+    name = "tool_action_line",
+    srcs = ["tool_action_line.tsx"],
+    deps = [
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+        "//haku/console/frontend/tool_previews",
+    ],
+)
+
+js_library(
+    name = "tool_call_card",
+    srcs = ["tool_call_card.tsx"],
+    deps = [
+        ":approval_state",
+        ":field",
+        ":tool_action_line",
+        ":tool_arguments_field",
+        ":tool_call_meta",
+        ":variant_toggle",
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+        "//haku/console/frontend/tool_previews:variant",
+    ],
+)
+
+js_library(
     name = "pending_tool_call_actions",
     srcs = ["pending_tool_call_actions.tsx"],
     deps = [
@@ -181,7 +207,6 @@ js_library(
     name = "variant_toggle",
     srcs = ["variant_toggle.tsx"],
     deps = [
-        "//:node_modules/@mantine/core",
         "//:node_modules/react",
         "//haku/console/frontend/tool_previews:variant",
     ],
@@ -197,8 +222,7 @@ js_library(
         ":icons",
         ":pending_tool_call_actions",
         ":theme",
-        ":tool_arguments_field",
-        ":tool_call_meta",
+        ":tool_call_card",
         ":variant_toggle",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
@@ -211,13 +235,11 @@ js_library(
     deps = [
         ":approval_state",
         ":client",
-        ":field",
         ":icons",
         ":pending_tool_call_actions",
         ":toast",
-        ":tool_arguments_field",
+        ":tool_call_card",
         ":tool_call_events",
-        ":tool_call_meta",
         ":variant_toggle",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
@@ -309,7 +331,9 @@ filegroup(
         "settings_page.tsx",
         "theme.ts",
         "toast.ts",
+        "tool_action_line.tsx",
         "tool_arguments_field.tsx",
+        "tool_call_card.tsx",
         "tool_call_meta.tsx",
         "tool_calls_page.tsx",
         "variant_toggle.tsx",
@@ -389,6 +413,7 @@ js_library(
         ":console_panel",
         ":settings_page",
         ":theme",
+        ":tool_action_line",
         ":tool_arguments_field",
         ":tool_calls_page",
         "//:node_modules/@mantine/core",

--- a/haku/console/frontend/TODO.md
+++ b/haku/console/frontend/TODO.md
@@ -1,11 +1,5 @@
 # haku/console/frontend TODO
 
-- Unify the action/identity header across registered and unregistered tools. A widget's
-  `ActionBadge` (e.g. grocy's "Remove stock") largely restates the `serverId.toolName` the card
-  header already shows. Want one treatment: a registered tool draws its own custom identity
-  header; an unregistered one renders `serverId.toolName` in the _same_ styling — so the header
-  reads consistently either way instead of the widget duplicating the tool name.
-
 - Let the pending tool-call note (`pending_tool_call_actions.tsx`) ride an **approve**, not just
   a deny — a general operator remark, not only a denial reason. The agent can already read
   decision notes back from the tool-call result DB, so this is mostly: persist a reason on the

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -18,8 +18,7 @@ import { Field } from "./field.tsx";
 import { HistoryIcon, MapPinIcon, MenuIcon, SettingsIcon } from "./icons.tsx";
 import { PendingToolCallActions } from "./pending_tool_call_actions.tsx";
 import { ACTION_COLOR } from "./theme.ts";
-import { ToolArgumentsField } from "./tool_arguments_field.tsx";
-import { ToolCallMeta } from "./tool_call_meta.tsx";
+import { ToolCallCard } from "./tool_call_card.tsx";
 import { useVariant, VariantToggle } from "./variant_toggle.tsx";
 
 export interface ShellDrawerProps {
@@ -192,44 +191,15 @@ function ToolApprovalCard({
   const [variant, toggleVariant] = useVariant("compact");
   const fields = approvalDisplayFields(approval);
   const armed = useArmed(`card:${approval.tool_call_id}`);
-  const detailed = variant === "detailed";
   return (
-    <section className="haku-shell-card">
-      <Stack gap="sm">
-        <Group justify="space-between" align="flex-start" gap="sm" wrap="nowrap">
-          <Stack gap={2} style={{ minWidth: 0 }}>
-            <Text fw={600} size="sm">
-              {fields.title}
-            </Text>
-            <Text size="xs" c="dimmed">
-              {fields.serverId}.{fields.toolName}
-            </Text>
-            {fields.rationale && <Text size="xs">{fields.rationale}</Text>}
-          </Stack>
-          <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
-            <Badge color={deciding ? "blue" : "yellow"} variant="light">
-              {deciding ? "Running" : "Pending"}
-            </Badge>
-            <VariantToggle variant={variant} onToggle={toggleVariant} />
-          </Group>
-        </Group>
-        <ToolArgumentsField
-          serverId={fields.serverId}
-          toolName={fields.toolName}
-          args={approval.arguments}
-          argumentsJson={fields.argumentsJson}
-          variant={variant}
-        />
-        {detailed && (
-          <ToolCallMeta
-            callerPrincipal={fields.callerPrincipal}
-            createdAt={fields.createdAt}
-            toolCallId={fields.toolCallId}
-          />
-        )}
-        <PendingToolCallActions busy={deciding} armed={armed} onApprove={onApprove} onDeny={onDeny} />
-      </Stack>
-    </section>
+    <ToolCallCard
+      fields={fields}
+      args={approval.arguments}
+      variant={variant}
+      onToggle={toggleVariant}
+      status={{ label: deciding ? "Running" : "Pending", color: deciding ? "blue" : "yellow" }}
+      footer={<PendingToolCallActions busy={deciding} armed={armed} onApprove={onApprove} onDeny={onDeny} />}
+    />
   );
 }
 
@@ -261,12 +231,9 @@ function GeolocationApprovalCard({
             </Text>
             <Text size="xs">{geolocationApprovalBody(approval)}</Text>
           </Stack>
-          <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
-            <Badge color={deciding ? "blue" : "yellow"} variant="light">
-              {deciding ? "Applying" : "Pending"}
-            </Badge>
-            <VariantToggle variant={variant} onToggle={toggleVariant} />
-          </Group>
+          <Badge color={deciding ? "blue" : "yellow"} variant="light" style={{ flexShrink: 0 }}>
+            {deciding ? "Applying" : "Pending"}
+          </Badge>
         </Group>
         {detailed && (
           <div className="haku-shell-fields">
@@ -284,6 +251,7 @@ function GeolocationApprovalCard({
             </details>
           </div>
         )}
+        <VariantToggle variant={variant} onToggle={toggleVariant} />
         <Group justify="flex-end" gap="xs">
           <Button size="compact-sm" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
             Deny
@@ -309,67 +277,26 @@ function RecentToolCallCard({
   const [variant, toggleVariant] = useVariant("compact");
   const record = recent.record;
   const fields = approvalDisplayFields(record);
-  const detailed = variant === "detailed";
   return (
-    <section className="haku-shell-card">
-      <Stack gap="sm">
-        <Group justify="space-between" align="flex-start" gap="sm" wrap="nowrap">
-          <Stack gap={2} style={{ minWidth: 0 }}>
-            <Text fw={600} size="sm">
-              {fields.title}
-            </Text>
-            <Text size="xs" c="dimmed">
-              {fields.serverId}.{fields.toolName}
-            </Text>
-            {record.error && (
-              <Text size="xs" c="red">
-                {record.error}
-              </Text>
-            )}
-            {fields.denialReason && (
-              <Text size="xs" c="dimmed">
-                Denied: {fields.denialReason}
-              </Text>
-            )}
-          </Stack>
-          <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
-            <Badge color={statusColor(record.status)} variant="light">
-              {terminalStatusLabel(record.status)}
-            </Badge>
-            <VariantToggle variant={variant} onToggle={toggleVariant} />
+    <ToolCallCard
+      fields={fields}
+      args={record.arguments}
+      variant={variant}
+      onToggle={toggleVariant}
+      status={{ label: terminalStatusLabel(record.status), color: statusColor(record.status) }}
+      error={record.error}
+      result={record.result}
+      footer={
+        <>
+          <RecentCountdown recent={recent} nowMs={nowMs} />
+          <Group justify="flex-end" gap="xs">
+            <Button size="compact-xs" variant="subtle" color="gray" onClick={onDismiss}>
+              Dismiss
+            </Button>
           </Group>
-        </Group>
-        <ToolArgumentsField
-          serverId={fields.serverId}
-          toolName={fields.toolName}
-          args={record.arguments}
-          argumentsJson={fields.argumentsJson}
-          variant={variant}
-        />
-        {detailed && (
-          <>
-            {record.result && (
-              <div className="haku-shell-fields">
-                <Field label="Result">
-                  <pre className="haku-shell-json">{JSON.stringify(record.result, null, 2)}</pre>
-                </Field>
-              </div>
-            )}
-            <ToolCallMeta
-              callerPrincipal={fields.callerPrincipal}
-              createdAt={fields.createdAt}
-              toolCallId={fields.toolCallId}
-            />
-          </>
-        )}
-        <RecentCountdown recent={recent} nowMs={nowMs} />
-        <Group justify="flex-end" gap="xs">
-          <Button size="compact-xs" variant="subtle" color="gray" onClick={onDismiss}>
-            Dismiss
-          </Button>
-        </Group>
-      </Stack>
-    </section>
+        </>
+      }
+    />
   );
 }
 

--- a/haku/console/frontend/screenshots/harness.tsx
+++ b/haku/console/frontend/screenshots/harness.tsx
@@ -13,6 +13,7 @@ import { createRoot } from "react-dom/client";
 import { ShellControls, ShellDrawer, type ShellDrawerProps } from "../console_panel.tsx";
 import { SettingsPage } from "../settings_page.tsx";
 import { hakuTheme } from "../theme.ts";
+import { ToolActionLine } from "../tool_action_line.tsx";
 import { ToolArgumentsField } from "../tool_arguments_field.tsx";
 import { ToolCallsPage } from "../tool_calls_page.tsx";
 import { PREVIEW_SAMPLES, SAMPLE_PENDING, SAMPLE_RECENT } from "./sample_data.ts";
@@ -32,9 +33,14 @@ function PreviewGallery() {
             const argumentsJson = JSON.stringify(args, null, 2);
             return (
               <div key={`${serverId}.${toolName}`} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                <Text fw={700} size="sm" ff="monospace">
-                  {serverId}.{toolName}
-                </Text>
+                <div>
+                  <Text fw={700} size="sm" ff="monospace">
+                    {serverId}.{toolName}
+                  </Text>
+                  {/* The action-description line each card renders in its header (or the raw
+                      serverId.toolName fallback for the widget-less sample). */}
+                  <ToolActionLine serverId={serverId} toolName={toolName} args={args} />
+                </div>
                 <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, alignItems: "start" }}>
                   {(["compact", "detailed"] as const).map((variant) => (
                     <section className="haku-shell-card" key={variant}>

--- a/haku/console/frontend/screenshots/render.mjs
+++ b/haku/console/frontend/screenshots/render.mjs
@@ -26,7 +26,7 @@ const SCENES = [
   {
     name: "history",
     viewport: { width: 1200, height: 1500 },
-    clicks: ["button::-p-text(Details)", "summary::-p-text(Metadata)", "button::-p-text(Details)"],
+    clicks: ["button::-p-text(Show details)", "summary::-p-text(Metadata)", "button::-p-text(Show details)"],
   },
   { name: "drawer", viewport: { width: 1200, height: 900 } },
   { name: "settings", viewport: { width: 1200, height: 900 } },

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -291,6 +291,34 @@
   margin-top: 0.55rem;
 }
 
+/* The card's compact/detailed toggle, styled to read as one of the card's disclosures (like the
+   Metadata/Raw arguments summaries): a rotating caret + dimmed label, left-aligned, at the bottom
+   of the card — not a button in the corner. */
+.haku-shell-expander {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  color: var(--mantine-color-dimmed);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.haku-shell-expander-caret {
+  display: inline-block;
+  font-size: 0.7em;
+  transition: transform 150ms ease;
+}
+
+.haku-shell-expander[aria-expanded="true"] .haku-shell-expander-caret {
+  transform: rotate(90deg);
+}
+
 @media (max-width: 520px) {
   .haku-shell-drawer {
     width: calc(100vw - 0.5rem);

--- a/haku/console/frontend/tool_action_line.tsx
+++ b/haku/console/frontend/tool_action_line.tsx
@@ -1,0 +1,24 @@
+import { Text } from "@mantine/core";
+
+import { toolActionDescription } from "./tool_previews";
+
+/** The card's identity line. A registered tool renders its own action description ("Gmail: Draft
+ * email", "kubectl: Delete Pod" — destructive ones in red); a tool with no widget falls back to
+ * `serverId.toolName`. One line, one style either way, so the header reads consistently and the
+ * widget body needn't restate the action. */
+export function ToolActionLine({
+  serverId,
+  toolName,
+  args,
+}: {
+  serverId: string;
+  toolName: string;
+  args: Record<string, unknown> | null | undefined;
+}) {
+  const action = args ? toolActionDescription(serverId, toolName, args) : null;
+  return (
+    <Text size="xs" c={action?.destructive ? "red" : "dimmed"}>
+      {action ? action.text : `${serverId}.${toolName}`}
+    </Text>
+  );
+}

--- a/haku/console/frontend/tool_call_card.tsx
+++ b/haku/console/frontend/tool_call_card.tsx
@@ -1,0 +1,93 @@
+import { Badge, Group, Stack, Text } from "@mantine/core";
+import type { ReactNode } from "react";
+
+import type { ApprovalDisplayFields } from "./approval_state.ts";
+import { Field } from "./field.tsx";
+import { ToolActionLine } from "./tool_action_line.tsx";
+import { ToolArgumentsField } from "./tool_arguments_field.tsx";
+import { ToolCallMeta } from "./tool_call_meta.tsx";
+import type { PreviewVariant } from "./tool_previews/variant.tsx";
+import { VariantToggle } from "./variant_toggle.tsx";
+
+/** One tool call, rendered the same way everywhere it appears — the drawer's pending and recent
+ * cards and the history page's rows. It owns the shared skeleton (the identity header + action
+ * line + rationale/error/denial subhead + status badge + Details toggle, the arguments body, and
+ * the detailed Result/Metadata) so all of that reads one way and lives in one place. The bits
+ * that genuinely differ per surface — the status badge's label/color and the footer actions
+ * (approve/deny, dismiss, countdown) — come in as props. */
+export function ToolCallCard({
+  fields,
+  args,
+  variant,
+  onToggle,
+  status,
+  error = null,
+  result,
+  footer,
+}: {
+  fields: ApprovalDisplayFields;
+  args: Record<string, unknown>;
+  variant: PreviewVariant;
+  onToggle: () => void;
+  status: { label: string; color: string };
+  error?: string | null;
+  result?: unknown;
+  footer?: ReactNode;
+}) {
+  const detailed = variant === "detailed";
+  return (
+    <section className="haku-shell-card">
+      <Stack gap="sm">
+        <Group justify="space-between" align="flex-start" gap="sm" wrap="nowrap">
+          <Stack gap={2} style={{ minWidth: 0 }}>
+            <Text fw={600} size="sm">
+              {fields.title}
+            </Text>
+            <ToolActionLine serverId={fields.serverId} toolName={fields.toolName} args={args} />
+            {fields.rationale && <Text size="xs">{fields.rationale}</Text>}
+            {error && (
+              <Text size="xs" c="red">
+                {error}
+              </Text>
+            )}
+            {fields.denialReason && (
+              <Text size="xs" c="dimmed">
+                Denied: {fields.denialReason}
+              </Text>
+            )}
+          </Stack>
+          <Badge color={status.color} variant="light" style={{ flexShrink: 0 }}>
+            {status.label}
+          </Badge>
+        </Group>
+        <ToolArgumentsField
+          serverId={fields.serverId}
+          toolName={fields.toolName}
+          args={args}
+          argumentsJson={fields.argumentsJson}
+          variant={variant}
+        />
+        {detailed && (
+          <>
+            {result != null && (
+              <div className="haku-shell-fields">
+                <Field label="Result">
+                  <pre className="haku-shell-json">{JSON.stringify(result, null, 2)}</pre>
+                </Field>
+              </div>
+            )}
+            <ToolCallMeta
+              serverId={fields.serverId}
+              toolName={fields.toolName}
+              callerPrincipal={fields.callerPrincipal}
+              createdAt={fields.createdAt}
+              toolCallId={fields.toolCallId}
+            />
+          </>
+        )}
+        <VariantToggle variant={variant} onToggle={onToggle} />
+        {footer}
+      </Stack>
+    </section>
+  );
+}

--- a/haku/console/frontend/tool_call_meta.tsx
+++ b/haku/console/frontend/tool_call_meta.tsx
@@ -6,10 +6,14 @@ import { Field } from "./field.tsx";
  * collapsed "Metadata" disclosure in the detailed drawer cards and history rows, keeping the
  * detailed body focused on the arguments/result. */
 export function ToolCallMeta({
+  serverId,
+  toolName,
   callerPrincipal,
   createdAt,
   toolCallId,
 }: {
+  serverId: string;
+  toolName: string;
   callerPrincipal: string | null;
   createdAt: string | null;
   toolCallId: string;
@@ -19,6 +23,9 @@ export function ToolCallMeta({
     <details className="haku-shell-disclosure">
       <summary>Metadata</summary>
       <div className="haku-shell-fields haku-shell-disclosure-body">
+        <Field label="Tool" mono>
+          {serverId}.{toolName}
+        </Field>
         {callerPrincipal && <Field label="Caller">{callerPrincipal}</Field>}
         {requested && (
           <Field label="Requested">

--- a/haku/console/frontend/tool_calls_page.tsx
+++ b/haku/console/frontend/tool_calls_page.tsx
@@ -1,16 +1,14 @@
-import { Badge, Button, Group, Loader, Stack, Text } from "@mantine/core";
+import { Button, Group, Loader, Text } from "@mantine/core";
 import { useCallback, useState } from "react";
 
 import { approvalDisplayFields, statusColor, terminalStatusLabel } from "./approval_state.ts";
 import { approveToolCall, denyToolCall, fetchToolCalls, type ToolCallRecord } from "./client.ts";
-import { Field } from "./field.tsx";
 import { ArrowLeftIcon } from "./icons.tsx";
 import { PendingToolCallActions } from "./pending_tool_call_actions.tsx";
 import { toastError, toastSuccess } from "./toast.ts";
-import { ToolArgumentsField } from "./tool_arguments_field.tsx";
-import { ToolCallMeta } from "./tool_call_meta.tsx";
+import { ToolCallCard } from "./tool_call_card.tsx";
 import { useToolCallEvents } from "./tool_call_events.ts";
-import { useVariant, VariantToggle } from "./variant_toggle.tsx";
+import { useVariant } from "./variant_toggle.tsx";
 
 // Matches the backend's `le=500` cap on GET /api/tool-calls (mcp_approval.py).
 const HISTORY_LIMIT = 500;
@@ -31,55 +29,17 @@ function ToolCallRow({
   const [variant, toggleVariant] = useVariant("compact");
   const fields = approvalDisplayFields(record);
   const pending = record.status === "pending_approval";
-  const detailed = variant === "detailed";
   return (
-    <section className="haku-shell-card">
-      <Stack gap="sm">
-        <Group justify="space-between" align="flex-start" gap="sm" wrap="nowrap">
-          <Stack gap={2} style={{ minWidth: 0 }}>
-            <Text fw={700}>{fields.title}</Text>
-            <Text size="xs" c="dimmed">
-              {fields.serverId}.{fields.toolName}
-            </Text>
-          </Stack>
-          <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
-            <Badge color={statusColor(record.status)} variant="light">
-              {terminalStatusLabel(record.status)}
-            </Badge>
-            <VariantToggle variant={variant} onToggle={toggleVariant} />
-          </Group>
-        </Group>
-        {record.error && (
-          <Text size="sm" c="red">
-            {record.error}
-          </Text>
-        )}
-        <div className="haku-shell-fields">
-          {detailed && fields.rationale && <Field label="Rationale">{fields.rationale}</Field>}
-          {fields.denialReason && <Field label="Denial reason">{fields.denialReason}</Field>}
-          <ToolArgumentsField
-            serverId={fields.serverId}
-            toolName={fields.toolName}
-            args={record.arguments}
-            argumentsJson={fields.argumentsJson}
-            variant={variant}
-          />
-          {detailed && record.result && (
-            <Field label="Result">
-              <pre className="haku-shell-json">{JSON.stringify(record.result, null, 2)}</pre>
-            </Field>
-          )}
-          {detailed && (
-            <ToolCallMeta
-              callerPrincipal={fields.callerPrincipal}
-              createdAt={fields.createdAt}
-              toolCallId={fields.toolCallId}
-            />
-          )}
-        </div>
-        {pending && <PendingToolCallActions busy={deciding} onApprove={onApprove} onDeny={onDeny} />}
-      </Stack>
-    </section>
+    <ToolCallCard
+      fields={fields}
+      args={record.arguments}
+      variant={variant}
+      onToggle={toggleVariant}
+      status={{ label: terminalStatusLabel(record.status), color: statusColor(record.status) }}
+      error={record.error}
+      result={record.result}
+      footer={pending ? <PendingToolCallActions busy={deciding} onApprove={onApprove} onDeny={onDeny} /> : null}
+    />
   );
 }
 

--- a/haku/console/frontend/tool_previews/entry.tsx
+++ b/haku/console/frontend/tool_previews/entry.tsx
@@ -7,24 +7,32 @@ import type { z } from "zod";
 
 import type { PreviewProps, PreviewVariant } from "./variant.tsx";
 
+/** A registered tool's own one-line action description for the card's identity line — a
+ * server-labelled verb phrase computed from the parsed args ("Gmail: Draft email", "kubectl:
+ * Delete Pod"). `destructive` colors it as a danger cue (irreversible deletes). */
+export type ToolAction = { text: string; destructive?: boolean };
+
 export type ToolPreview = {
   schema: z.ZodTypeAny;
   // Stored with `never` args: the schema-specific type is checked at the `definePreview` call
   // site and erased here so a heterogeneous `Record<string, ToolPreview>` holds every tool's
-  // entry. `renderPreview` is the one place that feeds it the schema's parsed output.
+  // entry. `renderPreview`/`describeAction` are the one place that feed them the parsed output.
   render: (args: never, variant: PreviewVariant) => ReactNode;
+  describe?: (args: never) => ToolAction;
 };
 
-/** Bind a tool's argument schema to the widget that renders it. `Widget` takes the schema's
- * inferred `args` (checked against `schema` here at the call site) plus the `variant`;
- * `renderPreview` supplies both. Pass the component directly — this builds the `<Widget/>`
+/** Bind a tool's argument schema to the widget that renders it (and, optionally, a `describe`
+ * that turns the parsed args into the card's action-description line). `Widget` takes the
+ * schema's inferred `args` plus the `variant`; both `render`- and `describe`-bound callbacks are
+ * fed the schema's parsed output. Pass the component directly — this builds the `<Widget/>`
  * element (a real child component, so the widget's own hooks work). */
 export function definePreview<S extends z.ZodTypeAny>(
   schema: S,
-  Widget: (props: PreviewProps<z.infer<S>>) => ReactNode
+  Widget: (props: PreviewProps<z.infer<S>>) => ReactNode,
+  describe?: (args: z.infer<S>) => ToolAction
 ): ToolPreview {
   const render = (args: z.infer<S>, variant: PreviewVariant): ReactNode => <Widget args={args} variant={variant} />;
-  return { schema, render: render as ToolPreview["render"] };
+  return { schema, render: render as ToolPreview["render"], describe: describe as ToolPreview["describe"] };
 }
 
 /** Parse `args` with the entry's schema and render; `null` on a schema mismatch, so the caller
@@ -39,4 +47,12 @@ export function renderPreview(
   // parsed.data is `unknown` (the schema is type-erased to ZodTypeAny in storage); the matching
   // `definePreview` bound this render to exactly this schema's output, so the cast is sound.
   return parsed.success ? preview.render(parsed.data as never, variant) : null;
+}
+
+/** The tool's action description for the card identity line, or `null` if it has no `describe`
+ * or its args don't parse (the caller then falls back to `serverId.toolName`). */
+export function describeAction(preview: ToolPreview, args: Record<string, unknown>): ToolAction | null {
+  if (!preview.describe) return null;
+  const parsed = preview.schema.safeParse(args);
+  return parsed.success ? preview.describe(parsed.data as never) : null;
 }

--- a/haku/console/frontend/tool_previews/gmail.tsx
+++ b/haku/console/frontend/tool_previews/gmail.tsx
@@ -16,7 +16,7 @@ import { Field } from "../field.tsx";
 import { fetchGmailThreadPreviews, type GmailThreadPreview } from "../gmail_client.ts";
 import { MailIcon } from "../icons.tsx";
 import { definePreview, type ToolPreview } from "./entry.tsx";
-import { COMPACT_ITEM_LIMIT, firstLines, MoreLine, type PreviewProps } from "./variant.tsx";
+import { COMPACT_ITEM_LIMIT, firstLines, MoreLine, plural, type PreviewProps } from "./variant.tsx";
 
 export const GMAIL_SERVER_ID = "gmail";
 
@@ -168,6 +168,8 @@ function CreateGmailDraftPreview({ args, variant }: PreviewProps<CreateGmailDraf
 /** Per-tool preview widgets for the `gmail` server's write tools. Read tools have no entry —
  * their args (a query, an id, a format) are self-descriptive, so the raw-JSON fallback serves. */
 export const gmailPreviews = {
-  threads_batch_modify: definePreview(zBatchModifyGmailThreadLabelsArgs, BatchModifyGmailThreadLabelsPreview),
-  drafts_create: definePreview(zCreateGmailDraftArgs, CreateGmailDraftPreview),
+  threads_batch_modify: definePreview(zBatchModifyGmailThreadLabelsArgs, BatchModifyGmailThreadLabelsPreview, (a) => ({
+    text: `Gmail: Relabel ${plural(a.thread_ids.length, "thread")}`,
+  })),
+  drafts_create: definePreview(zCreateGmailDraftArgs, CreateGmailDraftPreview, () => ({ text: "Gmail: Draft email" })),
 } satisfies Record<string, ToolPreview>;

--- a/haku/console/frontend/tool_previews/google_calendar.tsx
+++ b/haku/console/frontend/tool_previews/google_calendar.tsx
@@ -209,5 +209,7 @@ function CreateCalendarEventPreview({ args, variant }: PreviewProps<CreateCalend
 
 /** Per-tool preview widgets for the `google_calendar` server. */
 export const googleCalendarPreviews = {
-  create_calendar_event: definePreview(zCreateCalendarEventArgs, CreateCalendarEventPreview),
+  create_calendar_event: definePreview(zCreateCalendarEventArgs, CreateCalendarEventPreview, () => ({
+    text: "Google Calendar: Create event",
+  })),
 } satisfies Record<string, ToolPreview>;

--- a/haku/console/frontend/tool_previews/grocy.tsx
+++ b/haku/console/frontend/tool_previews/grocy.tsx
@@ -21,7 +21,7 @@ import { z } from "zod";
 
 import { fetchGrocyReference, type GrocyReferenceResponse } from "../grocy_client.ts";
 import { definePreview, type ToolPreview } from "./entry.tsx";
-import { ActionBadge, COMPACT_ITEM_LIMIT, MoreLine, type PreviewProps, type PreviewVariant } from "./variant.tsx";
+import { COMPACT_ITEM_LIMIT, MoreLine, plural, type PreviewProps, type PreviewVariant } from "./variant.tsx";
 
 export const GROCY_SERVER_ID = "grocy-sf";
 
@@ -150,7 +150,6 @@ function StockAddPreview({ args, variant }: PreviewProps<StockAddArgs>) {
   const shown = variant === "compact" ? args.items.slice(0, COMPACT_ITEM_LIMIT) : args.items;
   return (
     <Stack gap="xs">
-      <ActionBadge color="green">Add stock</ActionBadge>
       <Stack gap={4}>
         {shown.map((item, i) => (
           <StockAddRow key={i} item={item} reference={reference} />
@@ -187,7 +186,6 @@ function StockConsumePreview({ args, variant }: PreviewProps<StockConsumeArgs>) 
   const shown = variant === "compact" ? args.items.slice(0, COMPACT_ITEM_LIMIT) : args.items;
   return (
     <Stack gap="xs">
-      <ActionBadge color="red">Remove stock</ActionBadge>
       <Stack gap={4}>
         {shown.map((item, i) => (
           <StockConsumeRow key={i} item={item} reference={reference} />
@@ -277,7 +275,6 @@ function ProductsCreatePreview({ args, variant }: PreviewProps<ProductsCreateArg
   const shown = variant === "compact" ? args.items.slice(0, COMPACT_ITEM_LIMIT) : args.items;
   return (
     <Stack gap="xs">
-      <ActionBadge color="blue">Create product{args.items.length > 1 ? "s" : ""}</ActionBadge>
       <Stack gap={6}>
         {shown.map((item, i) => (
           <ProductsCreateRow key={i} item={item} reference={reference} variant={variant} />
@@ -291,7 +288,13 @@ function ProductsCreatePreview({ args, variant }: PreviewProps<ProductsCreateArg
 
 /** Per-tool preview widgets for the `grocy-sf` server's stock and product-creation tools. */
 export const grocyPreviews = {
-  stock_add: definePreview(zStockAddArgs, StockAddPreview),
-  stock_consume: definePreview(zStockConsumeArgs, StockConsumePreview),
-  products_create: definePreview(zProductsCreateArgs, ProductsCreatePreview),
+  stock_add: definePreview(zStockAddArgs, StockAddPreview, (a) => ({
+    text: `Grocy: Add ${plural(a.items.length, "item")} to stock`,
+  })),
+  stock_consume: definePreview(zStockConsumeArgs, StockConsumePreview, (a) => ({
+    text: `Grocy: Remove ${plural(a.items.length, "item")} from stock`,
+  })),
+  products_create: definePreview(zProductsCreateArgs, ProductsCreatePreview, (a) => ({
+    text: `Grocy: Create ${plural(a.items.length, "product")}`,
+  })),
 } satisfies Record<string, ToolPreview>;

--- a/haku/console/frontend/tool_previews/haku_routine.tsx
+++ b/haku/console/frontend/tool_previews/haku_routine.tsx
@@ -4,7 +4,7 @@
 // verbatim before approving. Hand-authored zod (there's no backend Pydantic arg model wired to
 // :schema_zod for one trivial optional string) — same caveat as kubectl.tsx.
 
-import { Stack, Text } from "@mantine/core";
+import { Text } from "@mantine/core";
 import { z } from "zod";
 
 import { Field } from "../field.tsx";
@@ -20,21 +20,18 @@ function LaunchRoutinePreview({ args, variant }: PreviewProps<LaunchRoutineArgs>
   const text = args.text?.trim();
   const shown = text ? (variant === "compact" ? clampBlock(text, 3) : text) : null;
   return (
-    <Stack gap="xs">
-      <Field label="Action">Start a new Haku run</Field>
-      <Field label="Instructions">
-        {shown ? (
-          <pre className="haku-shell-json">{shown}</pre>
-        ) : (
-          <Text size="sm" c="dimmed">
-            (routine default)
-          </Text>
-        )}
-      </Field>
-    </Stack>
+    <Field label="Instructions">
+      {shown ? (
+        <pre className="haku-shell-json">{shown}</pre>
+      ) : (
+        <Text size="sm" c="dimmed">
+          (routine default)
+        </Text>
+      )}
+    </Field>
   );
 }
 
 export const hakuRoutinePreviews = {
-  launch_routine: definePreview(zLaunchRoutineArgs, LaunchRoutinePreview),
+  launch_routine: definePreview(zLaunchRoutineArgs, LaunchRoutinePreview, () => ({ text: "Haku: Start a new run" })),
 } satisfies Record<string, ToolPreview>;

--- a/haku/console/frontend/tool_previews/index.tsx
+++ b/haku/console/frontend/tool_previews/index.tsx
@@ -7,7 +7,7 @@
 
 import type { ReactNode } from "react";
 
-import { renderPreview, type ToolPreview } from "./entry.tsx";
+import { describeAction, renderPreview, type ToolAction, type ToolPreview } from "./entry.tsx";
 import { GMAIL_SERVER_ID, gmailPreviews } from "./gmail.tsx";
 import { GOOGLE_CALENDAR_SERVER_ID, googleCalendarPreviews } from "./google_calendar.tsx";
 import { GROCY_SERVER_ID, grocyPreviews } from "./grocy.tsx";
@@ -31,4 +31,15 @@ export function toolPreview(
 ): ReactNode | null {
   const preview = REGISTRY[serverId]?.[toolName];
   return preview ? renderPreview(preview, args, variant) : null;
+}
+
+/** A registered tool's action description for the card's identity line, or `null` when no widget
+ * matches (the caller falls back to `serverId.toolName`). */
+export function toolActionDescription(
+  serverId: string,
+  toolName: string,
+  args: Record<string, unknown>
+): ToolAction | null {
+  const preview = REGISTRY[serverId]?.[toolName];
+  return preview ? describeAction(preview, args) : null;
 }

--- a/haku/console/frontend/tool_previews/kubectl.tsx
+++ b/haku/console/frontend/tool_previews/kubectl.tsx
@@ -10,7 +10,7 @@ import { Group, Stack, Text } from "@mantine/core";
 import { z } from "zod";
 
 import { definePreview, type ToolPreview } from "./entry.tsx";
-import { ActionBadge, clampBlock, type PreviewProps } from "./variant.tsx";
+import { clampBlock, type PreviewProps } from "./variant.tsx";
 
 export const KUBECTL_SERVER_ID = "kubectl-passthrough-mcp";
 
@@ -41,12 +41,7 @@ type PodsDeleteArgs = z.infer<typeof zPodsDeleteArgs>;
 
 function ResourcesApplyPreview({ args, variant }: PreviewProps<ResourcesCreateOrUpdateArgs>) {
   const resource = variant === "compact" ? clampBlock(args.resource, 3) : args.resource;
-  return (
-    <Stack gap="xs">
-      <ActionBadge color="blue">Apply</ActionBadge>
-      <pre className="haku-shell-json">{resource}</pre>
-    </Stack>
-  );
+  return <pre className="haku-shell-json">{resource}</pre>;
 }
 
 function DeleteTargetPreview({
@@ -62,7 +57,6 @@ function DeleteTargetPreview({
 }) {
   return (
     <Stack gap="xs">
-      <ActionBadge color="red">Delete</ActionBadge>
       <Group gap={4} className="haku-shell-mono">
         <Text span fw={600}>
           {kind}
@@ -101,7 +95,15 @@ function PodsDeletePreview({ args }: PreviewProps<PodsDeleteArgs>) {
 /** Per-tool preview widgets for the `kubectl-passthrough-mcp` server's highest-stakes tools
  * (apply and delete). */
 export const kubectlPreviews = {
-  resources_create_or_update: definePreview(zResourcesCreateOrUpdateArgs, ResourcesApplyPreview),
-  resources_delete: definePreview(zResourcesDeleteArgs, ResourcesDeletePreview),
-  pods_delete: definePreview(zPodsDeleteArgs, PodsDeletePreview),
+  resources_create_or_update: definePreview(zResourcesCreateOrUpdateArgs, ResourcesApplyPreview, () => ({
+    text: "kubectl: Apply resource",
+  })),
+  resources_delete: definePreview(zResourcesDeleteArgs, ResourcesDeletePreview, (a) => ({
+    text: `kubectl: Delete ${a.kind}`,
+    destructive: true,
+  })),
+  pods_delete: definePreview(zPodsDeleteArgs, PodsDeletePreview, () => ({
+    text: "kubectl: Delete Pod",
+    destructive: true,
+  })),
 } satisfies Record<string, ToolPreview>;

--- a/haku/console/frontend/tool_previews/variant.tsx
+++ b/haku/console/frontend/tool_previews/variant.tsx
@@ -4,8 +4,7 @@
 // first few lines. A **detailed** preview is the full form shown in the expanded detail
 // view. Leaf module (no widget deps) so index.tsx and every widget can import the type
 // without a cycle.
-import { Badge, Text } from "@mantine/core";
-import type { ReactNode } from "react";
+import { Text } from "@mantine/core";
 
 export type PreviewVariant = "compact" | "detailed";
 
@@ -17,15 +16,10 @@ export type PreviewProps<Args> = { args: Args; variant: PreviewVariant };
 // collapse to a single "… +N more" line so a card stays scannable.
 export const COMPACT_ITEM_LIMIT = 3;
 
-/** The action a widget performs, as one colored badge — the house form for every preview's
- * verb (green create/add, red destructive/remove, blue/gray neutral). No label above it: the
- * badge *is* the label. */
-export function ActionBadge({ color, children }: { color: string; children: ReactNode }) {
-  return (
-    <Badge color={color} variant="light">
-      {children}
-    </Badge>
-  );
+/** "4 threads" / "1 item" — a count plus its naively pluralized noun (append "s" unless
+ * singular), for the action descriptions ("Add 5 items to stock"). */
+export function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
 /** A dimmed "… +N more" line for the items a compact preview elided; renders nothing at 0. */

--- a/haku/console/frontend/variant_toggle.tsx
+++ b/haku/console/frontend/variant_toggle.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@mantine/core";
 import { useState } from "react";
 
 import type { PreviewVariant } from "./tool_previews/variant.tsx";
@@ -12,11 +11,17 @@ export function useVariant(initial: PreviewVariant): [PreviewVariant, () => void
   return [variant, () => setVariant((v) => (v === "compact" ? "detailed" : "compact"))];
 }
 
-/** Flips a view between compact and detailed; the label names the state it switches *to*. */
+/** Expands/collapses a card's detail, rendered as a caret disclosure that matches the card's
+ * other disclosures (Metadata, Raw arguments) — a rotating triangle + "Show details" / "Show
+ * less" at the bottom of the card, not a button in the corner. */
 export function VariantToggle({ variant, onToggle }: { variant: PreviewVariant; onToggle: () => void }) {
+  const detailed = variant === "detailed";
   return (
-    <Button size="compact-xs" variant="subtle" color="gray" onClick={onToggle}>
-      {variant === "compact" ? "Details" : "Compact"}
-    </Button>
+    <button type="button" className="haku-shell-expander" aria-expanded={detailed} onClick={onToggle}>
+      <span className="haku-shell-expander-caret" aria-hidden="true">
+        ▸
+      </span>
+      {detailed ? "Show less" : "Show details"}
+    </button>
   );
 }


### PR DESCRIPTION
Follow-up to the tool-call rendering pass (#3023). Three related cleanups.

## Fold the action into the identity line

A widget's `ActionBadge` ("Remove stock") largely restated the `serverId.toolName` the card header already showed. Now a registered tool describes its own action via `definePreview`'s third arg:

- `grocy-sf.stock_add` → **Grocy: Add 5 items to stock**
- `gmail.drafts_create` → **Gmail: Draft email**
- `kubectl…resources_delete` → **kubectl: Delete Pod** (destructive → red)
- `haku_routine.launch_routine` → **Haku: Start a new run**

It renders on the card's identity line (`tool_action_line.tsx`), **replacing** both the `serverId.toolName` subtitle and the now-removed `ActionBadge`; the widget body no longer restates the action. A tool with **no** widget falls back to `serverId.toolName` in the same line. The exact `serverId.toolName` moves into the `Metadata` disclosure (new `Tool` field).

## One shared `ToolCallCard`

The three renderings — the drawer's pending and recent cards (`console_panel.tsx`) and the history rows (`tool_calls_page.tsx`) — each re-spelled the same header → args → metadata skeleton, which is why `ToolCallMeta` had three callers. They now render through one shared `tool_call_card.tsx` (identity header + action line + status badge + detail toggle, arguments body, detailed Result/Metadata); only the status badge and footer actions differ per surface. `ToolCallMeta` / `ToolActionLine` each have one caller now, and rationale/error/denial/result read the same everywhere.

## Detail toggle → a real disclosure

The compact/detailed toggle was a "Details" button pinned to the card's top-right — not where a disclosure lives or how one reads. It's now a caret-led **"Show details" / "Show less"** at the bottom of the card, matching the card's other disclosures (`Metadata`, `Raw arguments`); the status badge sits alone in the header.

The design contract in `frontend/AGENTS.md` is updated to match; the `previews` gallery shows each tool's action line under its heading.

## Test

`bbr test //haku/console/...` — all 13 green on RBE (tsc, vitest, screenshots, backend). Eyeballed the `previews` gallery (every tool's action line, destructive deletes in red, ActionBadges gone), the `drawer` (shared card + bottom "Show details" disclosure), and the `history` (shared card + the new `Tool` metadata field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5PSCrFPzAn61Yqr2hZE9a