### PR TITLE
Make Forgejo benchmark runs collision-safe

### DIFF
--- a/cluster/k8s/rook-ceph-trial/benchmarks/forgejo-bench.sh
+++ b/cluster/k8s/rook-ceph-trial/benchmarks/forgejo-bench.sh
@@ -2,7 +2,7 @@
 set -eu
 
 auth="$(printf '%s:%s' "$FORGEJO_USERNAME" "$FORGEJO_PASSWORD" | base64 | tr -d '\n')"
-repo="ceph-storage-bench"
+repo="storage-bench-${TARGET_NAME}-$(date +%s)-$$"
 api="$FORGEJO_URL/api/v1"
 work=/tmp/forgejo-storage-bench
 
@@ -54,13 +54,13 @@ request "$api/repos/$FORGEJO_USERNAME/$repo/contents/seed.txt" >/dev/null
 
 i=1
 while [ "$i" -le 20 ]; do
-  timed_request version GET "$api/version"
+  timed_request version "$api/version"
   i=$((i + 1))
 done
 
 i=1
 while [ "$i" -le 20 ]; do
-  timed_request contents_read GET "$api/repos/$FORGEJO_USERNAME/$repo/contents/seed.txt"
+  timed_request contents_read "$api/repos/$FORGEJO_USERNAME/$repo/contents/seed.txt"
   i=$((i + 1))
 done
 


### PR DESCRIPTION
Flux force reconciliation and Reloader can replace a Job during startup. A fixed repository name then collides with files left by the interrupted run. Give each target/run a unique repository name. Also stop passing the literal `GET` token as an extra curl URL in timed reads.\n\nObserved in the live CephFS vs SeaweedFS benchmark. Validation: `sh -n`, root kustomize render, and pre-commit hooks.