### PR TITLE
Add Tana tool previews

### DIFF
--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -163,6 +163,7 @@ py_library(
         "//haku/console/tools:google_calendar",
         "//haku/console/tools:grocy",
         "//haku/console/tools:routine",
+        "//haku/console/tools:tana",
         "@pypi//fastapi",
         "@pypi//fastapi_csrf_protect",
         "@pypi//fastmcp",

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -32,6 +32,7 @@ from haku.console.tools import (
     google_calendar as google_calendar_tools,
     grocy as grocy_tools,
     routine as routine_tools,
+    tana as tana_tools,
 )
 
 logger = logging.getLogger(__name__)
@@ -147,6 +148,7 @@ def create_app(settings: Settings) -> FastAPI:
     app.include_router(gmail_tools.router)
     app.include_router(google_calendar_tools.router)
     app.include_router(grocy_tools.router)
+    app.include_router(tana_tools.router)
 
     # Optional direct local/dev fallback. Production serves the SPA from the
     # haku-console-static nginx image and leaves static_dir unset on this process.

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -62,6 +62,15 @@ js_library(
 )
 
 js_library(
+    name = "tana_client",
+    srcs = ["tana_client.ts"],
+    deps = [
+        ":client",
+        ":schema",
+    ],
+)
+
+js_library(
     name = "approval_state",
     srcs = ["approval_state.ts"],
     deps = [
@@ -342,6 +351,7 @@ filegroup(
         "pending_tool_call_actions.tsx",
         "routing.ts",
         "settings_page.tsx",
+        "tana_client.ts",
         "theme.ts",
         "toast.ts",
         "tool_action_line.tsx",
@@ -517,6 +527,7 @@ tsc_bin.tsc_test(
         "//haku/console/frontend/tool_previews:haku_routine_test",
         "//haku/console/frontend/tool_previews:index_test",
         "//haku/console/frontend/tool_previews:kubectl_test",
+        "//haku/console/frontend/tool_previews:tana_test",
         "//haku/console/frontend/tool_previews:variant_test",
     ],
     tags = ["lint"],
@@ -549,6 +560,7 @@ vitest_bin.vitest_test(
         "//haku/console/frontend/tool_previews:haku_routine_test",
         "//haku/console/frontend/tool_previews:index_test",
         "//haku/console/frontend/tool_previews:kubectl_test",
+        "//haku/console/frontend/tool_previews:tana_test",
         "//haku/console/frontend/tool_previews:variant_test",
     ],
 )

--- a/haku/console/frontend/TODO.md
+++ b/haku/console/frontend/TODO.md
@@ -6,12 +6,7 @@
   approve path of the decision endpoint (`mcp_approval.py`) and give the field a neutral
   placeholder when it applies to both outcomes.
 
-- Preview widget for **`tana-rw` › `import_tana_paste`** (`tool_previews/`): render the Tana
-  Paste body (compact = first lines, detailed = full) plus a link to the parent/target node.
-  Blocked on the arg schema — `tana-rw` is a **remote** server (`tana-mcp-facade.allegedly.works`,
-  the `ghcr.io/agentydragon/tana-desktop` image wrapping Tana desktop's own MCP), so the shape
-  isn't in the console's Pydantic models and `tools/list` is OAuth-gated (can't fetch headless).
-  To do it: connect the `tana-rw` MCP account in the console, read the reflected input schema from
-  `GET /api/capabilities/mcp-servers` (or the desktop MCP's `tools/list`), hand-write the matching
-  zod schema (the other remote-server widgets like `kubectl` do this rather than using
-  `schema.zod.ts`), and confirm the Tana node deep-link URL form for the parent-node link.
+- Add previews for the remaining **`tana-rw`** tools: `list_workspaces`, `search_nodes`, `read_node`,
+  `get_children`, `list_tags`, `get_tag_schema`, `tag`, `set_field_option`, `set_field_content`,
+  `create_tag`, `add_field_to_tag`, `set_tag_checkbox`, `check_node`, `uncheck_node`, and `open_node`.
+  The generic JSON preview remains intentional until each has a useful operator-focused rendering.

--- a/haku/console/frontend/screenshots/mock_api.ts
+++ b/haku/console/frontend/screenshots/mock_api.ts
@@ -25,6 +25,15 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promis
   // since the sample uses string names (resolveName returns those as-is).
   if (url.includes("/api/grocy-sf/reference"))
     return jsonResponse({ products: [], quantity_units: [], locations: [], product_groups: [] });
+  if (url.includes("/api/tana-rw/node-previews"))
+    return jsonResponse({
+      nodes: [
+        { id: "inbox", name: "Inbox" },
+        { id: "task", name: "Quarterly planning" },
+        { id: "project", name: "Console project" },
+        { id: "old-parent", name: "Backlog" },
+      ],
+    });
   // The Gmail thread-labels widget looks up subjects/labels for its thread ids.
   if (url.includes("/api/gmail/thread-previews")) return jsonResponse({ threads: SAMPLE_GMAIL_THREADS });
   // The create-event widget resolves a non-primary calendar_id to its display name + link.

--- a/haku/console/frontend/screenshots/render.mjs
+++ b/haku/console/frontend/screenshots/render.mjs
@@ -30,7 +30,7 @@ const SCENES = [
   },
   { name: "settings", viewport: { width: 1200, height: 900 } },
   // Every implemented tool-call preview, compact | detailed side by side — tall, so give it room.
-  { name: "previews", viewport: { width: 1100, height: 3600 } },
+  { name: "previews", viewport: { width: 1100, height: 4800 } },
   // The whole shell chrome: approvals panel open by default; the clicks open the live-offline
   // and location panels (their open state is internal to the chrome) so the shot shows all
   // three surfaces stacked by Y under the toggle-button row.

--- a/haku/console/frontend/screenshots/sample_data.ts
+++ b/haku/console/frontend/screenshots/sample_data.ts
@@ -241,6 +241,40 @@ export const PREVIEW_SAMPLES: { serverId: string; toolName: string; args: Record
     args: { name: "worker-6f9c2", namespace: "haku-sandbox" },
   },
   {
+    serverId: "tana-rw",
+    toolName: "import_tana_paste",
+    args: {
+      parentNodeId: "inbox",
+      content: "- Prepare planning review\n  - Gather Q3 notes\n  - Draft agenda\n  - Confirm attendees",
+    },
+  },
+  {
+    serverId: "tana-rw",
+    toolName: "get_or_create_calendar_node",
+    args: { workspaceId: "workspace", granularity: "day", date: "2026-07-11" },
+  },
+  {
+    serverId: "tana-rw",
+    toolName: "trash_node",
+    args: { nodeId: "task" },
+  },
+  {
+    serverId: "tana-rw",
+    toolName: "edit_node",
+    args: { nodeId: "task", name: { old_string: "Quarterly", new_string: "Q3", replace_all: false } },
+  },
+  {
+    serverId: "tana-rw",
+    toolName: "move_node",
+    args: {
+      nodeId: "task",
+      targetNodeId: "project",
+      sourceParentId: "old-parent",
+      position: "end",
+      keepSourceReference: true,
+    },
+  },
+  {
     // No widget for this (server, tool) — the generic raw-JSON fallback (compact clamps).
     serverId: "grocy-sf",
     toolName: "shopping_list_items_remove",

--- a/haku/console/frontend/tana_client.ts
+++ b/haku/console/frontend/tana_client.ts
@@ -1,0 +1,13 @@
+import { api, errorDetail } from "./client.ts";
+import type { components } from "./api/schema";
+
+export type TanaNodePreview = components["schemas"]["TanaNodePreview"];
+
+export async function fetchTanaNodePreviews(nodeIds: string[]): Promise<Record<string, TanaNodePreview>> {
+  if (nodeIds.length === 0) return {};
+  const { data, error } = await api.GET("/api/tana-rw/node-previews", {
+    params: { query: { node_id: nodeIds } },
+  });
+  if (error || !data) throw new Error(errorDetail(error, "Failed to load Tana node names"));
+  return Object.fromEntries(data.nodes.map((node) => [node.id, node]));
+}

--- a/haku/console/frontend/tool_previews/BUILD.bazel
+++ b/haku/console/frontend/tool_previews/BUILD.bazel
@@ -101,6 +101,20 @@ js_library(
 )
 
 js_library(
+    name = "tana",
+    srcs = ["tana.tsx"],
+    deps = [
+        ":entry",
+        ":variant",
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+        "//:node_modules/zod",
+        "//haku/console/frontend:field",
+        "//haku/console/frontend:tana_client",
+    ],
+)
+
+js_library(
     name = "tool_previews",
     srcs = ["index.tsx"],
     deps = [
@@ -110,6 +124,7 @@ js_library(
         ":grocy",
         ":haku_routine",
         ":kubectl",
+        ":tana",
         ":variant",
         "//:node_modules/react",
     ],
@@ -168,6 +183,15 @@ js_library(
     deps = [
         ":entry",
         ":kubectl",
+    ],
+)
+
+js_library(
+    name = "tana_test",
+    srcs = ["tana.test.ts"],
+    deps = [
+        ":entry",
+        ":tana",
     ],
 )
 

--- a/haku/console/frontend/tool_previews/index.test.ts
+++ b/haku/console/frontend/tool_previews/index.test.ts
@@ -18,6 +18,7 @@ describe("toolPreview registry", () => {
           variant
         )
       ).not.toBeNull();
+      expect(toolPreview("tana-rw", "trash_node", { nodeId: "node" }, variant)).not.toBeNull();
     }
   });
 

--- a/haku/console/frontend/tool_previews/index.tsx
+++ b/haku/console/frontend/tool_previews/index.tsx
@@ -13,6 +13,7 @@ import { GOOGLE_CALENDAR_SERVER_ID, googleCalendarPreviews } from "./google_cale
 import { GROCY_SERVER_ID, grocyPreviews } from "./grocy.tsx";
 import { HAKU_ROUTINE_SERVER_ID, hakuRoutinePreviews } from "./haku_routine.tsx";
 import { KUBECTL_SERVER_ID, kubectlPreviews } from "./kubectl.tsx";
+import { TANA_RW_SERVER_ID, tanaPreviews } from "./tana.tsx";
 import type { PreviewVariant } from "./variant.tsx";
 
 const REGISTRY: Record<string, Record<string, ToolPreview>> = {
@@ -21,6 +22,7 @@ const REGISTRY: Record<string, Record<string, ToolPreview>> = {
   [GROCY_SERVER_ID]: grocyPreviews,
   [HAKU_ROUTINE_SERVER_ID]: hakuRoutinePreviews,
   [KUBECTL_SERVER_ID]: kubectlPreviews,
+  [TANA_RW_SERVER_ID]: tanaPreviews,
 };
 
 export function toolPreview(

--- a/haku/console/frontend/tool_previews/tana.test.ts
+++ b/haku/console/frontend/tool_previews/tana.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { renderPreview } from "./entry.tsx";
+import { tanaPreviews } from "./tana.tsx";
+
+describe("tanaPreviews", () => {
+  it("renders each focused tool in both variants", () => {
+    const cases: [keyof typeof tanaPreviews, Record<string, unknown>][] = [
+      ["import_tana_paste", { parentNodeId: "parent", content: "- One\n  - Two" }],
+      ["get_or_create_calendar_node", { workspaceId: "workspace", granularity: "day", date: "2026-07-11" }],
+      ["trash_node", { nodeId: "node" }],
+      ["edit_node", { nodeId: "node", name: { old_string: "Old", new_string: "New" } }],
+      ["move_node", { nodeId: "node", targetNodeId: "target", position: "end", keepSourceReference: false }],
+    ];
+    for (const [tool, args] of cases) {
+      for (const variant of ["compact", "detailed"] as const) {
+        expect(renderPreview(tanaPreviews[tool], args, variant)).not.toBeNull();
+      }
+    }
+  });
+
+  it("rejects malformed tool arguments", () => {
+    expect(renderPreview(tanaPreviews.move_node, { nodeId: "node" }, "detailed")).toBeNull();
+    expect(renderPreview(tanaPreviews.edit_node, { nodeId: "node" }, "detailed")).toBeNull();
+  });
+
+  it("leaves unimplemented Tana tools unregistered", () => {
+    expect("tag" in tanaPreviews).toBe(false);
+  });
+});

--- a/haku/console/frontend/tool_previews/tana.tsx
+++ b/haku/console/frontend/tool_previews/tana.tsx
@@ -1,0 +1,188 @@
+// Focused previews for the remote, operator-authenticated `tana-rw` MCP server. The
+// desktop-backed server only receives opaque node ids, so the console's narrow
+// node-previews endpoint resolves names through the same operator credential that executes an
+// approved call. It deliberately does not parse Tana Paste or expose a generic MCP proxy.
+
+import { Anchor, Badge, Group, Stack, Text } from "@mantine/core";
+import { useEffect, useState } from "react";
+import { z } from "zod";
+
+import { Field } from "../field.tsx";
+import { fetchTanaNodePreviews, type TanaNodePreview } from "../tana_client.ts";
+import { definePreview, type ToolPreview } from "./entry.tsx";
+import { clampBlock, type PreviewProps } from "./variant.tsx";
+
+export const TANA_RW_SERVER_ID = "tana-rw";
+
+const zEditOperation = z.object({
+  old_string: z.string(),
+  new_string: z.string(),
+  replace_all: z.boolean().optional(),
+});
+
+const zImportTanaPasteArgs = z.object({ parentNodeId: z.string(), content: z.string() });
+const zGetOrCreateCalendarNodeArgs = z.object({
+  workspaceId: z.string(),
+  granularity: z.enum(["day", "week", "month", "year"]),
+  date: z.string().optional(),
+});
+const zTrashNodeArgs = z.object({ nodeId: z.string() });
+const zEditNodeArgs = z
+  .object({ nodeId: z.string(), name: zEditOperation.optional(), description: zEditOperation.optional() })
+  .refine((args) => args.name !== undefined || args.description !== undefined);
+const zMoveNodeArgs = z.object({
+  nodeId: z.string(),
+  targetNodeId: z.string(),
+  sourceParentId: z.string().optional(),
+  position: z.enum(["start", "end", "after", "before"]).default("end"),
+  referenceNodeId: z.string().optional(),
+  keepSourceReference: z.boolean().default(false),
+});
+
+type ImportTanaPasteArgs = z.infer<typeof zImportTanaPasteArgs>;
+type GetOrCreateCalendarNodeArgs = z.infer<typeof zGetOrCreateCalendarNodeArgs>;
+type TrashNodeArgs = z.infer<typeof zTrashNodeArgs>;
+type EditNodeArgs = z.infer<typeof zEditNodeArgs>;
+type MoveNodeArgs = z.infer<typeof zMoveNodeArgs>;
+
+function tanaNodeUrl(nodeId: string): string {
+  return `https://app.tana.inc?nodeid=${encodeURIComponent(nodeId)}`;
+}
+
+function useTanaNodePreviews(nodeIds: string[]): Record<string, TanaNodePreview> | null {
+  const [previews, setPreviews] = useState<Record<string, TanaNodePreview> | null>(null);
+  const key = [...new Set(nodeIds)].sort().join(",");
+
+  useEffect(() => {
+    let alive = true;
+    setPreviews(null);
+    fetchTanaNodePreviews(key === "" ? [] : key.split(",")).then(
+      (result) => {
+        if (alive) setPreviews(result);
+      },
+      () => {
+        if (alive) setPreviews({});
+      }
+    );
+    return () => {
+      alive = false;
+    };
+  }, [key]);
+
+  return previews;
+}
+
+function TanaNodeLink({ nodeId, previews }: { nodeId: string; previews: Record<string, TanaNodePreview> | null }) {
+  const preview = previews?.[nodeId];
+  return preview ? (
+    <Anchor href={tanaNodeUrl(nodeId)} target="_blank" rel="noreferrer" size="sm">
+      {preview.name}
+    </Anchor>
+  ) : (
+    <Text span className="haku-shell-mono" c="dimmed">
+      {nodeId}
+    </Text>
+  );
+}
+
+function ImportTanaPastePreview({ args, variant }: PreviewProps<ImportTanaPasteArgs>) {
+  const previews = useTanaNodePreviews([args.parentNodeId]);
+  const content = variant === "compact" ? clampBlock(args.content, 3) : args.content;
+  return (
+    <Stack gap="xs">
+      <Field label="Under">
+        <TanaNodeLink nodeId={args.parentNodeId} previews={previews} />
+      </Field>
+      <pre className="haku-shell-json">{content}</pre>
+    </Stack>
+  );
+}
+
+function GetOrCreateCalendarNodePreview({ args }: PreviewProps<GetOrCreateCalendarNodeArgs>) {
+  return (
+    <Group gap={6}>
+      <Badge variant="outline">{args.granularity}</Badge>
+      {args.date && <Text>{args.date}</Text>}
+      <Text c="dimmed" className="haku-shell-mono">
+        {args.workspaceId}
+      </Text>
+    </Group>
+  );
+}
+
+function TrashNodePreview({ args }: PreviewProps<TrashNodeArgs>) {
+  const previews = useTanaNodePreviews([args.nodeId]);
+  return <TanaNodeLink nodeId={args.nodeId} previews={previews} />;
+}
+
+function EditOperation({ label, edit }: { label: string; edit: z.infer<typeof zEditOperation> }) {
+  return (
+    <Stack gap={2}>
+      <Text size="sm" fw={600}>
+        {label}
+      </Text>
+      <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>
+        <Text span c="dimmed">
+          {edit.old_string || "(empty)"}
+        </Text>
+        {" → "}
+        {edit.new_string || "(clear)"}
+        {edit.replace_all && (
+          <Text span c="dimmed">
+            {" · all matches"}
+          </Text>
+        )}
+      </Text>
+    </Stack>
+  );
+}
+
+function EditNodePreview({ args }: PreviewProps<EditNodeArgs>) {
+  const previews = useTanaNodePreviews([args.nodeId]);
+  return (
+    <Stack gap="xs">
+      <TanaNodeLink nodeId={args.nodeId} previews={previews} />
+      {args.name && <EditOperation label="Name" edit={args.name} />}
+      {args.description && <EditOperation label="Description" edit={args.description} />}
+    </Stack>
+  );
+}
+
+function MoveNodePreview({ args }: PreviewProps<MoveNodeArgs>) {
+  const previews = useTanaNodePreviews(
+    [args.nodeId, args.targetNodeId, args.sourceParentId, args.referenceNodeId].filter(
+      (id): id is string => id !== undefined
+    )
+  );
+  return (
+    <Stack gap={4}>
+      <Group gap={6}>
+        <TanaNodeLink nodeId={args.nodeId} previews={previews} />
+        <Text c="dimmed">→</Text>
+        <TanaNodeLink nodeId={args.targetNodeId} previews={previews} />
+      </Group>
+      <Group gap={6}>
+        <Badge variant="outline">{args.position}</Badge>
+        {args.referenceNodeId && <TanaNodeLink nodeId={args.referenceNodeId} previews={previews} />}
+        {args.sourceParentId && (
+          <Text size="sm" c="dimmed">
+            from <TanaNodeLink nodeId={args.sourceParentId} previews={previews} />
+          </Text>
+        )}
+        {args.keepSourceReference && <Badge variant="outline">keep reference</Badge>}
+      </Group>
+    </Stack>
+  );
+}
+
+export const tanaPreviews = {
+  import_tana_paste: definePreview(zImportTanaPasteArgs, ImportTanaPastePreview, () => ({
+    text: "Tana: Import content",
+  })),
+  get_or_create_calendar_node: definePreview(zGetOrCreateCalendarNodeArgs, GetOrCreateCalendarNodePreview, () => ({
+    text: "Tana: Get or create calendar node",
+  })),
+  trash_node: definePreview(zTrashNodeArgs, TrashNodePreview, () => ({ text: "Tana: Trash node", destructive: true })),
+  edit_node: definePreview(zEditNodeArgs, EditNodePreview, () => ({ text: "Tana: Edit node" })),
+  move_node: definePreview(zMoveNodeArgs, MoveNodePreview, () => ({ text: "Tana: Move node" })),
+} satisfies Record<string, ToolPreview>;

--- a/haku/console/tools/BUILD.bazel
+++ b/haku/console/tools/BUILD.bazel
@@ -62,6 +62,19 @@ py_library(
 )
 
 py_library(
+    name = "tana",
+    srcs = ["tana.py"],
+    visibility = ["//haku/console:__subpackages__"],
+    deps = [
+        "//haku/console:deps",
+        "//haku/console:mcp_approval",
+        "//haku/console:mcp_operator_oauth",
+        "@pypi//fastapi",
+        "@pypi//pydantic",
+    ],
+)
+
+py_library(
     name = "routine",
     srcs = ["routine.py"],
     visibility = ["//haku/console:__subpackages__"],
@@ -90,6 +103,16 @@ py_test(
         # needs the plugin importable at runtime for its entry-point autoload; Gazelle
         # can't see that and will try to drop this dep on regen.
         "@pypi//pytest_asyncio",
+    ],
+)
+
+py_test(
+    name = "test_tana",
+    srcs = ["test_tana.py"],
+    deps = [
+        ":tana",
+        "//:conftest",
+        "@pypi//pytest_bazel",
     ],
 )
 

--- a/haku/console/tools/tana.py
+++ b/haku/console/tools/tana.py
@@ -1,0 +1,70 @@
+"""Tana node-name lookup for haku-console approval previews."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Annotated, Any, cast
+
+from fastapi import APIRouter, Query, Request
+from pydantic import BaseModel
+
+from haku.console.deps import SettingsDep
+from haku.console.mcp_approval import operator_authenticated_client
+from haku.console.mcp_operator_oauth import OAuthStoreDep
+
+TANA_RW_SERVER_ID = "tana-rw"
+
+router = APIRouter(prefix="/api/tana-rw", tags=["tana"])
+
+
+class TanaNodePreview(BaseModel):
+    id: str
+    name: str
+
+
+class TanaNodePreviewsResponse(BaseModel):
+    nodes: list[TanaNodePreview]
+
+
+_NODE_MARKER_RE = re.compile(r"^(?P<name>.*?)\s*<!-- node-id: (?P<id>[^ ]+) -->\s*$", re.MULTILINE)
+_BULLET_PREFIX_RE = re.compile(r"^\s*(?:-\s+)?(?:\[[ Xx]\]\s+)?")
+
+
+def node_name_from_markdown(markdown: str, node_id: str) -> str | None:
+    """Extract a node's displayed name from Tana's read_node markdown response."""
+    for match in _NODE_MARKER_RE.finditer(markdown):
+        if match["id"] == node_id:
+            name = _BULLET_PREFIX_RE.sub("", match["name"]).strip()
+            return name or None
+    return None
+
+
+def _tool_result_text(result: Any) -> str | None:
+    for content in cast(list[Any], result.content):
+        if getattr(content, "type", None) == "text":
+            return cast(str, content.text)
+    return None
+
+
+async def _read_node_preview(client: Any, node_id: str) -> TanaNodePreview | None:
+    try:
+        result = await client.call_tool("read_node", {"nodeId": node_id, "maxDepth": 0})
+    except Exception:
+        return None
+    markdown = _tool_result_text(result)
+    if markdown is None:
+        return None
+    name = node_name_from_markdown(markdown, node_id)
+    return TanaNodePreview(id=node_id, name=name) if name is not None else None
+
+
+@router.get("/node-previews")
+async def tana_node_previews(
+    request: Request, settings: SettingsDep, oauth_store: OAuthStoreDep, node_id: Annotated[list[str], Query()]
+) -> TanaNodePreviewsResponse:
+    """Resolve Tana node IDs for preview display through the approving operator's account."""
+    node_ids = list(dict.fromkeys(node_id))
+    async with await operator_authenticated_client(TANA_RW_SERVER_ID, request, settings, oauth_store) as client:
+        previews = await asyncio.gather(*(_read_node_preview(client, id_) for id_ in node_ids))
+    return TanaNodePreviewsResponse(nodes=[preview for preview in previews if preview is not None])

--- a/haku/console/tools/test_tana.py
+++ b/haku/console/tools/test_tana.py
@@ -1,0 +1,33 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest_bazel
+
+from haku.console.tools.tana import _read_node_preview, node_name_from_markdown
+
+
+def test_node_name_from_markdown_reads_the_matching_node_marker() -> None:
+    markdown = "- [ ] First node <!-- node-id: other -->\n- Target node #Task <!-- node-id: target -->"
+    assert node_name_from_markdown(markdown, "target") == "Target node #Task"
+
+
+def test_node_name_from_markdown_returns_none_without_the_requested_marker() -> None:
+    assert node_name_from_markdown("- A node <!-- node-id: other -->", "target") is None
+
+
+def test_read_node_preview_uses_a_depth_zero_read_and_ignores_unresolved_nodes() -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    class Client:
+        async def call_tool(self, name: str, arguments: dict[str, object]) -> object:
+            calls.append((name, arguments))
+            return SimpleNamespace(content=[SimpleNamespace(type="text", text="- Target <!-- node-id: target -->")])
+
+    preview = asyncio.run(_read_node_preview(Client(), "target"))
+    assert preview is not None
+    assert preview.name == "Target"
+    assert calls == [("read_node", {"nodeId": "target", "maxDepth": 0})]
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary

- add focused Tana approval previews for import, calendar nodes, trash, edit, and move
- resolve referenced Tana node IDs through the approving operator's linked MCP account and link them to Tana
- add gallery samples, remaining-preview follow-ups, and enough screenshot height to show every widget

## Validation

- `bbr test //haku/console/tools:test_tana //haku/console/frontend:tsc_test //haku/console/frontend:bridge_test`
- `bbr test //haku/console/frontend:screenshots`
- inspected light and dark screenshot output
