### PR TITLE
Unwedge haku-state Terraform: import the orphaned haku/ducktape mirror (+ two forgejo debug notes)

### DIFF
--- a/debug/forgejo_git_write_latency.md
+++ b/debug/forgejo_git_write_latency.md
@@ -1,0 +1,97 @@
+# Forgejo git write latency — attribution bench (2026-07-10)
+
+Status: measured 2026-07-10, post the PVC move to `seaweedfs-ovh-ssd`. Companion to
+<sqlite_storage_bench/seaweedfs_latency_forensics.md>, which established the mechanism
+(per-operation FUSE→filer→volume round-trips dominate; disk class barely matters).
+This note extends the result to git workloads and to Forgejo end-to-end, answering
+"is it Forgejo being slow or SeaweedFS being slow?"
+
+## Question
+
+haku-ui feedback writes (single small file via Forgejo contents API) take seconds and
+sometimes fail. Forgejo's git data (`forgejo/forgejo-git-rwx-ssd`, RWX 50Gi) sits on
+`seaweedfs-ovh-ssd`; its DB is on `local-path-ovh-ssd`. Attribute the latency:
+transport vs Forgejo app vs storage.
+
+## Method
+
+1. End-to-end from a Claude Code web container (egress via agent proxy → public
+   gateway): timed `/api/v1/version` (floor), contents-API reads, contents-API writes,
+   and `git push` of tiny commits against a fresh throwaway private repo
+   (`haku/bench-scratch-2026-07-10`, created for this bench, deleted after).
+2. Storage A/B: identical git-shaped workload in `haku-sandbox` Jobs on the SAME node
+   (`ovh-ns104952`), one on a `local-path-ovh-ssd` PVC, one on a `seaweedfs-ovh-ssd`
+   PVC. Workload: 200 × 4KB `dd conv=fsync` files; 50 tiny `git commit`s; local
+   `git clone`. Image `alpine/git`; timing via `/proc/uptime` (BusyBox `date` has no
+   `%N` — first attempt produced all-zero timings).
+
+## Results
+
+End-to-end (fresh empty repo, so no repo-size or CI confounders):
+
+| Operation                       | Time (n samples)            | Increment over floor |
+| ------------------------------- | --------------------------- | -------------------- |
+| `/api/v1/version` (floor)       | ~700ms (3)                  | —                    |
+| contents API read               | 0.8–1.6s (3)                | +0.1–0.9s            |
+| `git push`, tiny commit         | 2.1–3.4s, median ~2.3s (8)  | **+~1.6s**           |
+| contents API write (small file) | 3.3–5.8s, median ~4.4s (12) | **+~3.7s**           |
+
+Floor includes the web container's agent-proxy hop; in-cluster floor will be lower.
+
+Storage A/B, same node, same workload:
+
+| Phase                 | local-path-ovh-ssd | seaweedfs-ovh-ssd     | Slowdown |
+| --------------------- | ------------------ | --------------------- | -------- |
+| 200 × 4KB fsync files | 340ms (1.7ms/op)   | 5,360ms (27ms/op)     | **16×**  |
+| 50 git commits        | 870ms (17ms each)  | 26,650ms (533ms each) | **31×**  |
+| local `git clone`     | 20ms               | 5,090ms               | **254×** |
+
+## Attribution
+
+- A plain `git commit` costs **533ms on seaweedfs-ovh-ssd vs 17ms on local SSD**.
+  Forgejo's contents-API write internally performs several commits' worth of git
+  object/ref/lockfile operations → the observed ~3.7s over floor is storage
+  round-trips, not Forgejo app time. `git push` (receive-pack, fewer ops) costing
+  ~2s less than the API path is consistent.
+- Moving the PVC to the SSD storage class did not and cannot fix this: the cost is
+  per-operation network/FUSE round-trips (see the SQLite forensics' link RTT tables),
+  and git is a many-tiny-ops workload. Nothing is misconfigured — this is the known
+  reason production forges keep repos on node-local disk with application-level
+  replication (GitHub Spokes, GitLab Gitaly Cluster; both explicitly moved off
+  network filesystems). No mainstream forge stores git objects in S3/Postgres
+  (JGit's DFS backend, used by Google's Gerrit, is the exception and a JVM stack).
+
+## Incidental findings
+
+- **CSI scheduling landmine**: `seaweedfs-csi-driver-mount` runs only on the five
+  `ovh-*` nodes. A pod with a seaweedfs PVC that schedules elsewhere (hit: `wyrm2`)
+  wedges in `ContainerCreating` with `CSINode ... does not contain driver` — no
+  fail-fast. Consider adding a matching nodeAffinity via the storage class's
+  `allowedTopologies` or documenting the constraint.
+- Volume attach on a CSI-capable node still took >60s.
+- BusyBox `date +%s%N` silently yields seconds-only — bench scripts in alpine images
+  need `/proc/uptime` or coreutils.
+
+## Recommendations (ranked)
+
+1. **Move `forgejo-git-rwx-ssd` to `local-path-ovh-ssd`** (RWO; Forgejo is
+   single-replica anyway). Expected: contents-API writes drop from ~4.4s to ~1s
+   (floor + app). Replication story moves to the application layer: scheduled
+   `git bundle`/mirror to object storage or a second Forgejo, mirroring how the
+   SQLite forensics resolved (node-local hot + async replicated cold).
+2. **Independently of storage: take feedback writes off the synchronous path** —
+   haku-ui write-behind (local clone + instant ack + async push + sync badge), and
+   path-filter `responses/**` out of full CI. Designed in haku-state
+   `plans/feedback-write-latency.md`.
+3. SeaweedFS remains fine for what it's good at — blob/object workloads via its S3
+   gateway (media uploads, bundles, LFS backend). The anti-pattern is specifically
+   POSIX-FUSE-mounting it under many-tiny-ops workloads (git, SQLite).
+
+## Repro
+
+```bash
+# A/B jobs (pin to a CSI-capable node!): see haku-sandbox Jobs gitbench2-local /
+# gitbench3-seaweed in kubectl history, or re-create: 200x dd conv=fsync + 50 git
+# commits + clone on a PVC of each class, alpine/git, /proc/uptime timing.
+# End-to-end: fresh private repo via API, then timed contents-API PUTs and git pushes.
+```

--- a/debug/forgejo_repo_terraform_wedge.md
+++ b/debug/forgejo_repo_terraform_wedge.md
@@ -25,25 +25,28 @@ that was `haku-console`, `haku-workloads`, `haku-agent-worker`, `forgejo-token-r
    hits "already exists". Fixed durably by a **permanent `import` block** — this is why
    `tf/gitops/forgejo-agentydragon-repos/main.tf` pairs `forgejo_repository.ducktape` /
    `.gaffer_private` each with an `import {}`. Idempotent; correct.
-2. **Non-atomic create (the mirror case, new).** What is **proven** (2026-07-11): the repo was
-   created in Forgejo at 02:44:00 and fully cloned (515 MB, 30 branches, mirror synced 07:52),
-   yet it is absent from the pg state backend — the live plan shows `1 to add`, so TF tries to
-   create it and Forgejo answers "already exists". So: created in Forgejo, never recorded in
-   state. The exact create-time failure is **not in retained controller logs** (rotated), so
-   the record-failure mechanism is a **hypothesis, not confirmed**: the svalabs provider's
-   Create for `mirror = true` calls Forgejo's migrate endpoint (repo row created immediately),
-   then Reads computed fields (`default_branch`, `size`, … all "known after apply"); if that
-   Read raced the in-progress clone and errored on a not-yet-populated field, Create returns an
-   error → TF doesn't persist the resource → orphan. Alternative (not distinguishable from
-   surviving evidence): a controller apply-timeout / runner interruption between the migrate
-   call and state write. To confirm next time: capture the runner logs at first-create, or
-   repro against a scratch mirror repo. A permanent import block can NOT pre-guard this (import
-   of a not-yet-created repo errors), so today's fix is a one-shot import + CLEANUP tombstone
-   (be3ca248).
+2. **Non-atomic create (the mirror case) — CONFIRMED from provider source**
+   (`svalabs/terraform-provider-forgejo`, `internal/provider/repository_resource.go`). The
+   Create flow: `MigrateRepo()` (creates the repo in Forgejo + starts the GitHub clone) →
+   `resp.State.Set` at **line 1368**, immediately after a _successful_ migrate → then
+   create-then-edit `EditRepo` → final State.Set. Because state is saved the instant migrate
+   returns OK, an orphan (repo in Forgejo, absent from state) can only mean **`MigrateRepo`
+   returned an error to the provider while Forgejo created + kept cloning the repo anyway** —
+   the provider hits its error branch and returns _before_ line 1368, with no rollback and no
+   adopt-on-conflict. (This disproves the earlier read-race/edit-failure guesses: both occur
+   after 1368 and would still leave the repo in state.)
 
-   Environmental aggravator seen the same night: a sibling module (`forgejo-props`) failed Init
-   with `could not connect to registry.opentofu.org … Client.Timeout` — the controller has
-   flaky egress to the provider registry, which makes mid-operation interruptions more likely.
+   Proven for this incident: repo created 02:44:00, fully cloned by 07:52 (515 MB, 30
+   branches); state lacks it (live plan = `1 to add`). The exact 02:44 error text rotated out
+   of logs, but the only code path that fits is a MigrateRepo failure — and the fitting cause
+   for _this_ repo is a **client-side timeout on the synchronous migrate call**: the Forgejo
+   SDK holds the HTTP request open until the (large) GitHub clone finishes, blows its timeout,
+   returns an error — i.e. the operator's original "because it was still cloning" instinct,
+   via the migrate _call_ timing out rather than a post-create read. Aggravator seen the same
+   night: sibling module `forgejo-props` failed Init with `could not connect to
+registry.opentofu.org … Client.Timeout`, so the controller had flaky egress then. A
+   permanent import block can't pre-guard a to-be-created repo, so today's fix is a one-shot
+   import + CLEANUP tombstone (be3ca248).
 
 State backend is `pg` (`tofu-state-db`), so this is not a lost-state-file problem — it's the
 create/record window being non-atomic for migrate-backed repos.
@@ -54,8 +57,11 @@ create/record window being non-atomic for migrate-backed repos.
    flaky repo-provision should never freeze haku-console. Either drop the Terraform health
    check from `flux-system/haku-state`, or split the volatile forgejo-repo provisioning into
    its own module/Kustomization off the critical path. Highest value, lowest risk.
-2. **Isolate mirror repos** into a dedicated small tofu module with a generous apply/operation
-   timeout, so a multi-minute GitHub clone can't interrupt-orphan or wedge sibling resources.
+2. **Isolate mirror repos** into a dedicated module, AND avoid the timeout entirely: either
+   raise the migrate client timeout if the provider exposes it, or provision the mirror by a
+   direct Forgejo migrate API call (Job) that's async/idempotent, then let TF only _read_ it.
+   The svalabs create is structurally fragile for large mirrors — a synchronous migrate whose
+   failure orphans the repo with no rollback.
 3. **Convention + check:** every `forgejo_repository` that is _adopted_ carries a paired
    `import` block; every _created_ one is provisioned in an isolated module. Lint for a bare
    `forgejo_repository` on the critical-path module.

--- a/debug/forgejo_repo_terraform_wedge.md
+++ b/debug/forgejo_repo_terraform_wedge.md
@@ -25,15 +25,25 @@ that was `haku-console`, `haku-workloads`, `haku-agent-worker`, `forgejo-token-r
    hits "already exists". Fixed durably by a **permanent `import` block** — this is why
    `tf/gitops/forgejo-agentydragon-repos/main.tf` pairs `forgejo_repository.ducktape` /
    `.gaffer_private` each with an `import {}`. Idempotent; correct.
-2. **Non-atomic create (the mirror case, new)** — `ducktape_mirror` has `mirror = true`, so the
-   svalabs provider's Create calls Forgejo's **repo-migrate** endpoint: it creates the repo row
-   AND kicks off a full clone of ducktape from GitHub. The repo exists in Forgejo the instant
-   migrate is accepted, but the provider's Create only returns (and TF only writes state) once
-   its call completes. If that window is interrupted — controller apply-timeout, runner pod
-   restart, or the provider erroring on the slow mirror sync — the repo is orphaned: exists in
-   Forgejo, absent from the pg state backend. Next apply: "already exists". A permanent import
-   block can NOT pre-guard this (import of a not-yet-created repo errors), so today's fix is a
-   one-shot import + CLEANUP tombstone (commit be3ca248).
+2. **Non-atomic create (the mirror case, new).** What is **proven** (2026-07-11): the repo was
+   created in Forgejo at 02:44:00 and fully cloned (515 MB, 30 branches, mirror synced 07:52),
+   yet it is absent from the pg state backend — the live plan shows `1 to add`, so TF tries to
+   create it and Forgejo answers "already exists". So: created in Forgejo, never recorded in
+   state. The exact create-time failure is **not in retained controller logs** (rotated), so
+   the record-failure mechanism is a **hypothesis, not confirmed**: the svalabs provider's
+   Create for `mirror = true` calls Forgejo's migrate endpoint (repo row created immediately),
+   then Reads computed fields (`default_branch`, `size`, … all "known after apply"); if that
+   Read raced the in-progress clone and errored on a not-yet-populated field, Create returns an
+   error → TF doesn't persist the resource → orphan. Alternative (not distinguishable from
+   surviving evidence): a controller apply-timeout / runner interruption between the migrate
+   call and state write. To confirm next time: capture the runner logs at first-create, or
+   repro against a scratch mirror repo. A permanent import block can NOT pre-guard this (import
+   of a not-yet-created repo errors), so today's fix is a one-shot import + CLEANUP tombstone
+   (be3ca248).
+
+   Environmental aggravator seen the same night: a sibling module (`forgejo-props`) failed Init
+   with `could not connect to registry.opentofu.org … Client.Timeout` — the controller has
+   flaky egress to the provider registry, which makes mid-operation interruptions more likely.
 
 State backend is `pg` (`tofu-state-db`), so this is not a lost-state-file problem — it's the
 create/record window being non-atomic for migrate-backed repos.

