### PR TITLE
grocy: make the ADMIN permission grant actually grant everything

### DIFF
--- a/cluster/k8s/grocy/user-perms-base/policy.yaml
+++ b/cluster/k8s/grocy/user-perms-base/policy.yaml
@@ -3,7 +3,11 @@
 # converges each listed user to exactly this permission set, creating the user if
 # absent. Unlisted users are untouched — born read-only via
 # DEFAULT_PERMISSIONS=none (../app-base). Permission names are rows of
-# Grocy's permission_hierarchy table; ADMIN is the root and implies everything else.
+# Grocy's permission_hierarchy table. "ADMIN" here means "grant every permission
+# Grocy knows about" — provision.py expands it to the full explicit set rather than
+# relying on Grocy's own hierarchy resolution, which was observed live (2026-07-12) to
+# NOT treat holding just the ADMIN row as satisfying descendant checks
+# (MASTER_DATA_EDIT/STOCK_PURCHASE 403'd for a user converged to exactly {ADMIN}).
 users:
   agentydragon: [ADMIN]
   auragon: [ADMIN]

--- a/cluster/k8s/grocy/user-perms-base/policy.yaml
+++ b/cluster/k8s/grocy/user-perms-base/policy.yaml
@@ -2,14 +2,53 @@
 # The reconciler (provision.py; per-household bootstrap Job + daily CronJob)
 # converges each listed user to exactly this permission set, creating the user if
 # absent. Unlisted users are untouched — born read-only via
-# DEFAULT_PERMISSIONS=none (../app-base). Permission names are rows of
-# Grocy's permission_hierarchy table. "ADMIN" here means "grant every permission
-# Grocy knows about" — provision.py expands it to the full explicit set rather than
-# relying on Grocy's own hierarchy resolution, which was observed live (2026-07-12) to
-# NOT treat holding just the ADMIN row as satisfying descendant checks
-# (MASTER_DATA_EDIT/STOCK_PURCHASE 403'd for a user converged to exactly {ADMIN}).
+# DEFAULT_PERMISSIONS=none (../app-base). Permission names are rows of Grocy's
+# permission_hierarchy table (GET /api/objects/permission_hierarchy) — the reconciler
+# validates every name against that table live and fails loud on a typo.
+#
+# Every permission is listed explicitly per user, not just "ADMIN": Grocy's own runtime
+# check (`User::HasPermission`) does an exact-name lookup, not a hierarchy walk — holding
+# only the ADMIN row does NOT satisfy a check for a descendant permission like
+# MASTER_DATA_EDIT or STOCK_PURCHASE (confirmed live, 2026-07-12: a user converged to
+# exactly {ADMIN} still 403'd on both). So "full access" means every row below, not the
+# one ADMIN row. Keep this list in sync with `permission_hierarchy` if Grocy ever adds a
+# new permission (the reconciler's upfront validation will fail loud if it's missing here
+# but referenced by a user, but not the reverse — a new permission just sits ungranted
+# until added here).
+full_access: &full_access
+  - ADMIN
+  - USERS
+  - USERS_CREATE
+  - USERS_EDIT
+  - USERS_READ
+  - USERS_EDIT_SELF
+  - STOCK
+  - SHOPPINGLIST
+  - RECIPES
+  - CHORES
+  - BATTERIES
+  - TASKS
+  - EQUIPMENT
+  - CALENDAR
+  - STOCK_PURCHASE
+  - STOCK_CONSUME
+  - STOCK_INVENTORY
+  - STOCK_TRANSFER
+  - STOCK_OPEN
+  - STOCK_EDIT
+  - SHOPPINGLIST_ITEMS_ADD
+  - SHOPPINGLIST_ITEMS_DELETE
+  - RECIPES_MEALPLAN
+  - CHORE_TRACK_EXECUTION
+  - CHORE_UNDO_EXECUTION
+  - BATTERIES_TRACK_CHARGE_CYCLE
+  - BATTERIES_UNDO_CHARGE_CYCLE
+  - TASKS_UNDO_EXECUTION
+  - TASKS_MARK_COMPLETED
+  - MASTER_DATA_EDIT
+
 users:
-  agentydragon: [ADMIN]
-  auragon: [ADMIN]
+  agentydragon: *full_access
+  auragon: *full_access
   # Explicitly empty: haku stays read-only, converged back even if elevated in the UI.
   haku: []

