### PR TITLE
Size console drawers to content

### DIFF
--- a/haku/console/frontend/README.md
+++ b/haku/console/frontend/README.md
@@ -21,9 +21,10 @@ components + **Tailwind v4** utilities — modeled on
   semantic color cues (red pending count, orange offline, green live-location dot): approvals (a
   checklist), settings (a gear), plus a crossed-wifi live-offline warning when the event socket
   is down and a location pin while the standing grant is held. Below the toolbar, the open panels
-  stack: the approvals panel (queue + a Past-tool-calls link) flexes to fill and scrolls its
-  list; the smaller settings (MCP accounts), location (stop/withdraw), and live-offline panels
-  take their natural height beneath it. Opening several shows them stacked, not overlapping.
+  stack: the approvals panel (queue + a Past-tool-calls link) follows its content until it reaches
+  the available height, then scrolls its list; settings (MCP accounts) behaves the same way, while
+  location (stop/withdraw) and live-offline panels take their natural height beneath them. Opening
+  several shows them stacked, not overlapping.
 - `settings_page.tsx` — `SettingsPanel`, the operator settings drawer (a `ShellChrome` panel
   toggled from the toolbar's gear): MCP operator account connect/reconnect/disconnect. It's a
   chrome drawer, not a route, so it stacks alongside the other panels.

--- a/haku/console/frontend/console_panel.tsx
+++ b/haku/console/frontend/console_panel.tsx
@@ -305,11 +305,9 @@ function ApprovalsTab({
   return (
     <Stack gap="md">
       {!hasPending && !hasRecent && (
-        <section className="haku-shell-card">
-          <Text size="sm" c="dimmed">
-            No approvals pending.
-          </Text>
-        </section>
+        <Text size="sm" c="dimmed">
+          No approvals pending.
+        </Text>
       )}
       {hasPending && (
         <Stack gap="xs">
@@ -357,8 +355,8 @@ function ApprovalsTab({
 }
 
 // The approvals panel — the primary chrome surface. One block in the chrome column (below the
-// toolbar), it flexes to fill the column's height and scrolls its own list, so the smaller
-// settings/location/live panels can stack beneath it rather than being covered.
+// toolbar), it follows its content up to the available height and then scrolls its own list, so
+// the smaller settings/location/live panels can stack beneath it rather than being covered.
 function ApprovalsPanel(props: ShellChromeProps) {
   const pendingCount = props.pendingApprovals.length + props.geolocationApprovals.length;
   return (
@@ -420,8 +418,8 @@ function ChromeToggle({
 // The persistent shell chrome over the framed haku-ui: a floating top-right **toolbar** of
 // toggle buttons (squished together, no gaps) over a column that stacks its open panels **by
 // Y**, never by z-index. Each button is `filled` while its panel is open; opening more than one
-// panel stacks them vertically under the toolbar — the approvals panel flexes to fill remaining
-// height and scrolls internally, the smaller settings/location/live panels take their natural
+// panel stacks them vertically under the toolbar — the approvals panel follows its content up to
+// the available height and scrolls internally, while settings/location/live take their natural
 // height beneath it — so panels share the column instead of floating over one another. Toggles
 // are neutral gray; only genuinely semantic cues keep a color (red pending count, orange
 // offline, green live-location dot).

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -150,22 +150,23 @@
   pointer-events: auto;
 }
 
-/* The approvals panel flexes to fill the column and scrolls its own list, so the smaller side
-   panels stacked beneath it stay reachable rather than being pushed off-screen. */
+/* The approvals panel follows its content until the column runs out of room, then shrinks and
+   scrolls its list so smaller side panels remain reachable. */
 .haku-shell-approvals {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-height: 0;
+  max-height: 100%;
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
 }
 
-/* Settings panel: bounded so it can't hog the column when opened alongside approvals; its own
-   list scrolls inside. */
+/* The settings panel has the same content-sized behavior: only shrink and scroll its list when
+   the available column height constrains it. */
 .haku-shell-settings {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
   min-height: 0;
-  max-height: 45vh;
+  max-height: 100%;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;


### PR DESCRIPTION
## What changed

- render the empty approvals message directly in the approvals drawer instead of inside a nested card
- size the approvals and settings drawers to their content
- cap both drawers at the available column height and scroll their contents only when constrained

## Why

The empty approvals state had an unnecessary inner box, and both drawers occupied fixed or excess vertical space regardless of their content.

## Impact

The drawers stay compact for short and empty states while retaining scrolling for long approval queues and settings lists.

## Validation

- `bbr test //haku/console/frontend:screenshots`
- visually inspected all generated light and dark screenshots for chrome, history, previews, and settings
- pre-commit hooks passed