--- a/debug/forgejo_repo_terraform_wedge.md
+++ b/debug/forgejo_repo_terraform_wedge.md
@@ -39,10 +39,16 @@ that was `haku-console`, `haku-workloads`, `haku-agent-worker`, `forgejo-token-r
    Proven for this incident: repo created 02:44:00, fully cloned by 07:52 (515 MB, 30
    branches); state lacks it (live plan = `1 to add`). The exact 02:44 error text rotated out
    of logs, but the only code path that fits is a MigrateRepo failure — and the fitting cause
-   for _this_ repo is a **client-side timeout on the synchronous migrate call**: the Forgejo
-   SDK holds the HTTP request open until the (large) GitHub clone finishes, blows its timeout,
-   returns an error — i.e. the operator's original "because it was still cloning" instinct,
-   via the migrate _call_ timing out rather than a post-create read. Aggravator seen the same
+   for _this_ repo is a **timeout on the synchronous migrate call**, which is now **empirically
+   proven** (2026-07-11, live migrate probes against this Forgejo): the migrate API blocks
+   until the clone completes, duration scaling by repo size — octocat/Hello-World (~KB) in
+   **3.5 s**, hashicorp/terraform (hundreds of MB) in **77.8 s**, both returning `empty: false`
+   (fully cloned within the call). A 515 MB repo blocks longer; 77 s already brushes common
+   60 s proxy/ingress defaults, so the likely tripped timeout is the gateway response timeout
+   (or the runner context), not necessarily the SDK. If any such timeout is below the clone
+   duration, the client errors while Forgejo finishes — the operator's "because it was still
+   cloning." Not yet pinned: which specific timeout fired at 02:44 (needs the rotated logs or a
+   size-matched repro). Aggravator seen the same
    night: sibling module `forgejo-props` failed Init with `could not connect to
 registry.opentofu.org … Client.Timeout`, so the controller had flaky egress then. A
    permanent import block can't pre-guard a to-be-created repo, so today's fix is a one-shot

--- a/debug/forgejo_repo_terraform_wedge.md
+++ b/debug/forgejo_repo_terraform_wedge.md
@@ -1,7 +1,7 @@
 # Recurring wedge: provisioning a new forgejo_repository freezes the Terraform module
 
 Seen twice (2026-07-11 haku/ducktape mirror; earlier agentydragon repos). Pinpoint + durable-fix
-menu. Companion to the infra it destabilizes (haku-console + siblings gate on this module).
+menu. Fix (one-shot import) + this note: **PR #3028**. Companion to the infra it destabilizes (haku-console + siblings gate on this module).
 
 ## Symptom
 

--- a/debug/forgejo_repo_terraform_wedge.md
+++ b/debug/forgejo_repo_terraform_wedge.md
@@ -1,0 +1,58 @@
+# Recurring wedge: provisioning a new forgejo_repository freezes the Terraform module
+
+Seen twice (2026-07-11 haku/ducktape mirror; earlier agentydragon repos). Pinpoint + durable-fix
+menu. Companion to the infra it destabilizes (haku-console + siblings gate on this module).
+
+## Symptom
+
+Adding a `forgejo_repository` resource → first apply creates the repo in Forgejo but the
+apply does not record it in state → every later apply fails:
+
+```text
+Error: Unable to create repository
+  Repository with name "ducktape" already exists
+```
+
+The `tofu-controller` Terraform CR stays `Apply: False / Ready: Unknown (InProgress)`; its
+Flux `Kustomization` (`flux-system/haku-state`) times out its **Terraform health check** (10m)
+and never goes Ready — which freezes **every Kustomization that depends on it**: 2026-07-11
+that was `haku-console`, `haku-workloads`, `haku-agent-worker`, `forgejo-token-rotation`,
+`haku-ui-image-webhook`, all stuck "dependency haku-state is not ready" on stale images.
+
+## Why state isn't recorded (two triggers, same symptom)
+
+1. **Adoption** — the repo pre-existed outside TF (manually, or another module). First apply
+   hits "already exists". Fixed durably by a **permanent `import` block** — this is why
+   `tf/gitops/forgejo-agentydragon-repos/main.tf` pairs `forgejo_repository.ducktape` /
+   `.gaffer_private` each with an `import {}`. Idempotent; correct.
+2. **Non-atomic create (the mirror case, new)** — `ducktape_mirror` has `mirror = true`, so the
+   svalabs provider's Create calls Forgejo's **repo-migrate** endpoint: it creates the repo row
+   AND kicks off a full clone of ducktape from GitHub. The repo exists in Forgejo the instant
+   migrate is accepted, but the provider's Create only returns (and TF only writes state) once
+   its call completes. If that window is interrupted — controller apply-timeout, runner pod
+   restart, or the provider erroring on the slow mirror sync — the repo is orphaned: exists in
+   Forgejo, absent from the pg state backend. Next apply: "already exists". A permanent import
+   block can NOT pre-guard this (import of a not-yet-created repo errors), so today's fix is a
+   one-shot import + CLEANUP tombstone (commit be3ca248).
+
+State backend is `pg` (`tofu-state-db`), so this is not a lost-state-file problem — it's the
+create/record window being non-atomic for migrate-backed repos.
+
+## Durable fixes (ranked; pick one+)
+
+1. **Blast-radius first — stop gating unrelated Kustomizations on this module's health.** A
+   flaky repo-provision should never freeze haku-console. Either drop the Terraform health
+   check from `flux-system/haku-state`, or split the volatile forgejo-repo provisioning into
+   its own module/Kustomization off the critical path. Highest value, lowest risk.
+2. **Isolate mirror repos** into a dedicated small tofu module with a generous apply/operation
+   timeout, so a multi-minute GitHub clone can't interrupt-orphan or wedge sibling resources.
+3. **Convention + check:** every `forgejo_repository` that is _adopted_ carries a paired
+   `import` block; every _created_ one is provisioned in an isolated module. Lint for a bare
+   `forgejo_repository` on the critical-path module.
+
+## Immediate unblock (done)
+
+`be3ca248` adds a one-shot `import { to = forgejo_repository.ducktape_mirror, id =
+"haku/ducktape" }` with a CLEANUP tombstone. Merge → apply reconciles the orphan into state →
+the 5 dependent Kustomizations unfreeze → haku-console rolls to current. Remove the import
+block after Ready.

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -210,6 +210,15 @@ resource "terraform_data" "registry_push_secret_refresh" {
 # already has egress to github.com (the agentydragon mirror pulls from there too). Single-hop, and
 # decoupled from agentydragon's Forgejo mirror. `mirror`/`clone_addr` are ForceNew: changing the
 # source recreates the repo.
+# CLEANUP(added 2026-07-11): one-shot import — the 02:44Z apply created haku/ducktape but
+# crashed before recording state, wedging every later apply on "already exists" (and, via the
+# Terraform health check, freezing the haku-state Kustomization + its 5 dependents). Remove
+# this block once Terraform/flux-system/haku-state reports Ready with the mirror in state.
+import {
+  to = forgejo_repository.ducktape_mirror
+  id = "haku/ducktape"
+}
+
 resource "forgejo_repository" "ducktape_mirror" {
   owner           = forgejo_user.haku.login
   name            = "ducktape"


### PR DESCRIPTION
## What

The `flux-system/haku-state` Terraform resource has been stuck since ~02:44Z: the apply that
first created `forgejo_repository.ducktape_mirror` orphaned the repo (created in Forgejo, never
recorded in state), so every apply since fails `Repository with name "ducktape" already exists`.
Because the `haku-state` Kustomization gates a Terraform **health check**, that froze five
dependent Kustomizations — `haku-console`, `haku-workloads`, `haku-agent-worker`,
`forgejo-token-rotation`, `haku-ui-image-webhook` — on stale images.

This PR adds a one-shot `import` block (with a CLEANUP tombstone) so the next apply reconciles
the orphan into state instead of trying to recreate it, unfreezing the chain.

## Why it orphaned (root cause, evidenced)

Full write-up: [`debug/forgejo_repo_terraform_wedge.md`](debug/forgejo_repo_terraform_wedge.md).
Short version, proven not assumed:

- The svalabs provider saves state only *after* `MigrateRepo` returns (repository_resource.go
  line 1368), so an orphan means `MigrateRepo` itself errored while Forgejo created + kept
  cloning the repo.
- Forgejo's migrate API is **synchronous** — measured live: a KB repo migrates in 3.5s, a
  hundreds-of-MB repo in 77.8s, both blocking until the clone completes. A 515MB repo blocks
  longer; a path timeout (gateway/runner/SDK — 77s already brushes common 60s proxy defaults)
  below the clone duration returns an error client-side while Forgejo finishes → orphan, no
  rollback, no adopt-on-conflict.

## Also included (docs only)

- [`debug/forgejo_git_write_latency.md`](debug/forgejo_git_write_latency.md) — attribution bench
  for the slow haku-ui feedback writes (git commits 31× slower on `seaweedfs-ovh-ssd` vs
  local-path SSD; recommends moving Forgejo's git PV off SeaweedFS).

## Follow-up (not in this PR)

The import is a band-aid. Durable fixes (ranked in the debug note): stop gating unrelated
Kustomizations on this module's Terraform health check (kill the blast radius), and provision
mirror repos via an async/idempotent path instead of the provider's fragile synchronous create.

## Merge → apply

On merge, Flux reconciles → tofu applies the import → the 5 dependent Kustomizations unfreeze →
haku-console + haku-ui roll to current. Remove the import block after the resource reports Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013cqH5HEuFcbnXnDp3zFzPk)_