--- a/cluster/provisioners/grocy_user_perms/provision.py
+++ b/cluster/provisioners/grocy_user_perms/provision.py
@@ -76,10 +76,22 @@ def reconcile(client: httpx.Client, policy: Policy) -> None:
         if username not in user_ids:
             raise RuntimeError(f"{username!r} user was not created by the reverse-proxy auth")
         user_id = user_ids[username]
-        desired = {permission_ids[name] for name in permission_names}
+        # "ADMIN" is documented as permission_hierarchy's root and every other permission's
+        # ancestor, but Grocy's own runtime check (`User::HasPermission`, via the
+        # `user_permissions_resolved` view) does an exact-name lookup — holding just ADMIN's
+        # row does NOT reliably satisfy a descendant check in practice (observed live,
+        # 2026-07-12: an agentydragon/auragon user converged to exactly {ADMIN} still 403'd
+        # Grocy's own API on MASTER_DATA_EDIT and STOCK_PURCHASE). Don't depend on Grocy
+        # resolving the hierarchy itself — when "ADMIN" is requested, grant literally every
+        # known permission explicitly, so "ADMIN" means everything regardless.
+        desired = (
+            set(permission_ids.values())
+            if "ADMIN" in permission_names
+            else {permission_ids[name] for name in permission_names}
+        )
         current = {int(row["permission_id"]) for row in get_json(client, f"/api/users/{user_id}/permissions")}
         if current == desired:
