### PR TITLE
Remove MCP account reconnect flow

### DIFF
--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -70,12 +70,13 @@ Core endpoints:
 - `GET /api/capabilities/mcp-servers` — reflect the configured connected MCP servers and each
   server's `tools/list` metadata. Entries are explicitly `alive` or `degraded`; the console config
   names reachable servers, and each live MCP server remains the tool schema source.
-- `GET /api/mcp/operator-auth`, `POST /api/mcp/operator-auth/{server_id}/start`,
+- `GET /api/mcp/operator-auth`, `POST /api/mcp/operator-auth/{server_id}/connect`,
   `DELETE /api/mcp/operator-auth/{server_id}`, and `GET /api/mcp/operator-auth/callback` —
   operator account association for MCP servers whose config enables `operator_oauth` (this flow
   lives in `mcp_operator_oauth.py`, not the approval router). The catalog stays in the console
   YAML/ConfigMap; Postgres stores only short-lived DCR/PKCE flow state and per-operator token
   associations.
+  Connecting is available only while unconnected; disconnect first to replace an account link.
 - `POST /api/tool-calls` — submit a call with `server_id`, `tool_name`, exact
   `arguments`, and explicit `wait_for_ms`. The console mints the canonical `tool_call_id`.
 - `GET /api/approvals/pending`, `GET /api/approvals/events?after_event_id=...`, and

--- a/haku/console/frontend/client.ts
+++ b/haku/console/frontend/client.ts
@@ -17,7 +17,7 @@ export type ToolCallRecord = components["schemas"]["ToolCallRecord"];
 export type McpOperatorAuthStatus =
   | components["schemas"]["McpOperatorAuthConnected"]
   | components["schemas"]["McpOperatorAuthUnconnected"];
-export type McpOperatorAuthStartResponse = components["schemas"]["McpOperatorAuthStartResponse"];
+export type McpOperatorAuthConnectResponse = components["schemas"]["McpOperatorAuthConnectResponse"];
 
 // FastAPI error responses are `{detail: string}`; surface that real reason rather
 // than a generic message, falling back when the body isn't shaped that way. Exported
@@ -77,9 +77,9 @@ export async function fetchMcpOperatorAuthStatuses(): Promise<McpOperatorAuthSta
   return data.associations ?? [];
 }
 
