### PR TITLE
haku/console: compact highlighted JSON args; status left of an icon Brief/Full toggle

### DIFF
--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -151,8 +151,19 @@ js_library(
     srcs = ["tool_arguments_field.tsx"],
     deps = [
         ":field",
+        ":json_preview",
         "//:node_modules/react",
         "//haku/console/frontend/tool_previews",
+        "//haku/console/frontend/tool_previews:variant",
+    ],
+)
+
+js_library(
+    name = "json_preview",
+    srcs = ["json_preview.tsx"],
+    deps = [
+        "//:node_modules/highlight.js",
+        "//:node_modules/react",
         "//haku/console/frontend/tool_previews:variant",
     ],
 )
@@ -207,6 +218,7 @@ js_library(
     name = "variant_control",
     srcs = ["variant_control.tsx"],
     deps = [
+        ":icons",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
         "//haku/console/frontend/tool_previews:variant",

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -194,12 +194,12 @@ function GeolocationApprovalCard({
             </Text>
             <Text size="xs">{geolocationApprovalBody(approval)}</Text>
           </Stack>
-          <Stack gap={6} align="flex-end" style={{ flexShrink: 0 }}>
+          <Group gap="xs" align="center" wrap="nowrap" style={{ flexShrink: 0 }}>
             <Badge color={deciding ? "blue" : "yellow"} variant="light">
               {deciding ? "Applying" : "Pending"}
             </Badge>
             <VariantControl variant={variant} onChange={setVariant} />
-          </Stack>
+          </Group>
         </Group>
         {detailed && (
           <div className="haku-shell-fields">

--- a/haku/console/frontend/icons.tsx
+++ b/haku/console/frontend/icons.tsx
@@ -8,6 +8,8 @@ import IconCalendarEvent from "@tabler/icons-react/dist/esm/icons/IconCalendarEv
 import IconChecklist from "@tabler/icons-react/dist/esm/icons/IconChecklist.mjs";
 import IconClock from "@tabler/icons-react/dist/esm/icons/IconClock.mjs";
 import IconHistory from "@tabler/icons-react/dist/esm/icons/IconHistory.mjs";
+import IconList from "@tabler/icons-react/dist/esm/icons/IconList.mjs";
+import IconListDetails from "@tabler/icons-react/dist/esm/icons/IconListDetails.mjs";
 import IconMail from "@tabler/icons-react/dist/esm/icons/IconMail.mjs";
 import IconMapPin from "@tabler/icons-react/dist/esm/icons/IconMapPin.mjs";
 import IconSettings from "@tabler/icons-react/dist/esm/icons/IconSettings.mjs";
@@ -70,4 +72,14 @@ export function MailIcon(props: TablerIconProps) {
 /** Crossed-out wifi — the shell's "live updates disconnected" indicator. */
 export function WifiOffIcon(props: TablerIconProps) {
   return <IconWifiOff size={20} {...props} />;
+}
+
+/** Plain list — the "Brief" (compact) side of a card's detail toggle. */
+export function ListIcon(props: TablerIconProps) {
+  return <IconList size={20} {...props} />;
+}
+
+/** List with detail lines — the "Full" (detailed) side of a card's detail toggle. */
+export function ListDetailsIcon(props: TablerIconProps) {
+  return <IconListDetails size={20} {...props} />;
 }

--- a/haku/console/frontend/json_preview.tsx
+++ b/haku/console/frontend/json_preview.tsx
@@ -1,0 +1,83 @@
+import hljs from "highlight.js/lib/core";
+import json from "highlight.js/lib/languages/json";
+
+import type { PreviewVariant } from "./tool_previews/variant.tsx";
+
+hljs.registerLanguage("json", json);
+
+// Width-aware pretty-print: a value whose one-line form fits within `maxLength` (accounting for
+// the current indent) stays inline; only larger arrays/objects break, one child per line, each
+// child re-evaluated the same way. So `[1, 2, 3, 4, 5]` stays one line while a big nested object
+// expands. (A local ~30-line take on json-stringify-pretty-compact — kept in-repo because adding
+// that npm dep needs a pnpm-lock regen this environment's egress policy currently blocks.)
+function inlineJson(v: unknown): string {
+  if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
+  if (Array.isArray(v)) return `[${v.map(inlineJson).join(", ")}]`;
+  return `{${Object.entries(v as Record<string, unknown>)
+    .map(([k, val]) => `${JSON.stringify(k)}: ${inlineJson(val)}`)
+    .join(", ")}}`;
+}
+
+function compactStringify(value: unknown, maxLength: number, indent: string, unit = "  "): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  const oneLine = inlineJson(value);
+  if (indent.length + oneLine.length <= maxLength) return oneLine;
+  const inner = indent + unit;
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    return `[\n${value.map((v) => inner + compactStringify(v, maxLength, inner, unit)).join(",\n")}\n${indent}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) return "{}";
+  const body = entries
+    .map(([k, v]) => `${inner}${JSON.stringify(k)}: ${compactStringify(v, maxLength, inner, unit)}`)
+    .join(",\n");
+  return `{\n${body}\n${indent}}`;
+}
+
+// Compact-mode caps so a preview stays scannable; detailed shows the value in full. The compact
+// printer keeps short arrays/objects inline and only breaks larger ones, so `[1, 2, 3, 4, 5]`
+// stays one line — MAX_WIDTH is the fit-or-expand threshold.
+const COMPACT_ARRAY_ITEMS = 6;
+const COMPACT_OBJECT_ENTRIES = 8;
+const COMPACT_STRING_CHARS = 80;
+const COMPACT_DEPTH = 3;
+const MAX_WIDTH = 72;
+
+// Structurally truncate a value for compact rendering. Elided array tails / object key sets and
+// over-deep or over-long leaves are replaced with valid-JSON string sentinels (`…(+N more)`,
+// `[…]`, `{…}`, `…`) so the printed result stays parseable and highlights cleanly — unlike
+// clamping the printed string, which cuts mid-token and drops the highlighting on the tail.
+function truncate(value: unknown, depth: number): unknown {
+  if (typeof value === "string") {
+    return value.length > COMPACT_STRING_CHARS ? `${value.slice(0, COMPACT_STRING_CHARS)}…` : value;
+  }
+  if (Array.isArray(value)) {
+    if (depth <= 0) return "[…]";
+    const head: unknown[] = value.slice(0, COMPACT_ARRAY_ITEMS).map((v) => truncate(v, depth - 1));
+    if (value.length > COMPACT_ARRAY_ITEMS) head.push(`…(+${value.length - COMPACT_ARRAY_ITEMS} more)`);
+    return head;
+  }
+  if (value && typeof value === "object") {
+    if (depth <= 0) return "{…}";
+    const entries = Object.entries(value as Record<string, unknown>);
+    const kept: Record<string, unknown> = {};
+    for (const [k, v] of entries.slice(0, COMPACT_OBJECT_ENTRIES)) kept[k] = truncate(v, depth - 1);
+    if (entries.length > COMPACT_OBJECT_ENTRIES) kept["…"] = `(+${entries.length - COMPACT_OBJECT_ENTRIES} more)`;
+    return kept;
+  }
+  return value;
+}
+
+/** A tool call's arguments as a syntax-highlighted JSON code block. Width-aware pretty-printing
+ * keeps short collections inline and only breaks larger ones; highlight.js colors it (json grammar
+ * only, registered above — the lean core import, not the all-languages barrel). In compact mode the
+ * value is structurally truncated first, so the block stays short while keeping both highlighting
+ * and structure. */
+export function JsonPreview({ value, variant }: { value: unknown; variant: PreviewVariant }) {
+  const shown = variant === "compact" ? truncate(value, COMPACT_DEPTH) : value;
+  const code = compactStringify(shown, MAX_WIDTH, "");
+  // hljs escapes the input, so its span-wrapped output is safe to inject.
+  const html = hljs.highlight(code, { language: "json", ignoreIllegals: true }).value;
+  return <pre className="haku-shell-json hljs" dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/haku/console/frontend/screenshots/render.mjs
+++ b/haku/console/frontend/screenshots/render.mjs
@@ -20,13 +20,13 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 // separate page load driven by window.__SCENE__ (see harness.tsx).
 const SCENES = [
   // The history page, showing both row states in one shot: flip the first row's Brief/Full
-  // selector to Full and open its Metadata disclosure, leaving the rest Brief. Each row's
-  // selector shows both segments always, so `::-p-text(Full)` matches the first row's Full
-  // segment; the Metadata summary only exists once that row is detailed.
+  // selector to Full (its segments are icons, so match the "Full" icon by aria-label) and open
+  // its Metadata disclosure, leaving the rest Brief. `[aria-label="Full"]` matches the first
+  // row's Full segment; the Metadata summary only exists once that row is detailed.
   {
     name: "history",
     viewport: { width: 1200, height: 1500 },
-    clicks: ["label::-p-text(Full)", "summary::-p-text(Metadata)"],
+    clicks: ['[aria-label="Full"]', "summary::-p-text(Metadata)"],
   },
   { name: "settings", viewport: { width: 1200, height: 900 } },
   // Every implemented tool-call preview, compact | detailed side by side — tall, so give it room.

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -15,6 +15,11 @@
     /* Neutral gray code surface (matches the neutral dark-mode code bg below), not a tint. */
     --haku-code-bg: var(--mantine-color-gray-1);
     --haku-code-fg: var(--mantine-color-gray-9);
+    /* JSON syntax-highlight hues — muted so a code block reads as structured data, not a rainbow. */
+    --haku-json-key: #1971c2;
+    --haku-json-string: #2f9e44;
+    --haku-json-number: #e8590c;
+    --haku-json-literal: #9c36b5;
     --haku-backdrop: rgb(21 74 70 / 55%);
     --haku-shell-shadow: rgb(36 31 43 / 20%);
     --haku-shell-muted-bg: #f4f0f7;
@@ -33,6 +38,11 @@
     --haku-shell-shadow: rgb(0 0 0 / 45%);
     --haku-shell-muted-bg: var(--mantine-color-dark-6);
     --haku-shell-active-bg: var(--mantine-color-dark-5);
+    /* Lighter JSON hues for the dark code surface. */
+    --haku-json-key: #74c0fc;
+    --haku-json-string: #8ce99a;
+    --haku-json-number: #ffc078;
+    --haku-json-literal: #eebefa;
   }
   body {
     margin: 0;
@@ -324,6 +334,21 @@
   font-size: 0.82rem;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+
+/* highlight.js json tokens over the neutral code surface (see --haku-json-* vars). Punctuation
+   and braces carry no token class, so they inherit --haku-code-fg. */
+.haku-shell-json .hljs-attr {
+  color: var(--haku-json-key);
+}
+.haku-shell-json .hljs-string {
+  color: var(--haku-json-string);
+}
+.haku-shell-json .hljs-number {
+  color: var(--haku-json-number);
+}
+.haku-shell-json .hljs-literal {
+  color: var(--haku-json-literal);
 }
 
 .haku-shell-disclosure {

--- a/haku/console/frontend/tabler_icons.d.ts
+++ b/haku/console/frontend/tabler_icons.d.ts
@@ -54,6 +54,16 @@ declare module "@tabler/icons-react/dist/esm/icons/IconMapPin.mjs" {
   const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
   export default Icon;
 }
+declare module "@tabler/icons-react/dist/esm/icons/IconList.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}
+declare module "@tabler/icons-react/dist/esm/icons/IconListDetails.mjs" {
+  import type { FC, SVGProps } from "react";
+  const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;
+  export default Icon;
+}
 declare module "@tabler/icons-react/dist/esm/icons/IconWifiOff.mjs" {
   import type { FC, SVGProps } from "react";
   const Icon: FC<SVGProps<SVGSVGElement> & { size?: number | string; stroke?: number | string }>;

--- a/haku/console/frontend/tool_arguments_field.tsx
+++ b/haku/console/frontend/tool_arguments_field.tsx
@@ -1,16 +1,14 @@
 import { Field } from "./field.tsx";
+import { JsonPreview } from "./json_preview.tsx";
 import { toolPreview } from "./tool_previews/index.tsx";
-import { clampBlock, type PreviewVariant } from "./tool_previews/variant.tsx";
-
-// A compact raw-JSON fallback shows only the first few lines (for a tool with no custom
-// widget); the detailed view shows it in full.
-const COMPACT_JSON_LINES = 6;
+import type { PreviewVariant } from "./tool_previews/variant.tsx";
 
 /** The arguments of a tool call: a per-tool-type widget (the tool_previews/ per-server modules)
- * when one matches — rendered directly, since it's self-describing — else the generic raw-JSON
- * view, which keeps an "Arguments" label so it isn't mistaken for a result. `variant` picks the
- * compact (skim) or detailed form; detailed always offers the raw JSON behind a disclosure even
- * when a widget rendered. Shared by the approval drawer and the past-tool-calls history view. */
+ * when one matches — rendered directly, since it's self-describing — else the generic
+ * syntax-highlighted JSON view (compact-printed + truncated in brief mode, full in detailed),
+ * which keeps an "Arguments" label so it isn't mistaken for a result. `variant` picks the compact
+ * (skim) or detailed form; detailed always offers the exact raw JSON behind a disclosure even when
+ * a widget rendered. Shared by the approval drawer and the past-tool-calls history view. */
 export function ToolArgumentsField({
   serverId,
   toolName,
@@ -28,9 +26,7 @@ export function ToolArgumentsField({
   if (!nice) {
     return (
       <Field label="Arguments">
-        <pre className="haku-shell-json">
-          {variant === "compact" ? clampBlock(argumentsJson, COMPACT_JSON_LINES) : argumentsJson}
-        </pre>
+        <JsonPreview value={args} variant={variant} />
       </Field>
     );
   }
@@ -40,6 +36,8 @@ export function ToolArgumentsField({
       {variant === "detailed" && (
         <details className="haku-shell-disclosure">
           <summary>Raw arguments</summary>
+          {/* The disclosure stays byte-exact (JSON.stringify), so reflow/truncation never costs
+              the real, copyable payload. */}
           <pre className="haku-shell-json">{argumentsJson}</pre>
         </details>
       )}

--- a/haku/console/frontend/tool_call_card.tsx
+++ b/haku/console/frontend/tool_call_card.tsx
@@ -66,14 +66,14 @@ export function ToolCallCard({
               </Text>
             )}
           </Stack>
-          {/* Badge + Brief/Full selector anchored top-right: detail expands below, so the
-              selector never moves out from under the pointer. */}
-          <Stack gap={6} align="flex-end" style={{ flexShrink: 0 }}>
+          {/* Status badge left of the Brief/Full selector, anchored top-right: detail expands
+              below, so the selector never moves out from under the pointer. */}
+          <Group gap="xs" align="center" wrap="nowrap" style={{ flexShrink: 0 }}>
             <Badge color={status.color} variant="light">
               {status.label}
             </Badge>
             <VariantControl variant={variant} onChange={onVariantChange} />
-          </Stack>
+          </Group>
         </Group>
         <ToolArgumentsField
           serverId={fields.serverId}

--- a/haku/console/frontend/variant_control.tsx
+++ b/haku/console/frontend/variant_control.tsx
@@ -1,6 +1,7 @@
 import { SegmentedControl } from "@mantine/core";
 import { useState } from "react";
 
+import { ListDetailsIcon, ListIcon } from "./icons.tsx";
 import type { PreviewVariant } from "./tool_previews/variant.tsx";
 
 // The per-view compact/detailed selection, shared by the history page's per-row control and the
@@ -11,11 +12,12 @@ export function useVariant(initial: PreviewVariant): [PreviewVariant, (v: Previe
   return useState(initial);
 }
 
-/** Brief↔Full detail selector, rendered as a two-segment flip-flop. It's placed at the **top**
- * of a card (not the bottom) on purpose: switching to Full grows content below it, so the
- * control stays put under the pointer — you never have to chase it down the card to switch back.
- * A segmented control also shows both states at once, so it's self-explanatory (unlike a lone
- * "Show details" caret that hides what the other state is). */
+/** Brief↔Full detail selector, rendered as a two-segment flip-flop of icons: a plain list
+ * (compact) vs a list-with-detail-lines (detailed). It's placed at the **top** of a card (not the
+ * bottom) on purpose: switching to Full grows content below it, so the control stays put under the
+ * pointer — you never have to chase it down the card to switch back. A segmented control also
+ * shows both states at once, so it's self-explanatory (unlike a lone "Show details" caret). Each
+ * segment keeps a `title`/`aria-label` so the icons aren't ambiguous. */
 export function VariantControl({
   variant,
   onChange,
@@ -29,8 +31,22 @@ export function VariantControl({
       value={variant}
       onChange={(v) => onChange(v as PreviewVariant)}
       data={[
-        { value: "compact", label: "Brief" },
-        { value: "detailed", label: "Full" },
+        {
+          value: "compact",
+          label: (
+            <span title="Brief" aria-label="Brief" style={{ display: "flex" }}>
+              <ListIcon size={16} />
+            </span>
+          ),
+        },
+        {
+          value: "detailed",
+          label: (
+            <span title="Full" aria-label="Full" style={{ display: "flex" }}>
+              <ListDetailsIcon size={16} />
+            </span>
+          ),
+        },
       ]}
       aria-label="Detail level"
     />


### PR DESCRIPTION
Follow-ups on the console chrome (after #3043 merged).

## What

**Card header**
- The status badge (Pending / OK / Error / …) now sits to the **left** of the Brief/Full selector on one row, still anchored top-right so detail expands *below* it (the selector never slides out from under the pointer). Applies to both the shared tool-call card and the geolocation card.
- **Brief/Full is now an icon pair** — a plain list (compact) vs a list-with-detail-lines (detailed) — each segment keeping a `title`/`aria-label` so the icons aren't ambiguous.

**JSON arguments** (`json_preview.tsx`)
- The widget-less argument fallback is now a **syntax-highlighted, width-aware** JSON block. A short value's one-line form stays inline — `[1, 2, 3, 4, 5]` and `{"ids": [3, 7, 12]}` no longer explode to 7 lines — while only larger structures break (e.g. the multi-key calendar-event object still expands).
- **Brief mode structurally truncates first** (first N array items / object keys, capped strings, capped depth, with valid `…(+N more)` / `[…]` / `{…}` sentinels), so the block stays short while keeping both highlighting *and* structure — unlike clamping the printed string, which cut mid-token and dropped highlighting on the tail.
- Highlighting via the already-present **highlight.js** (lean `lib/core` + json grammar only — not the all-languages barrel); token hues tuned muted for light + dark.
- The **"Raw arguments" disclosure stays byte-exact** `JSON.stringify` for copy fidelity.

## Note on the compact printer

I used a small in-repo width-aware printer rather than the `json-stringify-pretty-compact` npm dep. Adding that dep needs a `pnpm-lock.yaml` regen, which is a local-only Bazel module extension — and local Bazel can't bootstrap in this environment (GitHub archive fetches for its own repos are policy-denied, 403). The result is identical; swapping to the lib later is a one-liner + lockfile update.

## Testing

`bbr test //haku/console/frontend/...` green (tsc + vitest + screenshots). Screenshots eyeballed in light and dark: compact one-line JSON with key/string/number highlighting, the icon Brief/Full toggle with the status badge to its left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cqH5HEuFcbnXnDp3zFzPk

---
_Generated by [Claude Code](https://claude.ai/code/session_013cqH5HEuFcbnXnDp3zFzPk)_