### PR TITLE
Polish Haku console theme surfaces

### DIFF
--- a/haku/console/frontend/AGENTS.md
+++ b/haku/console/frontend/AGENTS.md
@@ -11,13 +11,14 @@ screenshots before handing off:
 bbr test //haku/console/frontend:screenshots
 ```
 
-It renders each surface (`screenshots/harness.tsx`) to a PNG (one per scene: `history` — its
-first rows expanded into their detailed state with the Metadata disclosure open, the rest left
-compact — `drawer`, `settings`, `previews`, `controls`) in the test's **undeclared outputs**.
+It renders each surface (`screenshots/harness.tsx`) in both light and dark themes to PNGs (two
+per scene: `history` — its first rows expanded into their detailed state with the Metadata
+disclosure open, the rest left compact — `drawer`, `settings`, `previews`, `controls`) in the
+test's **undeclared outputs**.
 Browser rendering runs on the RBE worker, so this is a `bbr` test, not a local `bb run`. Fetch
 the PNGs
 with the `buildbuddy_api` skill (download the target's undeclared test outputs), then open every
-one and actually check it looks good — spacing, alignment, contrast, truncation, that nothing
+light and dark image and actually check it looks good — spacing, alignment, contrast, truncation, that nothing
 overflows or collides, and that both content and chrome read clearly — not merely that it
 rendered. The test is a generator, not a pixel-diff gate: it passes as long as every scene
 renders, so it never blocks CI on "looks different", but a blank/crashed scene fails it.

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -17,13 +17,12 @@ import type { PendingApproval } from "./client.ts";
 import { Field } from "./field.tsx";
 import { HistoryIcon, MapPinIcon, MenuIcon, SettingsIcon } from "./icons.tsx";
 import { PendingToolCallActions } from "./pending_tool_call_actions.tsx";
-import { ACTION_COLOR } from "./theme.ts";
+import { ACTION_COLOR, SUCCESS_COLOR } from "./theme.ts";
 import { ToolCallCard } from "./tool_call_card.tsx";
 import { useVariant, VariantToggle } from "./variant_toggle.tsx";
 
 export interface ShellDrawerProps {
   opened: boolean;
-  onClose: () => void;
   pendingApprovals: PendingApproval[];
   geolocationApprovals: GeolocationApproval[];
   decidingApprovalIds: readonly string[];
@@ -256,7 +255,7 @@ function GeolocationApprovalCard({
           <Button size="compact-sm" variant="light" color="red" disabled={deciding || !armed} onClick={onDeny}>
             Deny
           </Button>
-          <Button size="compact-sm" color={ACTION_COLOR} disabled={deciding || !armed} onClick={onApprove}>
+          <Button size="compact-sm" color={SUCCESS_COLOR} disabled={deciding || !armed} onClick={onApprove}>
             Approve
           </Button>
         </Group>
@@ -398,16 +397,13 @@ export function ShellDrawer(props: ShellDrawerProps) {
       {props.opened && (
         <aside className="haku-shell-drawer" aria-label="Haku console controls">
           <section className="haku-shell-card haku-shell-drawer-nav">
-            <Group justify="space-between" align="center" className="haku-shell-header">
+            <Group align="center" className="haku-shell-header">
               <Group gap="xs" align="center">
                 <Text fw={700}>Approvals</Text>
                 <Badge color={pendingCount > 0 ? "yellow" : "gray"} variant="light">
                   {pendingCount}
                 </Badge>
               </Group>
-              <Button size="compact-xs" variant="subtle" onClick={props.onClose}>
-                Close
-              </Button>
             </Group>
             <Group grow gap="xs">
               <Button

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -411,7 +411,6 @@ export function HakuUiEmbed({
       />
       <ShellDrawer
         opened={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
         pendingApprovals={toolApprovals}
         geolocationApprovals={geolocationApprovals}
         decidingApprovalIds={decidingApprovalIds}

--- a/haku/console/frontend/pending_tool_call_actions.tsx
+++ b/haku/console/frontend/pending_tool_call_actions.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, Textarea } from "@mantine/core";
 import { useState } from "react";
 
-import { ACTION_COLOR } from "./theme.ts";
+import { SUCCESS_COLOR } from "./theme.ts";
 
 // The approve/deny control for a pending tool call, shared by the drawer approval card and the
 // history row so both spell it one way. The optional free-text reason sits to the LEFT of the
@@ -49,7 +49,7 @@ export function PendingToolCallActions({
       >
         Deny
       </Button>
-      <Button size="compact-sm" color={ACTION_COLOR} loading={busy} disabled={disabled} onClick={onApprove}>
+      <Button size="compact-sm" color={SUCCESS_COLOR} loading={busy} disabled={disabled} onClick={onApprove}>
         Approve
       </Button>
     </Group>

--- a/haku/console/frontend/pending_tool_call_actions.tsx
+++ b/haku/console/frontend/pending_tool_call_actions.tsx
@@ -40,7 +40,7 @@ export function PendingToolCallActions({
         style={{ flex: 1 }}
       />
       <Button
-        size="compact-sm"
+        size="xs"
         variant="light"
         color="red"
         loading={busy}
@@ -49,7 +49,7 @@ export function PendingToolCallActions({
       >
         Deny
       </Button>
-      <Button size="compact-sm" color={SUCCESS_COLOR} loading={busy} disabled={disabled} onClick={onApprove}>
+      <Button size="xs" color={SUCCESS_COLOR} loading={busy} disabled={disabled} onClick={onApprove}>
         Approve
       </Button>
     </Group>

--- a/haku/console/frontend/screenshots/harness.tsx
+++ b/haku/console/frontend/screenshots/harness.tsx
@@ -1,6 +1,7 @@
 // Screenshot harness: renders each console visual surface into #app with mocked data, one
-// scene per page load (selected by `window.__SCENE__`). Bundled to an IIFE by
-// esbuild.config.mjs and driven by render.mjs, which screenshots each scene to a PNG. A
+// scene and color scheme per page load (selected by `window.__SCENE__` and
+// `window.__COLOR_SCHEME__`). Bundled to an IIFE by esbuild.config.mjs and driven by
+// render.mjs, which screenshots each combination to a PNG. A
 // generator for eyeballing the visuals, not a pixel-diff gate — see frontend/AGENTS.md.
 //
 // `./mock_api.ts` is imported FIRST so its `fetch` stub is installed before client.ts (via
@@ -112,10 +113,11 @@ function sceneElement(scene: string) {
 }
 
 const scene = (window as unknown as { __SCENE__?: string }).__SCENE__ ?? "history";
+const colorScheme = (window as unknown as { __COLOR_SCHEME__?: "light" | "dark" }).__COLOR_SCHEME__ ?? "light";
 const container = document.getElementById("app");
 if (!container) throw new Error("missing #app");
 createRoot(container).render(
-  <MantineProvider defaultColorScheme="light" theme={hakuTheme}>
+  <MantineProvider forceColorScheme={colorScheme} theme={hakuTheme}>
     {sceneElement(scene)}
   </MantineProvider>
 );

--- a/haku/console/frontend/screenshots/harness.tsx
+++ b/haku/console/frontend/screenshots/harness.tsx
@@ -69,7 +69,6 @@ function PreviewGallery() {
 
 const drawerProps: ShellDrawerProps = {
   opened: true,
-  onClose: noop,
   pendingApprovals: SAMPLE_PENDING,
   geolocationApprovals: [],
   decidingApprovalIds: [],
@@ -102,7 +101,21 @@ function sceneElement(scene: string) {
         />
       );
     case "drawer":
-      return <ShellDrawer {...drawerProps} />;
+      // Render the drawer in its real shell context so the screenshot catches collisions
+      // with the persistent menu/location toggle stack at the right edge.
+      return (
+        <>
+          <ShellControls
+            pendingCount={drawerProps.pendingApprovals.length + drawerProps.geolocationApprovals.length}
+            opened
+            onToggle={noop}
+            geoGranted
+            tracking
+            onWithdrawGeolocation={noop}
+          />
+          <ShellDrawer {...drawerProps} />
+        </>
+      );
     case "previews":
       return <PreviewGallery />;
     // The history page; render.mjs expands its first rows into their detailed state (opening the

--- a/haku/console/frontend/screenshots/render.mjs
+++ b/haku/console/frontend/screenshots/render.mjs
@@ -1,6 +1,6 @@
 // Screenshot generator for the console's own visual surfaces. Inlines the compiled
 // stylesheet and the bundled harness (harness.tsx) into a headless-Chromium page, one
-// scene per load, and writes a PNG per scene. This is a generator for eyeballing the
+// scene and theme per load, and writes a PNG for every combination. This is a generator for eyeballing the
 // visuals — NOT a pixel-diff regression gate — so it never fails on "looks different"; it
 // fails only if a scene crashes or renders an empty #app (waitForSelector below throws).
 //
@@ -36,6 +36,7 @@ const SCENES = [
   // so the screenshot captures the dropdown, not just the pin.
   { name: "controls", viewport: { width: 520, height: 380 }, click: '[aria-label="Location sharing: live"]' },
 ];
+const COLOR_SCHEMES = ["light", "dark"];
 
 function outputDir() {
   if (process.env.SCREENSHOT_OUT_DIR) return resolve(process.env.SCREENSHOT_OUT_DIR);
@@ -49,7 +50,7 @@ function outputDir() {
   return resolve("screenshot-out");
 }
 
-function pageHtml(css, harnessJs, scene) {
+function pageHtml(css, harnessJs, scene, colorScheme) {
   // The <base href> gives the origin-less setContent page a URL against which the SPA's
   // relative "/api/…" requests parse (the harness stubs the actual fetch). The scene global
   // is set before the harness IIFE runs so it renders the right surface.
@@ -58,6 +59,7 @@ function pageHtml(css, harnessJs, scene) {
     "<base href='https://haku-console.test/'>",
     `<style>${css}</style></head><body><div id='app'></div>`,
     `<script>window.__SCENE__=${JSON.stringify(scene)};</script>`,
+    `<script>window.__COLOR_SCHEME__=${JSON.stringify(colorScheme)};</script>`,
     `<script>${harnessJs}</script></body></html>`,
   ].join("");
 }
@@ -92,29 +94,34 @@ const browser = await launchPuppeteerBrowser({
   ],
 });
 try {
-  for (const { name, viewport, click, clicks } of SCENES) {
-    const page = await browser.newPage();
-    await page.setViewport({ ...viewport, deviceScaleFactor: 2 });
-    await page.emulateMediaFeatures([{ name: "prefers-reduced-motion", value: "reduce" }]);
-    await page.setContent(pageHtml(css, harnessJs, name), { waitUntil: "load" });
-    await page.waitForSelector("#app > *", { timeout: 10_000 });
-    // Let Mantine mount and layout settle, and outlast the approval buttons' 400ms arm
-    // delay so they render enabled (animations are reduced above).
-    await new Promise((r) => setTimeout(r, 700));
-    // Some scenes need clicks to reveal state internal to a component: a popover's open state
-    // (location-sharing control) or history rows toggled into their detailed view.
-    // Each click re-renders the DOM, so re-settle before the next one.
-    for (const selector of clicks ?? (click ? [click] : [])) {
-      await page.click(selector);
-      await new Promise((r) => setTimeout(r, 300));
+  for (const colorScheme of COLOR_SCHEMES) {
+    for (const { name, viewport, click, clicks } of SCENES) {
+      const page = await browser.newPage();
+      await page.setViewport({ ...viewport, deviceScaleFactor: 2 });
+      await page.emulateMediaFeatures([
+        { name: "prefers-reduced-motion", value: "reduce" },
+        { name: "prefers-color-scheme", value: colorScheme },
+      ]);
+      await page.setContent(pageHtml(css, harnessJs, name, colorScheme), { waitUntil: "load" });
+      await page.waitForSelector("#app > *", { timeout: 10_000 });
+      // Let Mantine mount and layout settle, and outlast the approval buttons' 400ms arm
+      // delay so they render enabled (animations are reduced above).
+      await new Promise((r) => setTimeout(r, 700));
+      // Some scenes need clicks to reveal state internal to a component: a popover's open state
+      // (location-sharing control) or history rows toggled into their detailed view.
+      // Each click re-renders the DOM, so re-settle before the next one.
+      for (const selector of clicks ?? (click ? [click] : [])) {
+        await page.click(selector);
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      const dest = join(outDir, `${name}-${colorScheme}.png`);
+      const png = await page.screenshot();
+      writeFileSync(dest, png);
+      console.log(`wrote ${dest}`);
+      await page.close();
     }
-    const dest = join(outDir, `${name}.png`);
-    const png = await page.screenshot();
-    writeFileSync(dest, png);
-    console.log(`wrote ${dest}`);
-    await page.close();
   }
 } finally {
   await browser.close();
 }
-console.log(`\n${SCENES.length} screenshots in ${outDir}`);
+console.log(`\n${SCENES.length * COLOR_SCHEMES.length} screenshots in ${outDir}`);

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -161,9 +161,12 @@
 }
 
 .haku-shell-drawer {
-  width: min(32rem, calc(100vw - 0.75rem));
+  /* Leave the persistent control stack exposed at the right edge. The menu button is
+     the drawer's natural close toggle, just as the location pin remains beside its
+     popover. */
+  width: min(32rem, calc(100vw - 4.25rem));
   height: calc(100dvh - 1rem);
-  margin: 0.5rem;
+  margin: 0.5rem 3.75rem 0.5rem 0.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -324,8 +327,8 @@
 
 @media (max-width: 520px) {
   .haku-shell-drawer {
-    width: calc(100vw - 0.5rem);
+    width: calc(100vw - 4rem);
     height: calc(100dvh - 0.5rem);
-    margin: 0.25rem;
+    margin: 0.25rem 3.5rem 0.25rem 0.25rem;
   }
 }

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -20,15 +20,18 @@
     --haku-shell-active-bg: #e7f4ef;
   }
   :root[data-mantine-color-scheme="dark"] {
-    --haku-page-bg: #0f1f1d;
-    --haku-panel-bg: #142724;
-    --haku-border: #3b5652;
-    --haku-code-bg: #172f2b;
-    --haku-code-fg: #e8f4f0;
+    /* Follow Mantine's neutral dark surfaces, as used by the location popover. The
+       shell used to tint every page and card dark green, which made this chrome
+       feel unrelated to both that popover and Haku's lavender/cream mark. */
+    --haku-page-bg: var(--mantine-color-dark-8);
+    --haku-panel-bg: var(--mantine-color-dark-7);
+    --haku-border: var(--mantine-color-dark-4);
+    --haku-code-bg: var(--mantine-color-dark-6);
+    --haku-code-fg: var(--mantine-color-gray-1);
     --haku-backdrop: rgb(0 0 0 / 68%);
     --haku-shell-shadow: rgb(0 0 0 / 45%);
-    --haku-shell-muted-bg: #1b2f2c;
-    --haku-shell-active-bg: #203d38;
+    --haku-shell-muted-bg: var(--mantine-color-dark-6);
+    --haku-shell-active-bg: var(--mantine-color-dark-5);
   }
   body {
     margin: 0;

--- a/haku/console/frontend/theme.ts
+++ b/haku/console/frontend/theme.ts
@@ -26,8 +26,8 @@ const hakuSpirit: MantineColorsTuple = [
   "#332d42",
 ];
 
-export const ACTION_COLOR = "haku";
-export const SUCCESS_COLOR = ACTION_COLOR;
+export const ACTION_COLOR = "hakuSpirit";
+export const SUCCESS_COLOR = "haku";
 export const CAPABILITY_COLOR = "hakuSpirit";
 
 export const hakuTheme = createTheme({


### PR DESCRIPTION
## What changed

- replace the Haku console's bespoke dark-green drawer and fullscreen surfaces with Mantine's neutral dark surfaces, matching the location-sharing popover
- use the logo-aligned lavender `hakuSpirit` palette for navigation/general action chrome while retaining green for Approve and semantic live/success states
- keep the persistent menu/location toggle stack exposed beside the approvals drawer, and use the active menu icon as the drawer's sole close toggle
- align the denial input, Deny button, and Approve button heights
- make the screenshot harness render every scene in both light and dark themes, including the drawer in its real context alongside the toggle stack
- document the dual-theme visual review requirement

## Why

The approval drawer and fullscreen history/settings pages had a dark-green treatment that did not match either the neutral location popover or Haku's lavender/cream icon palette. The drawer also covered the controls that naturally toggle these shell panels. The screenshot harness rendered the drawer without those controls and only in light mode, leaving both regressions uncovered.

## Validation

- `bbr test //haku/console/frontend:tsc_test //haku/console/frontend:bridge_test //haku/console/frontend:screenshots --test_output=errors --nocache_test_results`
- follow-up: `bbr test //haku/console/frontend:tsc_test //haku/console/frontend:screenshots --test_output=errors --nocache_test_results`
- `pre-commit run --files ...` on every changed frontend file
- inspected generated light/dark screenshots for all scenes; refreshed drawer images confirm exposed toggles, green Approve actions, and aligned decision controls