-export async function startMcpOperatorAuth(serverId: string): Promise<McpOperatorAuthStartResponse> {
+export async function connectMcpOperatorAuth(serverId: string): Promise<McpOperatorAuthConnectResponse> {
   const csrfToken = await fetchCsrfToken();
-  const { data, error } = await api.POST("/api/mcp/operator-auth/{server_id}/start", {
+  const { data, error } = await api.POST("/api/mcp/operator-auth/{server_id}/connect", {
     params: { path: { server_id: serverId } },
     headers: { "X-CSRF-Token": csrfToken },
   });

--- a/haku/console/frontend/settings_page.tsx
+++ b/haku/console/frontend/settings_page.tsx
@@ -6,7 +6,7 @@ import {
   disconnectMcpOperatorAuth,
   fetchMcpOperatorAuthStatuses,
   type McpOperatorAuthStatus,
-  startMcpOperatorAuth,
+  connectMcpOperatorAuth,
 } from "./client.ts";
 import { openExternal, POPUP_HINT } from "./open_external.ts";
 import { toastError, toastSuccess } from "./toast.ts";
@@ -43,14 +43,9 @@ function McpAccountCard({
       </Group>
       <Group justify="flex-end" gap="xs" mt="sm">
         {connected ? (
-          <>
-            <Button size="compact-sm" variant="light" onClick={onConnect}>
-              Reconnect
-            </Button>
-            <Button size="compact-sm" variant="subtle" color="red" onClick={onDisconnect}>
-              Disconnect
-            </Button>
-          </>
+          <Button size="compact-sm" variant="subtle" color="red" onClick={onDisconnect}>
+            Disconnect
+          </Button>
         ) : (
           <Button size="compact-sm" variant="light" onClick={onConnect}>
             Connect
@@ -98,7 +93,7 @@ export function SettingsPanel() {
   }, [load]);
 
   function connect(serverId: string) {
-    startMcpOperatorAuth(serverId).then(
+    connectMcpOperatorAuth(serverId).then(
       (started) => {
         if (!openExternal(started.authorization_url)) {
           toastError("Pop-up blocked", POPUP_HINT);

--- a/haku/console/mcp_operator_oauth.py
+++ b/haku/console/mcp_operator_oauth.py
@@ -95,7 +95,7 @@ class McpOperatorAuthStatusResponse(BaseModel):
     associations: list[McpOperatorAuthStatus] = Field(default_factory=list)
 
 
-class McpOperatorAuthStartResponse(BaseModel):
+class McpOperatorAuthConnectResponse(BaseModel):
     server_id: str
     authorization_url: str
     expires_at: datetime.datetime
@@ -200,11 +200,17 @@ class PostgresMcpOperatorOAuthStore:
             ]
         )
 
-    async def start_flow(
+    async def connect_flow(
         self, *, server: McpServerEntry, operator_principal: str, public_base_url: str
-    ) -> McpOperatorAuthStartResponse:
+    ) -> McpOperatorAuthConnectResponse:
         if not _operator_oauth_enabled(server):
             raise HTTPException(status_code=404, detail=f"MCP server {server.id} does not use operator OAuth")
+        with self._sessions.begin() as session:
+            existing = session.get(McpOperatorOAuthAssociation, (server.id, operator_principal))
+            if existing is not None:
+                raise HTTPException(
+                    status_code=409, detail=f"MCP server {server.id} is already connected; disconnect it first"
+                )
         flow = await _build_operator_oauth_flow(server, public_base_url.rstrip("/"))
         with self._sessions.begin() as session:
             now = datetime.datetime.now(datetime.UTC)
@@ -232,7 +238,7 @@ class PostgresMcpOperatorOAuthStore:
                     scope=flow.scope,
                 )
             )
-        return McpOperatorAuthStartResponse(
+        return McpOperatorAuthConnectResponse(
             server_id=server.id, authorization_url=flow.authorization_url, expires_at=flow.expires_at
         )
 
@@ -251,38 +257,28 @@ class PostgresMcpOperatorOAuthStore:
             existing = session.get(
                 McpOperatorOAuthAssociation, (flow.server_id, flow.operator_principal), with_for_update=True
             )
-            if existing is None:
-                existing = McpOperatorOAuthAssociation(
-                    server_id=flow.server_id,
-                    operator_principal=flow.operator_principal,
-                    created_at=now,
-                    updated_at=now,
-                    client_id=flow.client_id,
-                    client_secret=flow.client_secret,
-                    client_secret_expires_at=flow.client_secret_expires_at,
-                    token_endpoint_auth_method=flow.token_endpoint_auth_method,
-                    token_endpoint=flow.token_endpoint,
-                    resource=flow.resource,
-                    access_token=token.access_token,
-                    refresh_token=token.refresh_token,
-                    token_type=token.token_type,
-                    scope=token.scope or flow.scope,
-                    token_expires_at=token_expires_at,
+            if existing is not None:
+                raise HTTPException(
+                    status_code=409, detail=f"MCP server {flow.server_id} is already connected; disconnect it first"
                 )
-                session.add(existing)
-            else:
-                existing.updated_at = now
-                existing.client_id = flow.client_id
-                existing.client_secret = flow.client_secret
-                existing.client_secret_expires_at = flow.client_secret_expires_at
-                existing.token_endpoint_auth_method = flow.token_endpoint_auth_method
-                existing.token_endpoint = flow.token_endpoint
-                existing.resource = flow.resource
-                existing.access_token = token.access_token
-                existing.refresh_token = token.refresh_token
-                existing.token_type = token.token_type
-                existing.scope = token.scope or flow.scope
-                existing.token_expires_at = token_expires_at
+            existing = McpOperatorOAuthAssociation(
+                server_id=flow.server_id,
+                operator_principal=flow.operator_principal,
+                created_at=now,
+                updated_at=now,
+                client_id=flow.client_id,
+                client_secret=flow.client_secret,
+                client_secret_expires_at=flow.client_secret_expires_at,
+                token_endpoint_auth_method=flow.token_endpoint_auth_method,
+                token_endpoint=flow.token_endpoint,
+                resource=flow.resource,
+                access_token=token.access_token,
+                refresh_token=token.refresh_token,
+                token_type=token.token_type,
+                scope=token.scope or flow.scope,
+                token_expires_at=token_expires_at,
+            )
+            session.add(existing)
             return _oauth_status_from_row(flow.server_id, flow.operator_principal, existing)
 
     def disconnect(self, *, server_id: str, operator_principal: str) -> None:
@@ -622,13 +618,13 @@ async def mcp_operator_auth_statuses(
     return oauth_store.list_statuses(servers=_load_servers(settings), operator_principal=_operator_principal(request))
 
 
-@router.post("/api/mcp/operator-auth/{server_id}/start")
-async def start_mcp_operator_auth(
+@router.post("/api/mcp/operator-auth/{server_id}/connect")
+async def connect_mcp_operator_auth(
     server_id: str, request: Request, csrf_protect: Csrf, settings: SettingsDep, oauth_store: OAuthStoreDep
-) -> McpOperatorAuthStartResponse:
+) -> McpOperatorAuthConnectResponse:
     await csrf_protect.validate_csrf(request)
     server = _server_entry(settings, server_id)
-    return await oauth_store.start_flow(
+    return await oauth_store.connect_flow(
         server=server,
         operator_principal=_operator_principal(request),
         public_base_url=_public_base_url(request, settings),

--- a/haku/console/test_mcp_approval.py
+++ b/haku/console/test_mcp_approval.py
@@ -388,7 +388,7 @@ def test_operator_oauth_association_drives_tool_reflection(make_client, tmp_path
             "/api/capabilities/mcp-servers", headers={"X-authentik-username": "operator@example.com"}
         ).json()
         started = client.post(
-            "/api/mcp/operator-auth/grocy-sf/start",
+            "/api/mcp/operator-auth/grocy-sf/connect",
             headers={"X-CSRF-Token": _csrf(client), "X-authentik-username": "operator@example.com"},
         )
         state = parse_qs(urlparse(started.json()["authorization_url"]).query)["state"][0]
@@ -419,7 +419,7 @@ def test_operator_oauth_static_client_id_skips_dynamic_registration(make_client,
         ) as client,
     ):
         started = client.post(
-            "/api/mcp/operator-auth/grocy-sf/start",
+            "/api/mcp/operator-auth/grocy-sf/connect",
             headers={"X-CSRF-Token": _csrf(client), "X-authentik-username": "operator@example.com"},
         )
         assert started.status_code == 200, started.text
@@ -607,7 +607,7 @@ def test_operator_oauth_association_drives_approved_tool_execution(make_client, 
         ]
 
         started = client.post(
-            "/api/mcp/operator-auth/grocy-sf/start",
+            "/api/mcp/operator-auth/grocy-sf/connect",
             headers={"X-CSRF-Token": _csrf(client), "X-authentik-username": "operator@example.com"},
         )
         assert started.status_code == 200, started.text
@@ -626,6 +626,18 @@ def test_operator_oauth_association_drives_approved_tool_execution(make_client, 
         after = client.get("/api/mcp/operator-auth", headers={"X-authentik-username": "operator@example.com"}).json()
         assert after["associations"][0]["status"] == "connected"
         assert after["associations"][0]["connected_at"]
+
+        reconnect = client.post(
+            "/api/mcp/operator-auth/grocy-sf/connect",
+            headers={"X-CSRF-Token": _csrf(client), "X-authentik-username": "operator@example.com"},
+        )
+        removed_start = client.post(
+            "/api/mcp/operator-auth/grocy-sf/start",
+            headers={"X-CSRF-Token": _csrf(client), "X-authentik-username": "operator@example.com"},
+        )
+        assert reconnect.status_code == 409
+        assert reconnect.json()["detail"] == "MCP server grocy-sf is already connected; disconnect it first"
+        assert removed_start.status_code == 404
 
         submitted = _submit(client)
         approved = client.post(


### PR DESCRIPTION
Removes the MCP-account Reconnect control and replaces the reusable OAuth start route with a connect-only endpoint. Connected accounts must now be explicitly disconnected before a new OAuth association can be created.\n\nThe old start endpoint is removed; connect attempts for an existing association return 409, including a late OAuth callback.\n\nChecks: bbr test //haku/console:test_mcp_approval; bbr build //haku/console/frontend:settings_page; pre-commit hooks.