### PR TITLE
config: register GPT-5.6 model series

### DIFF
--- a/cluster/k8s/agents/codex-pod/README.md
+++ b/cluster/k8s/agents/codex-pod/README.md
@@ -92,7 +92,7 @@ this non-root image pod has not) and no boot-time render script:
   models instead of an interactive ChatGPT sign-in. The baked `~/.codex/config.toml`
   defines a `litellm` `model_provider` (`base_url = litellm.allegedly.works/v1`,
   `wire_api = responses`, `env_key = LITELLM_API_KEY`) and defaults to
-  `gpt-5.5-chatgpt`. `LITELLM_API_KEY` is a dedicated virtual key minted by
+  `gpt-5.6-sol-chatgpt`. `LITELLM_API_KEY` is a dedicated virtual key minted by
   `tf/gitops/litellm-keys` (alias `codex-pod`, scoped to the oai/chatgpt models with
   a budget — deleting it is the kill switch), reflected into `codex-pod` and set on
   the container via `secretKeyRef` (`optional: true`).

--- a/cluster/k8s/agents/openclaw/gateway/openclawinstance.yaml
+++ b/cluster/k8s/agents/openclaw/gateway/openclawinstance.yaml
@@ -65,6 +65,12 @@ spec:
               alias: gemini-2.5-flash
             openai/gpt-5.2:
               alias: gpt-5.2
+            openai/gpt-5.6-sol:
+              alias: gpt-5.6-sol
+            openai/gpt-5.6-terra:
+              alias: gpt-5.6-terra
+            openai/gpt-5.6-luna:
+              alias: gpt-5.6-luna
             openai/gpt-5.2-pro:
               alias: gpt-5.2-pro
             openai/gpt-5.2-codex:
@@ -141,6 +147,24 @@ spec:
             baseUrl: "https://api.openai.com/v1"
             api: openai-completions
             models:
+              - id: "gpt-5.6-sol"
+                name: "GPT-5.6 Sol"
+                reasoning: true
+                input: ["text", "image"]
+                contextWindow: 1050000
+                maxTokens: 128000
+              - id: "gpt-5.6-terra"
+                name: "GPT-5.6 Terra"
+                reasoning: true
+                input: ["text", "image"]
+                contextWindow: 1050000
+                maxTokens: 128000
+              - id: "gpt-5.6-luna"
+                name: "GPT-5.6 Luna"
+                reasoning: true
+                input: ["text", "image"]
+                contextWindow: 1050000
+                maxTokens: 128000
               - id: "gpt-5.2"
                 name: "GPT-5.2"
                 reasoning: true

