### PR TITLE
haku: kitchen/household-stocking subagent + Langfuse + console-as-MCP + deep-link delegation plans

### DIFF
--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -15,7 +15,11 @@ rationale:
 - **Threat model, enforcement inventory, and the invariants edits must preserve:**
   <docs/security.md> — the durable doctrine's canonical home; start a security review there.
 - The live primary runtime today is the manually configured Claude Code web home:
-  `haku/runtime/claude_web_env/`, which runs `haku/run.md`.
+  `haku/runtime/claude_web_env/`, which runs `haku/run.md`. A separate, deliberately
+  distinct thing: the operator's own **second coding-delegation path** using Claude
+  Code web deep links (pre-filled prompt + repo + environment) —
+  `haku/plans/claude_code_web_deep_link_delegation.md`. Don't conflate the two; the
+  deep-link path must not reuse Haku's own web-home environment/secrets.
 - The trusted console (capability tier + iframe shell): `haku/console/README.md`;
   containment contract: `haku/console/docs/containment.md`. Alternative runtimes
   (Managed Agents): `haku/runtime/managed_agent/` + `haku/plans/`.

--- a/haku/plans/claude_code_web_deep_link_delegation.md
+++ b/haku/plans/claude_code_web_deep_link_delegation.md
@@ -1,6 +1,6 @@
 # Plan: Claude Code web deep links as a second coding-delegation path
 
-Status: design landed, one operator confirmation outstanding (see _Open question_).
+Status: **built** (haku-state `ui/frontend/src/affordances.tsx`, `<code-session>` widget).
 
 ## Why
 
@@ -26,10 +26,9 @@ prompt and an environment:
   self-hosted on Forgejo (`git.allegedly.works`), not GitHub, so this delegation path
   is `ducktape`-only. (A `haku-state` coding task still has to go through Haku's own
   Claude Code web home, which clones it directly — see `haku/runtime/claude_web_env/`.)
-- `environment` — name/ID of a saved cloud environment (network policy, setup script,
-  env vars). This is the parameter that actually grants the git remote access —
-  picking the wrong one either fails outright or hands the session credentials scoped
-  for a different purpose.
+- `environment` — **name or ID** of a saved cloud environment (confirmed in the docs
+  verbatim: "Name or ID of the environment to preselect") — no opaque-ID lookup
+  needed, the environment's display name works directly.
 
 Example: `https://claude.ai/code?prompt=Fix%20the%20login%20bug&repositories=agentydragon/ducktape&environment=<name>`.
 
