### PR TITLE
Document tofu runner reboot lock failures

### DIFF
--- a/cluster/docs/lessons_learned/2026_07_03_tofu_controller_runner_rpc_hang.md
+++ b/cluster/docs/lessons_learned/2026_07_03_tofu_controller_runner_rpc_hang.md
@@ -1,7 +1,7 @@
 # tofu-controller Reconcile Hangs Forever When a Runner Pod Dies Mid-Init (Upstream Bug)
 
-**Date**: 2026-07-03
-**Status**: Resolved (controller restart); upstream fix filed — [flux-iac/tofu-controller#1838](https://github.com/flux-iac/tofu-controller/pull/1838) (the PR body doubles as the bug report; no separate issue)
+**Date**: 2026-07-03; recurrence confirmed 2026-07-11
+**Status**: Recurring; controller restart required each time. Upstream fix filed — [flux-iac/tofu-controller#1838](https://github.com/flux-iac/tofu-controller/pull/1838) (the PR body doubles as the bug report; no separate issue). As of 2026-07-11 the PR is open, unreviewed, and unmerged.
 **Affected version**: `ghcr.io/flux-iac/tofu-controller:v0.16.1` (defect identical through v0.16.4 and `main`)
 
 ## Summary
@@ -18,6 +18,27 @@ cluster schedules onto wyrm2 (see "Aggravating factor"), so one reboot wedged th
 Terraform fleet at once — including `agent-machine-access`, which provisions haku's
 mailbox Authentik OIDC provider (`stalwart-haku`) and the `haku-mail-client-credentials`
 secret. Presenting symptom was "haku's email automation won't reconcile."
+
+### 2026-07-11 recurrence
+
+The same failure reproduced after another `wyrm2` reboot. This time
+`Terraform/flux-system/haku-state` was applying revision `a980d1a7` when its runner died.
+The runner container exited 255 and restarted after the pod sandbox changed, but the CR
+remained `Ready=Unknown / Initializing` with `reconciliationFailures=347`. Meanwhile the
+Flux source advanced to `404c1fc`, including the follow-up HCL fix in `81a774cbb`; the
+Terraform CR never observed it.
+
+This recurrence directly tested the recovery boundary:
+
+- deleting `Pod/flux-system/haku-state-tf-runner` did not create a replacement;
+- annotating the Terraform CR with `reconcile.fluxcd.io/requestedAt` was accepted, but
+  `status.lastHandledReconcileAt` did not advance;
+- waiting three minutes for `Ready` timed out;
+- controller logs contained no new `haku-state` reconcile after the runner disappeared.
+
+That behavior rules out a stale pod or ordinary retry delay: the old `Reconcile` call was
+still occupying the key and ignoring newly queued events. Restarting the controller was
+again required to cancel the parked goroutine.
 
 ## Root Cause
 
@@ -139,7 +160,8 @@ setting up terraform → plan no changes`). Dependency cascades (`haku-state`,
 
 ## Upstream Status
 
-**Not fixed.** v0.16.1 (ours), v0.16.4, and `main` (last commit 2026-06-22) are
+**Not fixed as of 2026-07-11.** v0.16.1 (ours), v0.16.4 (the newest release), and
+`main` (head `273b7aa`, 2026-06-22) are
 byte-identical on all three defects — upgrading does not help. `backend.go:52` even carries
 a **commented-out** `// ctx30s, cancelCtx30s := context.WithTimeout(ctx, 30*time.Second)`:
 a maintainer started adding exactly the RPC deadline that would prevent this, then
@@ -194,6 +216,10 @@ Validated locally with `go build` + `go vet`; the envtest integration suite is C
 fails identically on unmodified `main` in a local sandbox, so it's a harness/env issue, not
 the change). This is a low-traffic upstream — expect review latency; track the PR before
 assuming it lands.
+
+As of 2026-07-11, GitHub reports #1838 open, mergeable but blocked, with no requested
+reviewers, reviews, or comments. No released version contains it. Do not treat a routine
+upgrade from v0.16.1 to v0.16.4 as mitigation for this incident class.
 
 ## Key Lessons
 

--- a/cluster/docs/lessons_learned/2026_07_11_tofu_pg_orphaned_session_lock.md
+++ b/cluster/docs/lessons_learned/2026_07_11_tofu_pg_orphaned_session_lock.md
@@ -1,0 +1,129 @@
+# tofu PG Backend Lock Survives Runner Node Reboot
+
+**Date**: 2026-07-11
+**Status**: Recovered manually; prevention pending
+
+## Summary
+
+A `wyrm2` reboot killed several tofu-controller runner pods. The controller itself also
+wedged on a dead runner RPC (see
+<2026_07_03_tofu_controller_runner_rpc_hang.md>) and had to be restarted. After that
+restart, `Terraform/flux-system/sso-providers` repeatedly failed to acquire its PG backend
+state lock, blocking this Flux dependency chain:
+
+```text
+sso-providers-tf -> forgejo -> haku-state -> haku-console
+```
+
+Image automation had already selected and committed a new `haku-console` image, but the
+Deployment stayed on the old image until the dependency chain recovered.
+
+The PG backend did not contain a durable lock row. The lock was a PostgreSQL
+session-scoped advisory lock held by an orphaned server backend. The runner pod and its
+node-side TCP state were gone, but PostgreSQL had received neither FIN nor RST and still
+considered the idle TCP connection alive.
+
+## Smoking Gun
+
+Querying the **current CNPG primary** showed the orphaned session:
+
+```text
+pid=343808
+client_addr=10.244.5.135
+state=idle
+wait_event=ClientRead
+query=SELECT data FROM "sso_providers"."states" WHERE name = $1
+locktype=advisory
+classid=0
+objid=177
+granted=true
+connected since 2026-07-11 08:37Z
+```
+
+No pod still owned `10.244.5.135`. Terminating only that PostgreSQL backend immediately
+released the lock:
+
+```sql
+SELECT pg_terminate_backend(343808);
+```
+
+`Terraform/sso-providers` then reached `Ready=True`; `forgejo`, `haku-state`, and
+`haku-console` followed. The console Deployment rolled successfully to
+`devel-20260711101943-459cd26` with `2/2` replicas available.
+
+## Why It Did Not Recover Quickly
+
+PostgreSQL was configured to inherit the host TCP keepalive defaults:
+
+```text
+tcp_keepalives_idle = 0                 # use kernel default
+tcp_keepalives_interval = 0             # use kernel default
+tcp_keepalives_count = 0                # use kernel default
+client_connection_check_interval = 0   # disabled
+
+net.ipv4.tcp_keepalive_time = 7200      # first probe after 2 hours
+net.ipv4.tcp_keepalive_intvl = 75
+net.ipv4.tcp_keepalive_probes = 9
+```
+
+Worst-case dead-peer detection was therefore about 2 hours 11 minutes. The orphan was
+about 1 hour 46 minutes old when diagnosed, so the kernel had not sent its first keepalive
+probe. PG advisory locks do auto-release when their owning database session ends; the
+mistake was assuming runner-pod disappearance implies prompt database-session death.
+
+## Recovery-State Matrix
+
+| State                                                                                                | Automatic recovery                                                               | Required action                                                                                   |
+| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Runner exits gracefully and closes PostgreSQL connection                                             | Immediate                                                                        | None                                                                                              |
+| Runner process/pod dies and the server receives FIN/RST                                              | Immediate                                                                        | None                                                                                              |
+| Runner node reboots or disappears without FIN/RST while its connection is idle                       | Eventually, after TCP keepalive failure; about 2h 11m with the observed defaults | Terminate the confirmed orphaned PostgreSQL backend, or wait for keepalive expiry                 |
+| tofu-controller reconcile is parked in deadline-free gRPC `Init` after runner loss                   | Never on v0.16.1                                                                 | Restart tofu-controller; track upstream PR `flux-iac/tofu-controller#1838`                        |
+| A new runner retries with `lockTimeout: 0s` while the orphan exists                                  | Never succeeds before the holder disappears; churns every retry interval         | Remove the orphaned DB session; a bounded `lockTimeout` reduces churn but cannot evict the holder |
+| `tfstate.forceUnlock` targets the lock while another PostgreSQL session still owns the advisory lock | Does not solve the owning session                                                | Identify and terminate the orphaned DB backend first                                              |
+| Flux Kustomizations depend on the unhealthy Terraform/Kustomization                                  | No progress until dependency is Ready                                            | Recover the root Terraform object; then let Flux unwind the dependency chain                      |
+| Existing Deployment is healthy while its Kustomization is dependency-blocked                         | Keeps serving the old image indefinitely                                         | Recover the dependency chain; verify desired policy tag equals Deployment image afterward         |
+
+## Safe Diagnosis
+
+First find the current primary; `pg_stat_activity` and session locks are local to each
+PostgreSQL server, so querying a replica produces a misleading empty result:
+
+```bash
+kubectl -n tofu-state get cluster tofu-state-db-ovh \
+  -o jsonpath='{.status.currentPrimary}{"\n"}'
+```
+
+Then inspect advisory-lock owners on that primary:
+
+```sql
+SELECT
+  a.pid,
+  a.client_addr,
+  a.state,
+  a.wait_event_type,
+  a.wait_event,
+  a.query_start,
+  a.query,
+  l.classid,
+  l.objid,
+  l.granted
+FROM pg_stat_activity AS a
+JOIN pg_locks AS l ON l.pid = a.pid
+WHERE l.locktype = 'advisory';
+```
+
+Before terminating anything, prove that the client IP no longer belongs to a live runner
+and that the lock maps to the affected backend state. Terminate only the confirmed
+orphaned PID; do not restart CNPG or kill all `tfstate` sessions.
+
+## Prevention
+
+- Configure materially shorter TCP keepalive/dead-client detection for the tofu-state
+  PostgreSQL cluster so a vanished runner cannot retain an advisory lock for two hours.
+- Give tofu-controller Terraform CRs a bounded `spec.tfstate.lockTimeout` to avoid rapid
+  retry churn during legitimate short overlaps. This is mitigation, not orphan eviction.
+- Land or carry `flux-iac/tofu-controller#1838` so runner loss cannot also park the
+  reconcile goroutine forever.
+- After any runner-node reboot, check both stuck Terraform reconciles and advisory locks
+  on the **current CNPG primary**.

--- a/cluster/docs/troubleshooting.md
+++ b/cluster/docs/troubleshooting.md
@@ -197,13 +197,23 @@ kubectl -n flux-system delete pod -l app.kubernetes.io/name=tf-runner --field-se
 See <lessons_learned/2026_07_03_tofu_controller_runner_rpc_hang.md> (upstream fix:
 `flux-iac/tofu-controller#1838`).
 
-### Stale State Locks (historical — kubernetes backend only)
+### PG Advisory Lock Survives Runner Node Reboot
 
-All `Terraform` CRs now use the PG backend, whose session-based advisory locks
-auto-release on runner-pod death. The kubernetes-backend stale-lock failure
-mode described in <lessons_learned/2026_03_18_tofu_controller_stale_state_locks.md>
-is no longer reachable. Kept as a pointer in case we ever re-add a CR on the
-kubernetes backend.
+PG advisory locks release when the owning **database session ends**, not merely when
+Kubernetes reports the runner pod gone. A node reboot can drop the runner without sending
+FIN/RST; PostgreSQL then retains the idle session and its advisory lock until TCP
+keepalives detect the dead peer. The observed defaults waited two hours before the first
+probe. Repeated `tfstate.forceUnlock` attempts do not evict a lock still owned by another
+PostgreSQL session.
+
+Query `pg_stat_activity` plus `pg_locks` on the **current CNPG primary**, prove the client
+IP belongs to no live runner, then terminate only that orphaned backend with
+`pg_terminate_backend(pid)`. See
+<lessons_learned/2026_07_11_tofu_pg_orphaned_session_lock.md> for the state matrix and
+exact diagnosis.
+
+The separate Kubernetes-backend stale-Lease failure mode is historical because all CRs
+now use PG; see <lessons_learned/2026_03_18_tofu_controller_stale_state_locks.md>.
 
 ## Secrets & Auth Issues
 

--- a/cluster/k8s/TODO.md
+++ b/cluster/k8s/TODO.md
@@ -198,6 +198,30 @@ Authentik route work; these tighten them (operator-approved as follow-ups):
       principal on the repo). Mint a read-only Forgejo deploy key for `haku-state`
       and point the GitRepository's `secretRef` at it instead.
 
