### PR TITLE
Allow two-node Forgejo rolling updates

### DIFF
--- a/cluster/k8s/rook-ceph-trial/forgejo-app/helmrelease.yaml
+++ b/cluster/k8s/rook-ceph-trial/forgejo-app/helmrelease.yaml
@@ -36,6 +36,9 @@ spec:
     replicaCount: 2
     strategy:
       type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 0
+        maxUnavailable: 1
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The Ceph benchmark Forgejo deployment uses hard anti-affinity on exactly two nodes. The chart default of `maxUnavailable: 0` deadlocks secret-triggered rollouts because no replacement can schedule. Use `maxSurge: 0` and `maxUnavailable: 1` so one replica stays available while the other is replaced.\n\nObserved live during the Rook/CephFS benchmark rollout. Validation: rendered root kustomization and pre-commit hooks including kubeconform.