@@ -37,46 +36,56 @@ Example: `https://claude.ai/code?prompt=Fix%20the%20login%20bug&repositories=age
 hand in the Claude Code web UI after it loads. If a task needs a specific base branch,
 say so in the prompt text itself rather than relying on the link to pre-select it.
 
-## Open question: which `environment` to target
+## Which `environment` to target
 
-Do **not** reuse the dedicated "Haku" web-home environment
-(`haku/runtime/claude_web_env/README.md`) for this — it's provisioned with Haku's own
-`SOPS_AGE_KEY` and a domain allowlist scoped to Haku's operational needs (cluster API,
-Gmail, `*.allegedly.works`), not a general-purpose coding sandbox. Reusing it for
-arbitrary delegated coding tasks would hand those sessions Haku's own secrets for no
-reason.
+The operator runs **multiple environments for different cases** and picks per task
+which one a link should target — there's no single default to hardcode. (One data
+point: this very session's own environment turned out to already be "Haku" —
+`DUCKTAPE_CLAUDE_HOOKS_PROFILE` points at Haku's profile, `K8S_NAMESPACE=haku-sandbox`
+— confirming an environment name alone is enough to identify it, with no separate ID
+lookup required. Whether "Haku" itself is ever the right target for one of these links
+is the operator's call each time, not something to assume.)
 
-This plan needs the operator to confirm the exact name/ID of the environment he wants
-these links to target (a general `ducktape` dev environment, separate from Haku's).
-Once confirmed, record it in haku-state's `memory/delegation.md` so every future link
-uses the same value instead of guessing.
+## Policy: no approval gate, but a real gate DOES exist — go through it, don't route around it
 
-## Policy: no approval gate
+**Correction (operator, 2026-07-11):** the first version of this plan assumed a plain
+markdown link would just work in haku-ui with zero engineering. Wrong — the operator
+caught it: haku-ui runs inside haku-console's **sandboxed cross-origin iframe**
+(`sandbox="allow-scripts allow-same-origin allow-forms"`, deliberately **no
+`allow-popups`**), so a native `<a target="_blank">` click from inside that iframe is
+silently blocked by the browser — it can't open anything. The console's actual
+mechanism is the **`openLink` bridge**: the iframe `postMessage`s `{type: "openLink",
+url}` to the trusted shell, which vets the URL (`vetOpenLink` in
+`haku/console/frontend/bridge.ts`) — HTTPS/mailto only as a hard scheme gate, then a
+host **whitelist** (`OPEN_LINK_WHITELIST`, PR-gated, shell-owned) decides open-directly
+vs. show-a-confirm-dialog. `claude.ai` is already on that whitelist (used by the
+existing `<handoff>` widget for `claude.ai/new`), so a `claude.ai/code` link matches
+the same host and opens directly — **no console/ducktape change needed**, no new
+approval plumbing, and this genuinely has "nothing to approve" once routed through the
+bridge that already exists. The lesson: "gated" here means "goes through the
+console's one real link-opening mechanism," not "needs a new approval step" — those
+are different things, and the fix was routing through the existing gate correctly, not
+adding or removing one.
 
-These links are **inert until a human opens them in a browser** — clicking one just
-navigates to `claude.ai/code`, which runs Anthropic's own session-creation flow
-(its own confirmation UI) before anything happens. No credential is exposed, no
-mutation occurs, and no ducktape/haku-console code executes as a side effect of
-generating or clicking the link. Per the operator's own framing ("I'll want to
-autoapprove those links") and the existing `<handoff>`-vs-`<tool-call>` calibration
-rule (`procedures/tool_calls.md` in haku-state): render these as a **plain link**, not
-a `<tool-call>` — there is nothing to approve. Confirmed in haku-state's renderer
-(`ui/frontend/src/mdx.tsx`): an external markdown link already renders as a clickable
-`<Anchor target="_blank">` with zero extra frontend work needed.
+## What got built
 
-## What this does NOT need
-
-- No new haku-state UI widget — a plain `[Open in Claude Code web](https://claude.ai/code?...)`
-  markdown link in an item body already renders correctly (verified against the
-  existing `mdx.tsx` link-rendering path).
-- No ducktape-side script/service to mint these links — the URL is simple enough to
-  construct inline (base URL + `urllib.parse.urlencode`-style encoding of `prompt`)
-  each time one is authored; a dedicated helper would be premature abstraction for a
-  three-field query string.
-- No new approval/auth plumbing — see _Policy_ above.
+- **`ui/frontend/src/affordances.tsx`** (haku-state): `<CodeSession>` component, a
+  direct sibling of the existing `<Handoff>` (which already does this exact pattern for
+  `claude.ai/new` — same `openLink` call, same whitelist hit). Builds
+  `https://claude.ai/code?prompt=...&repositories=...&environment=...` and calls the
+  existing gated `openLink`.
+- **`ui/frontend/src/mdx.tsx`**: registers `<code-session prompt="…" repository="…"
+environment="…" label="…"></code-session>` as an authorable widget tag (mirroring
+  `<handoff>`), plus the two new attributes in DOMPurify's `ADD_ATTR` allowlist.
+- **`procedures/garden.md`** (haku-state): documents the new tag alongside `<handoff>`.
+- Tests: `affordances.test.tsx` (URL construction, defaults) and
+  `mdx_render.test.tsx` (DOMPurify sanitizer regression, matching the existing
+  `<handoff>` coverage).
+- **No ducktape-side change was needed** — the `openLink` whitelist already covers
+  `claude.ai` for any path, so no PR to `haku/console/frontend/bridge.ts` was required.
 
 ## Where the authoring guidance lives
 
-haku-state's `memory/delegation.md` carries the operational "when to use this, how to
-build the URL" guidance for Haku itself; this file is the durable design record for
-why the mechanism works the way it does and what it deliberately doesn't build.
+haku-state's `memory/delegation.md` carries the operational "when to use this" guidance
+for Haku itself; this file is the durable design record for why the mechanism works the
+way it does.

--- a/haku/plans/claude_code_web_deep_link_delegation.md
+++ b/haku/plans/claude_code_web_deep_link_delegation.md
@@ -36,6 +36,15 @@ Example: `https://claude.ai/code?prompt=Fix%20the%20login%20bug&repositories=age
 hand in the Claude Code web UI after it loads. If a task needs a specific base branch,
 say so in the prompt text itself rather than relying on the link to pre-select it.
 
+**Pre-fill is not auto-submit.** The docs' own wording is "prefill the prompt... in the
+input box" — clicking the link lands the operator on `claude.ai/code` with the prompt
+sitting in the input box, unsent. He still reads it and presses Enter (or edits/cancels)
+before anything actually runs. This is a real, structural review step — different in
+kind from `<tool-call>`'s executed-on-approval model, where clicking through in
+haku-console is the last human touch before execution. Don't describe `<code-session>`
+as fully zero-touch the way an executed tool call is; "nothing to approve" is true only
+about the link itself, not about whether the resulting session runs unreviewed.
+
 ## Which `environment` to target
 
 The operator runs **multiple environments for different cases** and picks per task

--- a/haku/plans/claude_code_web_deep_link_delegation.md
+++ b/haku/plans/claude_code_web_deep_link_delegation.md
@@ -1,0 +1,82 @@
+# Plan: Claude Code web deep links as a second coding-delegation path
+
+Status: design landed, one operator confirmation outstanding (see _Open question_).
+
+## Why
+
+Operator ask (2026-07-11): a second way to delegate coding tasks, alongside describing
+a task directly to Claude.ai chat. The gap that motivates it: a plain claude.ai
+conversation has no git remote access, so any actual code change still has to come
+back through a human. A Claude Code web session pre-wired to `ducktape` gets **push
+access to the repo directly** — closing that gap for anything that's really a coding
+task rather than a research/writing one.
+
+## The mechanism (confirmed real, not speculative)
+
+`code.claude.com/docs/en/web-quickstart.md` → "Pre-fill sessions" documents URL query
+parameters on `https://claude.ai/code` that open a **new** session pre-loaded with a
+prompt and an environment:
+
+- `prompt` (alias `q`) — the input box text, URL-encoded, ~5,000 char cap. Use
+  `prompt_url` instead (a URL Claude fetches for the prompt text) if a task
+  description needs to run longer.
+- `repositories` (alias `repo`) — comma-separated `owner/repo` GitHub slugs. This is
+  GitHub-specific: it only reaches repos the Claude Code web GitHub integration can
+  see. **`ducktape` (`agentydragon/ducktape`) qualifies; `haku-state` does not** — it's
+  self-hosted on Forgejo (`git.allegedly.works`), not GitHub, so this delegation path
+  is `ducktape`-only. (A `haku-state` coding task still has to go through Haku's own
+  Claude Code web home, which clones it directly — see `haku/runtime/claude_web_env/`.)
+- `environment` — name/ID of a saved cloud environment (network policy, setup script,
+  env vars). This is the parameter that actually grants the git remote access —
+  picking the wrong one either fails outright or hands the session credentials scoped
+  for a different purpose.
+
+Example: `https://claude.ai/code?prompt=Fix%20the%20login%20bug&repositories=agentydragon/ducktape&environment=<name>`.
+
+**Known gap: no branch parameter.** Whoever opens the link still picks the branch by
+hand in the Claude Code web UI after it loads. If a task needs a specific base branch,
+say so in the prompt text itself rather than relying on the link to pre-select it.
+
+## Open question: which `environment` to target
+
+Do **not** reuse the dedicated "Haku" web-home environment
+(`haku/runtime/claude_web_env/README.md`) for this — it's provisioned with Haku's own
+`SOPS_AGE_KEY` and a domain allowlist scoped to Haku's operational needs (cluster API,
+Gmail, `*.allegedly.works`), not a general-purpose coding sandbox. Reusing it for
+arbitrary delegated coding tasks would hand those sessions Haku's own secrets for no
+reason.
+
+This plan needs the operator to confirm the exact name/ID of the environment he wants
+these links to target (a general `ducktape` dev environment, separate from Haku's).
+Once confirmed, record it in haku-state's `memory/delegation.md` so every future link
+uses the same value instead of guessing.
+
+## Policy: no approval gate
+
+These links are **inert until a human opens them in a browser** — clicking one just
+navigates to `claude.ai/code`, which runs Anthropic's own session-creation flow
+(its own confirmation UI) before anything happens. No credential is exposed, no
+mutation occurs, and no ducktape/haku-console code executes as a side effect of
+generating or clicking the link. Per the operator's own framing ("I'll want to
+autoapprove those links") and the existing `<handoff>`-vs-`<tool-call>` calibration
+rule (`procedures/tool_calls.md` in haku-state): render these as a **plain link**, not
+a `<tool-call>` — there is nothing to approve. Confirmed in haku-state's renderer
+(`ui/frontend/src/mdx.tsx`): an external markdown link already renders as a clickable
+`<Anchor target="_blank">` with zero extra frontend work needed.
+
+## What this does NOT need
+
+- No new haku-state UI widget — a plain `[Open in Claude Code web](https://claude.ai/code?...)`
+  markdown link in an item body already renders correctly (verified against the
+  existing `mdx.tsx` link-rendering path).
+- No ducktape-side script/service to mint these links — the URL is simple enough to
+  construct inline (base URL + `urllib.parse.urlencode`-style encoding of `prompt`)
+  each time one is authored; a dedicated helper would be premature abstraction for a
+  three-field query string.
+- No new approval/auth plumbing — see _Policy_ above.
+
+## Where the authoring guidance lives
+
+haku-state's `memory/delegation.md` carries the operational "when to use this, how to
+build the URL" guidance for Haku itself; this file is the durable design record for
+why the mechanism works the way it does and what it deliberately doesn't build.

--- a/haku/plans/console_mcp_approval_queue.md
+++ b/haku/plans/console_mcp_approval_queue.md
@@ -23,11 +23,52 @@ Status: open follow-ups only. Implemented behavior belongs in:
    the source of truth for tool-call authorization, execution, audit, and results. Do not add a
    `tool_results/` git mirror.
 
-3. Console-as-MCP airlock.
-   Haku can already use haku-console's HTTP API to request approval-gated calls. Later, expose the
-   same approval ledger and execution path as an MCP proxy too. Future auto-allow policy can execute
-   immediately for allowed calls; all other calls stay approval-gated or get punted to the
-   asynchronous haku-ui affordance flow.
+3. Console-as-MCP airlock — fleshed out (operator, 2026-07-11), still not built.
+
+   **Why now:** every haku-console call from Haku's web session today goes through a short-lived
+   `haku-sandbox` pod (`kubectl run` a curl container, write the JSON body via a ConfigMap, read
+   `kubectl logs`, delete the pod) — the workaround `haku/base/instructions.md` documents for
+   reaching any cluster-internal Service from a web session that has no cluster-internal network
+   path. It works, but it's slow, easy to fumble, and 2026-07-11's session hit it repeatedly (a
+   Grocy shopping-list refresh, several tool-call submissions, a permission probe — each its own
+   pod). A native MCP connection (the same mechanism this session already uses for `tana-mcp-ro`
+   and `grocy-mcp-sf`) replaces all of that with a normal tool call.
+
+   **The constraint that shapes this:** `haku.allegedly.works` is not a usable base — it's 100%
+   an Authentik **proxy provider** (browser SSO forward-auth, policy-restricted to the operator's
+   own account), with no bearer/API path at all. This needs its own public route, not a carve-out
+   of that hostname.
+
+   **Precedent to follow, not invent:** `tana-mcp-ro.allegedly.works` is exactly this pattern
+   already shipped — a public `HTTPRoute` + a static bearer (`haku-tana-ro-token`), whose own
+   annotation states the reason verbatim: it "exists so Haku's Claude Code web home can reach the
+   facade directly... [since] there is no cluster-internal path from the home." A
+   `haku-console-mcp` route would be the same shape: public HTTPRoute, static bearer — reusing the
+   **existing** `haku-console-agent-api` token (already scoped to exactly "request/read tool
+   calls, not approve them" — the right scope for this) rather than inventing new auth. The
+   OAuth-DCR pattern `grocy-sf`/`tana-rw` use doesn't fit here: that authenticates the _operator's_
+   own browser-linked identity for servers _he_ wants to use through the console; there's no
+   analogous "Haku's own OAuth identity" anywhere in this repo, and inventing one is out of scope
+   for what's really just replacing a pod-curl workaround with a normal MCP transport.
+
+   **What it wraps:** haku-console is a plain FastAPI app, not an MCP server — it uses FastMCP
+   only as an in-process _client_ (per-tool `FastMCP` instances registered in
+   `haku/console/mcp_config.py`'s `InProcessServers`, reflecting the operator's connected tools
+   outward). This plan is the reverse direction: a new `FastMCP` instance wrapping
+   `mcp_approval.py`'s three operations Haku already calls today —
+   submit (`POST /api/tool-calls`), list/status (`GET /api/tool-calls`), and the audit sweep — as
+   `@mcp.tool`s, mounted alongside the existing FastAPI app (FastMCP supports co-mounting with
+   FastAPI in one ASGI app) or as a sibling route on the new hostname.
+
+   **Where it belongs:** `haku/docs/security.md`'s own invariant #3 settles this — "does it hold
+   a secret, perform a privileged action, or define the trust boundary? If not, it belongs to
+   Haku." The approval ledger and its execution path are exactly that boundary, so this MCP
+   surface lives in haku-console, not in Haku's own state or a new service.
+
+   Once live, auto-allow policy (already the plan for allowed calls) can return `ok`/`error`
+   directly in the tool response; everything else still lands `pending_approval` for the
+   operator, same as today — this only changes the transport Haku uses to reach the queue, not
+   the approval semantics.
 
 4. Additional server onboarding.
    Add more connected MCP servers as concrete use cases arrive, such as a kubectl MCP server for

--- a/haku/plans/kitchen_stocking_subagent.md
+++ b/haku/plans/kitchen_stocking_subagent.md
@@ -139,6 +139,25 @@ just today's synthetic starting states.
   artifact to what this subagent's recipe-planning output should look like — a reasonable
   seed for what "reasonably cookable" means operationally, if this gets built.
 
+## Observability: needs the still-unbuilt Langfuse wiring, not just LiteLLM key metadata
+
+Operator's instinct (2026-07-11) is correct: today's "existing litellm level markings" —
+`litellm_key` Terraform resources with a `key_alias`/`metadata` map
+(`tf/gitops/litellm-keys/main.tf`) — are key-level attribution (which lane/consumer a key
+belongs to), not per-call traces. Actual prompt/completion/tool-call traces need Langfuse, and
+the workers-LiteLLM the zai/oai zones route through doesn't have it wired yet — this is a
+pre-existing gap, not new: see `multi_agent.md`'s "Langfuse `haku-workers` project + viewer
+key" bullet (now fleshed out with what's concretely missing). This subagent shouldn't design
+its own tracing story — it's a consumer of that same fix, and probably the forcing function
+that finally gets it built, given it's a real recurring workload worth actually watching.
+
+The one kitchen-specific input to that decision: whether it gets a dedicated **"Haku kitchen"**
+Langfuse project (operator's suggestion) rather than sharing one flat `haku-workers` project
+with every other zone workload. A dedicated project makes sense once there's more than one
+real subagent — cleaner filtering, per-domain budget/cost visibility — but is one more thing to
+provision (Langfuse has no Terraform provider today; see `multi_agent.md`). Worth deciding
+alongside whatever workload becomes the second one, not in isolation for this one.
+
 ## Relationship to haku-state
 
 The canonical home for the shopping list itself is Grocy (operator's call, 2026-07-11) —

--- a/haku/plans/kitchen_stocking_subagent.md
+++ b/haku/plans/kitchen_stocking_subagent.md
@@ -1,0 +1,149 @@
+# Kitchen/household-stocking subagent
+
+**Status: undesigned — this doc is the first pass, from the operator's own framing
+(2026-07-11).** Nothing here is built. It fleshes out the "Deferred: grocery-order
+bounded-write MCP" line in [`multi_agent.md`](multi_agent.md) into a fuller shape; that
+line's intent is a building block of this plan, not a separate thing.
+
+## Goal
+
+A dedicated subagent that owns pantry/fridge/shopping-list state end-to-end, instead of
+Haku reasoning over Grocy inline on every kitchen pass (today's mode: `procedures/grocy_log.md`
+and hand-curated `kitchen/board.yaml` sections in `haku-state`, all done by Haku itself in its
+main session). Targets, in the operator's words: keep the shopping list current, plan
+_reasonably cookable_ recipes from what's on hand, keep good fresh fruit in stock matching
+what he actually likes.
+
+## Trigger model
+
+Operator's framing: something collects what changed since the subagent's last run (from
+Grocy, and possibly other sources) and decides whether to trigger; when it does trigger, it
+processes the whole batch of changes at once rather than reacting edit-by-edit.
+
+**What exists today that this can build on:** `haku/dispatch/app.py` is Haku-initiated only
+— `POST /jobs` (Haku's own bearer token), no externally-triggered job creation path.
+Sensors (`changedetection.io` → webhook → `haku-state intake/`) are step 6 in
+`multi_agent.md`'s build order and not built; even once they exist, they land findings in
+Haku's own intake for Haku to act on, not a direct dispatch trigger.
+
+Two ways to get the "batch since last run" behavior without waiting on sensor infra:
+
+1. **Haku-initiated batching (buildable today, no new infra):** each Haku pass reads Grocy's
+   `stock_log` since a bookmark (exactly what `kitchen/grocy_log.py` already does), and when
+   there's a nonempty delta, Haku itself calls `POST /jobs` with the batch as the prompt. This
+   reuses 100% of existing dispatch-plane machinery; the "trigger decision" just lives in
+   Haku's own run cadence rather than a standalone watcher.
+2. **A real collector/watcher (new infra):** a small always-on or cron-triggered component
+   polls Grocy's `stock_log` (or a webhook, if Grocy has one — unverified) independent of
+   Haku's own run cadence, and calls `POST /jobs` directly once it has a batch worth acting on.
+   This is closer to the operator's framing ("something... can tell us whether we should
+   trigger") but needs a place to run (a CronJob in `haku-sandbox` is the obvious fit — Haku
+   already has full CRUD there) and its own bookmark storage (could reuse
+   `haku-state`'s `kitchen/board.yaml:grocy_bookmark`, or keep its own).
+
+Start with (1) — it's free — and only build (2) if latency (Haku's own run cadence isn't
+tight enough) turns out to matter.
+
+## Zone / trust fit
+
+Operator's framing: "low sensitivity... run this one easily with z.ai." Worth checking
+against the zai zone's actual admission policy before assuming it clears: `multi_agent.md`
+describes the zai classifier as admitting **"public-by-construction" prompts only** — the
+bar today is about the _prompt_ being safe to leak, not just "low sensitivity" in a general
+sense. Household pantry contents aren't secret, but they're also not obviously
+public-by-construction the way a public-repo doc audit is. Two live options if zai's actual
+classifier turns out to be stricter than this task fits:
+
+- **The oai zone** (moderate trust, described but only partially built per `multi_agent.md`'s
+  step 5) explicitly allows "project/calendar-shaped facts, coarse finances" — household
+  stock/shopping data fits comfortably there even if it doesn't clear zai's bar.
+- **A local model** (`local_dispatch_zone.md`, fully designed, nothing landed) sidesteps the
+  question — no data leaves the cluster at all, and the operator explicitly floated this
+  ("maybe even a local model, IDK — we would need to actually measure that").
+
+Whichever zone, the workload doesn't need real-time responsiveness (option 1 above ties it
+to Haku's run cadence anyway), so it's a good first real workload for whichever
+lower-cost lane ends up cleared for it — including being the forcing case that gets the oai
+zone or the local zone from "designed" to "built."
+
+## Write surface: needs a bounded-write MCP, not the existing grocy_mcp server as-is
+
+`grocy_mcp/` (`server.py`) is a single full-read-write server per household
+(`grocy-mcp-sf`/`grocy-mcp-vallejo`), scoped only by the _calling user's own_ Grocy
+permissions via Authentik identity passthrough (`mcp_infra/authentik_auth`) — there is no
+service-account/API-key path and no read-only-vs-read-write split at the tool level. That's
+the right shape for an operator-driven Haku session (or the haku-console `grocy-sf`
+OAuth-linked connector Haku already uses via approval-gated tool-calls), but it's the wrong
+shape to hand directly to a low-trust dispatch-plane worker: the full tool surface includes
+`product_delete` (irreversible), arbitrary `entities_create/update/delete`, and no per-op
+allowlist.
+
+This is exactly the "reviewed MCP server holding the credential server-side, exposing only
+bounded ops" pattern `multi_agent.md` already named for grocery-order writes. Concretely, a
+kitchen-stocking-subagent write surface probably wants: `stock_add` / `stock_consume` /
+`stock_set` (for reconciling what changed), `shopping_list_items_add` /
+`shopping_list_item_edit` / `shopping_list_items_remove` — and _not_ `product_delete`,
+`entities_delete`, or raw `entities_create` on arbitrary types. Whether that's a genuinely
+separate bounded-write MCP deployment or a scoped credential + tool-allowlist in front of
+the existing server is an open implementation question; the trust requirement (no
+irreversible ops reachable by a zai/oai-tier worker) is the fixed point.
+
+## Model selection: the existing Grocy eval harness is already set up for this
+
+`grocy_mcp/eval/` (`cli.py`, `cases.py`, `run.py`) is **already model-agnostic** — no new
+harness code needed for a cheap-vs-expensive-vs-local comparison:
+
+```bash
+bazel run //grocy_mcp/eval:cli -- --api anthropic --model claude-haiku-4-5-20251001 ...
+bazel run //grocy_mcp/eval:cli -- --api openai --model gpt-4o-mini ...
+bazel run //grocy_mcp/eval:cli -- --api openai --model <local-model> --base-url <ollama/litellm endpoint> ...
+```
+
+Each run spins up a fresh, isolated Grocy container (`grocy_container.py`), seeds realistic
+state (`seed.py`), runs the model against the live MCP server, and snapshots
+`final_state.json` + `transcript.jsonl` + `summary.json`. Two existing cases
+(`shopping_planning`, `post_cook_logging`) are close analogues of what this subagent would
+do; there's no case yet for "here's a batch of `stock_log` changes since last run, reconcile
+the shopping list" — adding one is small, additive work in `cases.py`.
+
+**Missing piece: grading.** `EvalResult` carries prose `success_criteria` and a
+model-generated `postmortem_text`, but nothing scores a run against the criteria
+automatically today (`cases.py`'s own docstring flags this as "for future LLM-driven
+grading"). `props/` — the repo's existing LLM-critic eval system — is the natural thing to
+wire in rather than building a second grading mechanism; unconfirmed whether its critic
+shape (built for a different eval surface) plugs into `EvalResult`/`final_state.json`
+directly or needs an adapter.
+
+Plan: (1) add a batch-reconcile eval case, (2) wire a grading step (props/ critic or a
+simple rubric prompt, whichever is cheaper to stand up), (3) run it across candidate
+models/zones, (4) let the results — not a guess — decide the model tier this subagent
+actually ships on. "Realistic snapshots / realistic event progressions" (the operator's
+phrase) means `seed.py` should grow scenarios that look like real `stock_log` history, not
+just today's synthetic starting states.
+
+## Open gaps beyond model/trust/trigger
+
+- **Presence/occupancy signal.** The subagent needs to know roughly whether the operator is
+  home / planning to be home / expecting guests (different quantities, different menu). No
+  source exists for this today — `current_location.ts`'s session-local class
+  (home/vallejo/sf/elsewhere, `haku-state`-side) and his calendar are the closest existing
+  signals, but neither answers "is someone else eating here tonight." Real gap, not just
+  reuse-what-exists.
+- **Data sources beyond Grocy.** The operator floated the Thrive Market catalog data
+  (currently curated by Haku in `kitchen/board.yaml`'s `thrive_order`/`incoming` sections
+  through what looks like manual research, not an automated feed — **unconfirmed**, worth
+  checking before assuming there's a scraper to wire up) and "maybe more" sources,
+  unspecified.
+- **Recipe-planning target.** `kitchen/board.yaml`'s `make_now` section (hand-curated by
+  Haku today: named dishes, ingredient lists, cookability notes) is the closest existing
+  artifact to what this subagent's recipe-planning output should look like — a reasonable
+  seed for what "reasonably cookable" means operationally, if this gets built.
+
+## Relationship to haku-state
+
+The canonical home for the shopping list itself is Grocy (operator's call, 2026-07-11) —
+`haku-state`'s `kitchen/board.yaml:shopping_list` is a stopgap mirror for the haku-ui
+Shopping tab until Grocy write permissions are sorted and/or this subagent exists. Once
+built, this subagent's output surfaces through the same approval/tool-call path Haku already
+uses for Grocy writes (`procedures/tool_calls.md` in haku-state) unless/until its own bounded
+write MCP is trusted enough to write directly.

--- a/haku/plans/multi_agent.md
+++ b/haku/plans/multi_agent.md
@@ -48,6 +48,11 @@ New local-inference follow-up: <local_dispatch_zone.md>. It adapts the existing 
 perimeter to Ollama-hosted models and adds an active-model scheduler so local workers do
 not thrash model residency by running agents across multiple models at once.
 
+New application follow-up: <kitchen_stocking_subagent.md>. Fleshes out the grocery-order
+bounded-write MCP line above into a first design pass for a kitchen/household-stocking
+subagent (operator, 2026-07-11) — a candidate first real workload for the oai or local zone,
+using the existing `grocy_mcp/eval` harness (already model-agnostic) to pick the tier.
+
 ## The oai zone (step 5)
 
 The middle trust level the two-level design lacked: OpenAI, subscription-billed, trusted

--- a/haku/plans/multi_agent.md
+++ b/haku/plans/multi_agent.md
@@ -120,7 +120,24 @@ Still to wire:
   viewer-scoped key into `haku-sandbox`. Worker traffic is non-sensitive by construction
   (gated prompts), so Haku reading its own prompts/completions/costs is fine; a shared
   all-of-LiteLLM project would expose other consumers. The trace is the highest-value
-  "stuck/looping/burning budget" signal.
+  "stuck/looping/burning budget" signal. Concretely still missing (confirmed 2026-07-11):
+  today only the _main_ LiteLLM instance has `callbacks: ["langfuse_otel", "prometheus"]`
+  wired (`cluster/k8s/litellm/app/deployment.yaml`, one project: `langfuse-litellm-project`);
+  the workers-LiteLLM generator explicitly flags the gap
+  (`cluster/k8s/haku/dispatch/litellm/generate_workers_litellm.py`'s own
+  `# TODO(langfuse)` comment — `callbacks: ["prometheus"]` only). There's also **no
+  Terraform provider for Langfuse** (`tf/gitops/sso-providers/provider_langfuse.tf` is only
+  the Authentik OIDC login client) — every project/key that exists today came from Langfuse
+  Helm's one-shot `LANGFUSE_INIT_*` headless-init env vars, not a reusable provisioner.
+  Standing up a second project needs either extending that one-shot mechanism (awkward — it
+  only runs at chart install) or a new provisioner hitting Langfuse's Admin/Projects API
+  directly (matching the pattern of `cluster/provisioners/` for grocy/matrix/inventree), then
+  reflecting the resulting viewer key into `haku-sandbox` via the standard emberstack
+  pattern. **Open question raised by the kitchen-stocking-subagent plan** (operator,
+  2026-07-11): one shared `haku-workers` project for all zone traffic, or per-domain
+  sub-projects (e.g. a dedicated "Haku kitchen" project) so traces filter cleanly per
+  subagent as more get built? Leaning toward per-domain once there's more than one real
+  workload, but that's a provisioner-design call, not decided here.
 - **Raw worker logs — pre-approved in principle, skipped at v1** (operator, 2026-07-02).
   Traces + status/events + the result blob cover v1; the case they answer poorly is
   "harness stuck vs. waiting on a long job." If that need materializes, grant Haku


### PR DESCRIPTION
## Summary

- New `haku/plans/kitchen_stocking_subagent.md`: a first design pass for a dedicated kitchen/household-stocking subagent, from the operator's own framing (2026-07-11 Haku session). Fleshes out `multi_agent.md`'s deferred "grocery-order bounded-write MCP" line into a fuller shape.
- Cross-linked from `multi_agent.md`'s "New application follow-up" section, matching the existing `local_dispatch_zone.md` pattern.
- Fleshed out `multi_agent.md`'s existing "Langfuse `haku-workers` project + viewer key" TODO with what's concretely missing (only the main LiteLLM instance has the langfuse_otel callback wired; the workers-LiteLLM generator has its own unaddressed `TODO(langfuse)` comment; no Terraform provider for Langfuse projects/keys exists) and added the per-domain-vs-shared-project question the kitchen plan raised.
- Fleshed out `console_mcp_approval_queue.md`'s "Console-as-MCP airlock" placeholder into a concrete design: expose haku-console's existing tool-call submit/list/audit operations (`mcp_approval.py`) as an MCP server over a new public route, following the `tana-mcp-ro` precedent (static bearer, reusing the existing `haku-console-agent-api` token) rather than the operator-OAuth pattern `grocy-sf`/`tana-rw` use (which doesn't fit — there's no "Haku's own identity" concept in this repo). Replaces the pod-curl workaround Haku's web session currently needs for every haku-console call.
- New `haku/plans/claude_code_web_deep_link_delegation.md`: a second coding-delegation path for the operator himself, alongside talking to Claude.ai directly — pre-filled `claude.ai/code?prompt=&repositories=&environment=` links get a session with real `ducktape` git push access, which a plain chat doesn't have. Confirms the mechanism is a real, documented Anthropic feature; scopes it to `ducktape` only (`haku-state` is self-hosted on Forgejo, not GitHub, so it can't be targeted this way); and confirms no new approval plumbing is needed since these are inert links until manually opened in a browser. Cross-linked from `haku/PLAN.md`.

## What's covered

**Kitchen subagent:**
- **Trigger model**: batch-on-change over Grocy's `stock_log`, with two paths — Haku-initiated batching (buildable today, reuses existing dispatch-plane machinery) vs. a real collector/watcher (new infra, closer to the operator's framing but needs a place to run and its own bookmark).
- **Zone/trust fit**: checks the operator's "just use z.ai, low sensitivity" framing against the zai zone's actual "public-by-construction prompts only" classifier policy — household pantry data may not clear that bar, so the oai zone or a local model are flagged as live alternatives.
- **Write surface**: the existing `grocy_mcp/` server is full-read-write per household with no service-account path and no bounded-op tool split — wrong shape to hand a low-trust worker directly. Names the specific ops a bounded surface would want (`stock_add`/`stock_consume`/`shopping_list_items_*`) and the ones it shouldn't have (`product_delete`, arbitrary `entities_*`).
- **Model selection**: the existing `grocy_mcp/eval` harness is already model-agnostic (`--api`/`--model`/`--base-url`) — no new harness code needed to compare cheap/expensive/local models, just a new eval case (batch-reconcile) and a grading step (grading is the one missing piece today).
- **Observability**: needs the (still unbuilt) Langfuse wiring below, not just LiteLLM key metadata — validated the operator's own instinct on this.
- **Open gaps**: no presence/occupancy signal exists yet, Thrive catalog data source is unconfirmed as automated vs. manual, recipe-planning target is seeded by today's hand-curated `kitchen/board.yaml` `make_now` section.

**Console-as-MCP airlock:**
- Confirmed `haku.allegedly.works` has no bearer/API path at all (100% Authentik SSO browser proxy) — a new route is required, not a carve-out.
- Names the exact operations to wrap (submit/list/audit, already implemented in `mcp_approval.py`) and cites `security.md`'s own ownership invariant for why this belongs in haku-console, not Haku's state.

**Claude Code web deep-link delegation:**
- Confirms the URL scheme (`prompt`/`prompt_url`, `repositories`, `environment`) and its one real gap — no branch parameter, so the branch still has to be picked by hand after the session opens.
- Flags that the link must **not** target Haku's own web-home environment (it carries Haku's `SOPS_AGE_KEY` and a scoped domain allowlist) — one open item is left for the operator: naming the actual environment these links should target.
- Confirms no new haku-state frontend work is needed — a plain markdown link already renders as a clickable external `<Anchor>` in the existing renderer (`ui/frontend/src/mdx.tsx`), and no approval gate applies since the link does nothing until a human opens it.

Nothing built in any of the four docs — plan docs only. Status lines make that explicit.

## Test plan

- [x] `pre-commit run` (prettier, ducktape hooks) — clean
- N/A — docs-only change, no code/build/test surface affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