--- a/cluster/k8s/litellm/app/generate_litellm.py
+++ b/cluster/k8s/litellm/app/generate_litellm.py
@@ -67,7 +67,7 @@ ZAI_ANTHROPIC_MODELS: list[str] = [
 # token on demand and rewrites that file, so the mount must be read-write. `drop_params`
 # (below) strips the max_tokens/metadata fields this backend rejects.
 #
-# Only these three are served by the Codex/ChatGPT-account backend (verified live).
+# Only these models are served by the Codex/ChatGPT-account backend (verified live).
 # Others tried and rejected with "not supported when using Codex with a ChatGPT
 # account": gpt-5.4-pro, gpt-5.3-codex, gpt-5.3-instant, gpt-5.3-chat-latest.
 #
@@ -75,7 +75,14 @@ ZAI_ANTHROPIC_MODELS: list[str] = [
 # output[] and the /v1/chat/completions bridge fails with "Unknown items in responses
 # API response: []" — an unfixed LiteLLM bug (BerriAI/litellm#25429; fix PRs like #27562
 # still unmerged as of litellm 1.90.x). Callers must send stream:true to /v1/responses.
-_CHATGPT_MODELS: list[str] = ["gpt-5.4", "gpt-5.5", "gpt-5.3-codex-spark"]
+_CHATGPT_MODELS: list[str] = [
+    "gpt-5.4",
+    "gpt-5.5",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.3-codex-spark",
+]
 
 
 # Real Anthropic API (plain claude-* names — the "-anthropic" suffix above means

--- a/cluster/k8s/litellm/app/proxy-config.yaml
+++ b/cluster/k8s/litellm/app/proxy-config.yaml
@@ -182,6 +182,21 @@ model_list:
       model: chatgpt/gpt-5.5
     model_info:
       mode: responses
+  - model_name: gpt-5.6-sol-chatgpt
+    litellm_params:
+      model: chatgpt/gpt-5.6-sol
+    model_info:
+      mode: responses
+  - model_name: gpt-5.6-terra-chatgpt
+    litellm_params:
+      model: chatgpt/gpt-5.6-terra
+    model_info:
+      mode: responses
+  - model_name: gpt-5.6-luna-chatgpt
+    litellm_params:
+      model: chatgpt/gpt-5.6-luna
+    model_info:
+      mode: responses
   - model_name: gpt-5.3-codex-spark-chatgpt
     litellm_params:
       model: chatgpt/gpt-5.3-codex-spark

--- a/cluster/k8s/openhands/app/externalsecret-settings.yaml
+++ b/cluster/k8s/openhands/app/externalsecret-settings.yaml
@@ -30,12 +30,16 @@ spec:
                   "api_key": "{{ .zaiApiKey }}",
                   "base_url": "https://api.z.ai/api/anthropic"
                 },
-                "gpt-5.5-pro": {
-                  "model": "gpt-5.5-pro",
+                "gpt-5.6-sol": {
+                  "model": "gpt-5.6-sol",
                   "api_key": "{{ .openaiApiKey }}"
                 },
-                "gpt-5.5": {
-                  "model": "gpt-5.5",
+                "gpt-5.6-terra": {
+                  "model": "gpt-5.6-terra",
+                  "api_key": "{{ .openaiApiKey }}"
+                },
+                "gpt-5.6-luna": {
+                  "model": "gpt-5.6-luna",
                   "api_key": "{{ .openaiApiKey }}"
                 }
               },

--- a/haku/dispatch/test_app.py
+++ b/haku/dispatch/test_app.py
@@ -59,7 +59,7 @@ async def test_unknown_zone_rejected(client, haku_headers):
 
 
 async def test_model_outside_zone_allowlist_rejected(client, haku_headers):
-    response = await client.post("/jobs", json=_REQUEST | {"model": "gpt-5.5-chatgpt"}, headers=haku_headers)
+    response = await client.post("/jobs", json=_REQUEST | {"model": "gpt-5.6-sol-chatgpt"}, headers=haku_headers)
     assert response.status_code == 422
 
 

--- a/nix/home/codex/default.nix
+++ b/nix/home/codex/default.nix
@@ -24,9 +24,9 @@ let
   # profiles live in localModelSettings (opt-in via ducktape.codex.localModels);
   # the writable-roots sandbox block is appended only under workspace-write.
   baseSettings = {
-    model = "gpt-5.5";
-    model_reasoning_effort = "xhigh";
-    plan_mode_reasoning_effort = "xhigh";
+    model = "gpt-5.6-sol";
+    model_reasoning_effort = "medium";
+    plan_mode_reasoning_effort = "medium";
 
     features = {
       streamable_shell = true;

--- a/openai_utils/model_metadata.py
+++ b/openai_utils/model_metadata.py
@@ -1,14 +1,15 @@
 """Unified OpenAI model metadata: pricing, context limits, and capabilities.
 
 Data provenance:
-  - Pricing: https://openai.com/api/pricing/ (accessed 2025-11-24)
+  - GPT-5.6 pricing and limits: https://developers.openai.com/api/docs/models/ (accessed 2026-07-11)
+  - Other pricing: https://openai.com/api/pricing/ (accessed 2025-11-24)
   - Context limits: Web search 2025-11-30
     - GPT-5: https://allthings.how/gpt-5-context-window-limits-and-usage-in-chatgpt-and-api/
     - General: https://www.scriptbyai.com/token-limit-openai-chatgpt/
     - Community reports: https://community.openai.com/t/huge-gpt-5-documentation-gap-flaw-causing-bugs-input-tokens-exceed-the-configured-limit-of-272-000-tokens/1344734
   - Note: OpenAI API /v1/models endpoint does NOT expose context_window or max_output fields
 
-Last updated: 2025-12-08
+Last updated: 2026-07-10
 """
 
 from __future__ import annotations

--- a/openai_utils/model_metadata.yaml
+++ b/openai_utils/model_metadata.yaml
@@ -1,3 +1,24 @@
+gpt-5.6-sol:
+  input_usd_per_1m_tokens: 5.0
+  cached_input_usd_per_1m_tokens: 0.5
+  output_usd_per_1m_tokens: 30.0
+  context_window_tokens: 1050000
+  max_output_tokens: 128000
+
+gpt-5.6-terra:
+  input_usd_per_1m_tokens: 2.5
+  cached_input_usd_per_1m_tokens: 0.25
+  output_usd_per_1m_tokens: 15.0
+  context_window_tokens: 1050000
+  max_output_tokens: 128000
+
+gpt-5.6-luna:
+  input_usd_per_1m_tokens: 1.0
+  cached_input_usd_per_1m_tokens: 0.1
+  output_usd_per_1m_tokens: 6.0
+  context_window_tokens: 1050000
+  max_output_tokens: 128000
+
 gpt-5.1:
   input_usd_per_1m_tokens: 1.25
   cached_input_usd_per_1m_tokens: 0.125

--- a/tf/gitops/litellm-keys/main.tf
+++ b/tf/gitops/litellm-keys/main.tf
@@ -57,10 +57,10 @@ locals {
     for m in ["glm-4.5", "glm-4.5-air", "glm-4.6", "glm-4.7", "glm-5", "glm-5-turbo", "glm-5.1", "glm-5.2"] :
     "${m}-anthropic"
   ]
-  # Only the three models the Codex/ChatGPT-account backend actually serves
+  # Only the models the Codex/ChatGPT-account backend actually serves
   # (see _CHATGPT_MODELS in generate_litellm.py).
   oai_lane_models = [
-    for m in ["gpt-5.4", "gpt-5.5", "gpt-5.3-codex-spark"] :
+    for m in ["gpt-5.4", "gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.3-codex-spark"] :
     "${m}-chatgpt"
   ]
   # Real Anthropic models (ANTHROPIC_MODELS in generate_litellm.py) — the

--- a/x/codex_pod_image/home.nix
+++ b/x/codex_pod_image/home.nix
@@ -131,7 +131,7 @@ in
     # LiteLLM virtual key (LITELLM_API_KEY, from the reflected litellm-key-codex-pod
     # secret; see deployment.yaml + tf/gitops/litellm-keys). wire_api=responses:
     # LiteLLM serves these models over the Responses API (streaming-only).
-    model = "gpt-5.5-chatgpt";
+    model = "gpt-5.6-sol-chatgpt";
     model_provider = "litellm";
     model_providers.litellm = {
       name = "Cluster LiteLLM";


### PR DESCRIPTION
## Summary

- register `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` across LiteLLM, OpenHands, OpenClaw, and shared OpenAI model metadata
- expose the ChatGPT-backed LiteLLM aliases to the Codex pod virtual-key lane
- default Home Manager Codex configuration to `gpt-5.6-sol` with medium reasoning effort in normal and plan modes

## Model capabilities

All three GPT-5.6 variants record their supported 1,050,000-token context window and 128,000-token maximum output. Pricing metadata follows the published Sol, Terra, and Luna model pages.

## Validation

- `bbr test //cluster/k8s/litellm/app:test_generate_litellm //nix/home/codex:merge_test //haku/dispatch:test_app`
- `bbr build //openai_utils:model_metadata`
- `pre-commit run --files <changed files>`
- `git diff --check`