-            print(f"{username!r} (id={user_id}) already at {sorted(permission_names)}")
+            print(f"{username!r} (id={user_id}) already at {sorted(permission_names)} ({len(desired)} permission ids)")
             continue
         client.put(f"/api/users/{user_id}/permissions", json={"permissions": sorted(desired)}).raise_for_status()
         print(

--- a/cluster/provisioners/grocy_user_perms/provision.py
+++ b/cluster/provisioners/grocy_user_perms/provision.py
@@ -76,22 +76,10 @@ def reconcile(client: httpx.Client, policy: Policy) -> None:
         if username not in user_ids:
             raise RuntimeError(f"{username!r} user was not created by the reverse-proxy auth")
         user_id = user_ids[username]
-        # "ADMIN" is documented as permission_hierarchy's root and every other permission's
-        # ancestor, but Grocy's own runtime check (`User::HasPermission`, via the
-        # `user_permissions_resolved` view) does an exact-name lookup — holding just ADMIN's
-        # row does NOT reliably satisfy a descendant check in practice (observed live,
-        # 2026-07-12: an agentydragon/auragon user converged to exactly {ADMIN} still 403'd
-        # Grocy's own API on MASTER_DATA_EDIT and STOCK_PURCHASE). Don't depend on Grocy
-        # resolving the hierarchy itself — when "ADMIN" is requested, grant literally every
-        # known permission explicitly, so "ADMIN" means everything regardless.
-        desired = (
-            set(permission_ids.values())
-            if "ADMIN" in permission_names
-            else {permission_ids[name] for name in permission_names}
-        )
+        desired = {permission_ids[name] for name in permission_names}
         current = {int(row["permission_id"]) for row in get_json(client, f"/api/users/{user_id}/permissions")}
         if current == desired:
-            print(f"{username!r} (id={user_id}) already at {sorted(permission_names)} ({len(desired)} permission ids)")
+            print(f"{username!r} (id={user_id}) already at {sorted(permission_names)}")
             continue
         client.put(f"/api/users/{user_id}/permissions", json={"permissions": sorted(desired)}).raise_for_status()
         print(

--- a/cluster/provisioners/grocy_user_perms/test_provision.py
+++ b/cluster/provisioners/grocy_user_perms/test_provision.py
@@ -54,28 +54,27 @@ def make_client(fake: FakeGrocy) -> httpx.Client:
     return httpx.Client(base_url="http://grocy", transport=httpx.MockTransport(fake.handler))
 
 
-def test_admin_expands_to_every_known_permission():
-    # "ADMIN" doesn't just grant the ADMIN row -- Grocy's own runtime permission check
-    # does an exact-name lookup (via user_permissions_resolved), not hierarchy resolution,
-    # so ADMIN must expand to literally every permission_hierarchy id to mean "everything".
-    # agentydragon holds only the ADMIN row (drift, PUT to the full set), haku wrongly
-    # elevated (PUT back to empty), auragon absent (auto-created, then PUT to the full set).
-    fake = FakeGrocy({"agentydragon": {1}, "haku": {2}})
-    reconcile(make_client(fake), Policy(users={"agentydragon": {"ADMIN"}, "auragon": {"ADMIN"}, "haku": set()}))
-    assert fake.puts == {"agentydragon": [1, 2], "auragon": [1, 2], "haku": []}
+def test_converges_only_drifted_users():
+    # agentydragon already at its full explicit set (no PUT), haku wrongly elevated
+    # (PUT back to empty), auragon absent (auto-created, then PUT to its full set).
+    fake = FakeGrocy({"agentydragon": {1, 2}, "haku": {2}})
+    reconcile(
+        make_client(fake),
+        Policy(
+            users={
+                "agentydragon": {"ADMIN", "MASTER_DATA_EDIT"},
+                "auragon": {"ADMIN", "MASTER_DATA_EDIT"},
+                "haku": set(),
+            }
+        ),
+    )
+    assert fake.puts == {"auragon": [1, 2], "haku": []}
     assert fake.user_permissions == {"agentydragon": {1, 2}, "auragon": {1, 2}, "haku": set()}
-
-
-def test_admin_user_already_at_full_set_is_not_repeatedly_put():
-    fake = FakeGrocy({"agentydragon": {1, 2}})
-    reconcile(make_client(fake), Policy(users={"agentydragon": {"ADMIN"}}))
-    assert fake.puts == {}
-    assert fake.user_permissions["agentydragon"] == {1, 2}
 
 
 def test_unlisted_users_untouched():
     fake = FakeGrocy({"agentydragon": {1, 2}, "bystander": {2}})
-    reconcile(make_client(fake), Policy(users={"agentydragon": {"ADMIN"}}))
+    reconcile(make_client(fake), Policy(users={"agentydragon": {"ADMIN", "MASTER_DATA_EDIT"}}))
     assert fake.puts == {}
     assert fake.user_permissions["bystander"] == {2}
 

--- a/cluster/provisioners/grocy_user_perms/test_provision.py
+++ b/cluster/provisioners/grocy_user_perms/test_provision.py
@@ -54,17 +54,27 @@ def make_client(fake: FakeGrocy) -> httpx.Client:
     return httpx.Client(base_url="http://grocy", transport=httpx.MockTransport(fake.handler))
 
 
-def test_converges_only_drifted_users():
-    # agentydragon already ADMIN (no PUT), haku wrongly elevated (PUT back to
-    # empty), auragon absent (auto-created, then PUT to ADMIN).
+def test_admin_expands_to_every_known_permission():
+    # "ADMIN" doesn't just grant the ADMIN row -- Grocy's own runtime permission check
+    # does an exact-name lookup (via user_permissions_resolved), not hierarchy resolution,
+    # so ADMIN must expand to literally every permission_hierarchy id to mean "everything".
+    # agentydragon holds only the ADMIN row (drift, PUT to the full set), haku wrongly
+    # elevated (PUT back to empty), auragon absent (auto-created, then PUT to the full set).
     fake = FakeGrocy({"agentydragon": {1}, "haku": {2}})
     reconcile(make_client(fake), Policy(users={"agentydragon": {"ADMIN"}, "auragon": {"ADMIN"}, "haku": set()}))
-    assert fake.puts == {"auragon": [1], "haku": []}
-    assert fake.user_permissions == {"agentydragon": {1}, "auragon": {1}, "haku": set()}
+    assert fake.puts == {"agentydragon": [1, 2], "auragon": [1, 2], "haku": []}
+    assert fake.user_permissions == {"agentydragon": {1, 2}, "auragon": {1, 2}, "haku": set()}
+
+
+def test_admin_user_already_at_full_set_is_not_repeatedly_put():
+    fake = FakeGrocy({"agentydragon": {1, 2}})
+    reconcile(make_client(fake), Policy(users={"agentydragon": {"ADMIN"}}))
+    assert fake.puts == {}
+    assert fake.user_permissions["agentydragon"] == {1, 2}
 
 
 def test_unlisted_users_untouched():
-    fake = FakeGrocy({"agentydragon": {1}, "bystander": {2}})
+    fake = FakeGrocy({"agentydragon": {1, 2}, "bystander": {2}})
     reconcile(make_client(fake), Policy(users={"agentydragon": {"ADMIN"}}))
     assert fake.puts == {}
     assert fake.user_permissions["bystander"] == {2}


### PR DESCRIPTION
## Summary

- Root cause of tonight's repeated 403s on Grocy writes: the user-permissions reconciler (`cluster/provisioners/grocy_user_perms/provision.py`) declares `agentydragon`/`auragon` as `{ADMIN}`, and `cluster/k8s/grocy/user-perms-base/policy.yaml`'s comment assumed Grocy's own `permission_hierarchy` resolves that to every descendant permission (`ADMIN` is the hierarchy's root node, parent of `STOCK` → `STOCK_PURCHASE`, `SHOPPINGLIST`, etc.).
- Verified this assumption doesn't hold in practice, two ways:
  - **Grocy's own source** (`controllers/Users/User.php`): `HasPermission()` queries the `user_permissions_resolved` view by exact permission name — no hierarchy walk in the PHP layer.
  - **Live behavior tonight**: the reconciler's CronJob/bootstrap Job both completed successfully (exit 0) converging `agentydragon` to exactly `{ADMIN}`, yet real Grocy API calls authenticated as `agentydragon` (via the `grocy-sf` operator-OAuth chain) 403'd repeatedly on `MASTER_DATA_EDIT`, `SHOPPINGLIST_ITEMS_ADD`, and `STOCK_PURCHASE`.
- **Fix (per operator feedback):** rather than making the reconciler special-case `"ADMIN"` to silently mean "everything" (which would make the config's meaning diverge from what Grocy itself means by ADMIN), `provision.py` stays exactly as it was — `desired` is always precisely the named permissions, no magic. Instead, `cluster/k8s/grocy/user-perms-base/policy.yaml` now lists **every one of Grocy's 30 current `permission_hierarchy` names explicitly** for `agentydragon` and `auragon`, via a YAML anchor (`&full_access`/`*full_access`) so the list isn't duplicated. The config itself is now the readable, explicit source of truth for what "full access" means.
- Takes effect automatically on the next reconciler run once this deploys — the daily CronJob, or immediately via the policy-hash Flux force-annotation on the bootstrap Job (per `provision.py`'s own docstring).

## What's covered

- `cluster/k8s/grocy/user-perms-base/policy.yaml`: `agentydragon`/`auragon` each now list all 30 permission names (`ADMIN`, `USERS`, `USERS_CREATE`, `USERS_EDIT`, `USERS_READ`, `USERS_EDIT_SELF`, `STOCK`, `SHOPPINGLIST`, `RECIPES`, `CHORES`, `BATTERIES`, `TASKS`, `EQUIPMENT`, `CALENDAR`, `STOCK_PURCHASE`, `STOCK_CONSUME`, `STOCK_INVENTORY`, `STOCK_TRANSFER`, `STOCK_OPEN`, `STOCK_EDIT`, `SHOPPINGLIST_ITEMS_ADD`, `SHOPPINGLIST_ITEMS_DELETE`, `RECIPES_MEALPLAN`, `CHORE_TRACK_EXECUTION`, `CHORE_UNDO_EXECUTION`, `BATTERIES_TRACK_CHARGE_CYCLE`, `BATTERIES_UNDO_CHARGE_CYCLE`, `TASKS_UNDO_EXECUTION`, `TASKS_MARK_COMPLETED`, `MASTER_DATA_EDIT`), fetched live from the deployed Grocy instance's own `/api/objects/permission_hierarchy`.
- `cluster/provisioners/grocy_user_perms/provision.py`: unchanged from `devel` — no ADMIN special-casing.
- `cluster/provisioners/grocy_user_perms/test_provision.py`: tests updated to reflect the multi-permission-name policy shape (no behavior change to assert beyond what was already there — drift-only-converges, unlisted-users-untouched, unknown-permission-name-rejected).

## Test plan

- [x] `pre-commit run` (ruff, prettier, ducktape hooks) — clean
- [x] Traced both tests by hand against the fake Grocy transport (no local Python env with `httpx`/`pytest` available in this session to execute directly — Bazel is blocked from `forgejo-http.forgejo:3000`, cluster-internal only)
- [x] Verified the YAML anchor/alias resolves correctly with `yaml.safe_load` (both users get the identical 30-item list) and that `Policy.model_validate` ignores the extra top-level `full_access` key (Pydantic v2 default `extra='ignore'`)
- [ ] Real verification: once deployed, re-attempt a Grocy write (`stock_add`/`products_create`) as `agentydragon` and confirm it no longer 403s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
