### PR TITLE
Make direct storage benchmark volumes writable

### DIFF
--- a/cluster/k8s/rook-ceph-trial/benchmarks/jobs.yaml
+++ b/cluster/k8s/rook-ceph-trial/benchmarks/jobs.yaml
@@ -11,6 +11,9 @@ spec:
         app.kubernetes.io/name: storage-bench-cephfs-vs-seaweedfs
     spec:
       restartPolicy: Never
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       nodeSelector:
         kubernetes.io/hostname: ovh-ns104952
       containers:


### PR DESCRIPTION
A fresh CephFS subvolume root is not writable by the rootless Forgejo benchmark image. Set pod fsGroup 1000 so Kubernetes prepares both CephFS and SeaweedFS volume roots for the same writer.\n\nObserved live after the end-to-end Jobs succeeded; the direct Job completed its first SeaweedFS round and failed when entering CephFS. Validation: root kustomize render and pre-commit hooks including kubeconform.