### PR TITLE
Decouple storage benchmark from Forgejo Flux drift

### DIFF
--- a/cluster/k8s/rook-ceph-trial/benchmarks/flux-kustomization.yaml
+++ b/cluster/k8s/rook-ceph-trial/benchmarks/flux-kustomization.yaml
@@ -16,7 +16,6 @@ spec:
     name: flux-system
   dependsOn:
     - name: rook-ceph-trial-forgejo-bench
-    - name: forgejo
   healthChecks:
     - apiVersion: batch/v1
       kind: Job


### PR DESCRIPTION
Production Forgejo is healthy, but its Flux wrapper can be NotReady when an unrelated upstream dependency is reconciling. Do not block the disposable benchmark Jobs on that wrapper; the end-to-end script already waits for the actual Forgejo HTTP endpoint. Keep the Ceph benchmark Forgejo dependency.\n\nObserved live during the Rook/CephFS benchmark. Validation: root kustomize render and pre-commit hooks including kubeconform.