+- [ ] **Make tofu-controller recover runner restarts without a controller restart.**
+      On 2026-07-11, `wyrm2` rebooted while `Terraform/flux-system/haku-state` was
+      reconciling. The `haku-state-tf-runner` container restarted (exit 255), but
+      tofu-controller kept the old reconciliation in `Initializing`, pinned to
+      source revision `a980d1a7` even after `GitRepository/flux-system` advanced.
+      This left the parent Kustomization and five Terraform dependents blocked
+      until tofu-controller itself was restarted; deleting the runner and annotating
+      the CR did not recover it. Track and help land upstream PR
+      `flux-iac/tofu-controller#1838` (runner-RPC deadline plus failed-pod reaping),
+      then upgrade when a release contains it. If upstream stalls, carry the patch
+      in an operator-owned image or add a watchdog that restarts the controller when
+      initialization makes no progress past a bounded deadline. Add an automated
+      failure-injection test covering node loss/container restart during init. Full
+      RCA: `cluster/docs/lessons_learned/2026_07_03_tofu_controller_runner_rpc_hang.md`.
+
+- [ ] **Shorten tofu-state PostgreSQL dead-client detection.** A `wyrm2` reboot left an
+      idle PostgreSQL backend session holding the `sso_providers` advisory lock even
+      though its runner pod/IP was gone. PostgreSQL inherited the kernel's two-hour
+      `tcp_keepalive_time`, so this did not recover promptly and blocked the Flux chain
+      through `haku-console`. Configure shorter keepalives (and consider a bounded
+      Terraform `tfstate.lockTimeout` to reduce retry churn), then failure-test runner
+      node loss. RCA and recovery matrix:
+      `cluster/docs/lessons_learned/2026_07_11_tofu_pg_orphaned_session_lock.md`.
+
 ## agent-box follow-ups
 
 The agent-box VM and its `codex` user are live (see


### PR DESCRIPTION
## What changed

- document the 2026-07-11 tofu-controller runner-RPC hang recurrence
- add an RCA for the PostgreSQL advisory lock retained by an orphaned runner session
- replace the inaccurate troubleshooting claim that PG locks promptly release when a runner pod disappears
- record systematic follow-ups for the upstream controller fix and shorter dead-client detection

## Root cause

The runner node reboot produced two independent failure modes. tofu-controller v0.16.1 parked a reconcile forever in a deadline-free, wait-for-ready gRPC `Init` call. Separately, PostgreSQL retained an idle TCP session from the vanished runner because no FIN/RST arrived and the first kernel keepalive was two hours away; that session continued holding the `sso_providers` advisory lock.

The lock blocked `sso-providers-tf -> forgejo -> haku-state -> haku-console`, leaving the healthy console Deployment on its old image after image automation had committed a new tag.

## Validation

- repo Prettier hook
- markdownlint-cli2
- ducktape pre-commit checks
- `git diff --check`
- live recovery verified through `Terraform/sso-providers`, Flux dependencies, and `Deployment/haku-console` at 2/2 available
