### PR TITLE
Fix Grocy exchange identity isolation

### DIFF
--- a/grocy_mcp/README.md
+++ b/grocy_mcp/README.md
@@ -26,7 +26,7 @@ claude.ai ──OAuth (MCP spec)──▶ https://grocy-mcp-{sf,vallejo}.alleged
                                       │ generated tool call
                                       │   → httpx.AsyncClient.request(...)
                                       │     ↓ AuthentikExchangeAuth
-                                      │       1. get_access_token().token  (upstream user JWT)
+                                      │       1. originating request Authorization bearer
                                       │       2. POST https://auth.allegedly.works/application/o/token/
                                       │            grant_type=client_credentials
                                       │            client_id=<grocy proxy provider client_id>

--- a/mcp_infra/authentik_auth/auth.py
+++ b/mcp_infra/authentik_auth/auth.py
@@ -37,7 +37,7 @@ from fastmcp.server.auth import MultiAuth
 from fastmcp.server.auth.auth import AuthProvider, TokenVerifier
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
-from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.dependencies import get_access_token, get_http_headers
 from glide_shared.exceptions import TimeoutError as GlideTimeoutError
 from key_value.aio.protocols import AsyncKeyValue
 from mcp.server.auth.provider import TokenError
@@ -309,6 +309,20 @@ def _token_expired(token_data: dict[str, Any]) -> bool:
     return time.time() >= float(expires_at) - _EXPIRY_LEEWAY
 
 
+def _upstream_access_token() -> str:
+    """Return the bearer credential from the originating MCP request."""
+    authorization = get_http_headers(include={"authorization"}).get("authorization")
+    if authorization is not None:
+        scheme, separator, token = authorization.partition(" ")
+        if scheme.lower() != "bearer" or not separator or not token:
+            raise RuntimeError("authenticated MCP request has a malformed Authorization header")
+        return token
+    access = get_access_token()
+    if access is None:
+        raise RuntimeError("no authenticated access token in request context")
+    return access.token
+
+
 class AuthentikExchangeAuth(httpx.Auth):
     """httpx Auth that mints a proxy-provider-scoped JWT per request.
 
@@ -390,9 +404,6 @@ class AuthentikExchangeAuth(httpx.Auth):
             return str(token_data["access_token"])
 
     async def async_auth_flow(self, request: httpx.Request) -> AsyncGenerator[httpx.Request, httpx.Response]:
-        access = get_access_token()
-        if access is None:
-            raise RuntimeError("no authenticated access token in request context")
-        token = await self._get_exchanged_token(access.token)
+        token = await self._get_exchanged_token(_upstream_access_token())
         request.headers["Authorization"] = f"Bearer {token}"
         yield request

--- a/mcp_infra/authentik_auth/test_auth.py
+++ b/mcp_infra/authentik_auth/test_auth.py
@@ -28,6 +28,7 @@ from mcp_infra.authentik_auth.auth import (
     AuthentikExchangeAuth,
     ResilientOIDCProxy,
     _cache_key,
+    _upstream_access_token,
     build_authentik_auth,
 )
 
@@ -366,6 +367,35 @@ async def test_exchange_auth_works_without_store() -> None:
         assert fetch.call_count == 1
 
     await auth.aclose()
+
+
+def test_upstream_access_token_uses_originating_request_header() -> None:
+    with (
+        patch(
+            "mcp_infra.authentik_auth.auth.get_http_headers", return_value={"authorization": "Bearer operator-token"}
+        ),
+        patch(
+            "mcp_infra.authentik_auth.auth.get_access_token", return_value=SimpleNamespace(token="stale-haku-token")
+        ) as parsed_access,
+    ):
+        assert _upstream_access_token() == "operator-token"
+    parsed_access.assert_not_called()
+
+
+def test_upstream_access_token_falls_back_outside_http_request() -> None:
+    with (
+        patch("mcp_infra.authentik_auth.auth.get_http_headers", return_value={}),
+        patch("mcp_infra.authentik_auth.auth.get_access_token", return_value=SimpleNamespace(token="background-token")),
+    ):
+        assert _upstream_access_token() == "background-token"
+
+
+def test_upstream_access_token_rejects_malformed_originating_header() -> None:
+    with (
+        patch("mcp_infra.authentik_auth.auth.get_http_headers", return_value={"authorization": "Basic credentials"}),
+        pytest.raises(RuntimeError, match="malformed Authorization header"),
+    ):
+        _upstream_access_token()
 
 
 # ── ResilientOIDCProxy tests ──────────────────────────────────────────────


### PR DESCRIPTION
## What changed

- derive the Authentik exchange assertion from the originating MCP HTTP request's `Authorization` header
- retain parsed access-token context only as a fallback for non-HTTP/background execution
- fail closed when an originating request carries a malformed authorization header
- document the request-owned token source and add regression coverage for stale parsed identity

## Root cause

Authentik outpost logs showed the approved Grocy mutations were forwarded as `haku`, even though the operator exchange immediately before them authenticated `agentydragon`. `AuthentikExchangeAuth` obtained its upstream assertion from FastMCP's parsed access-token helper late in downstream request execution. That helper can fall back through parsed/session authentication state, allowing stale Haku identity to win over the credential attached to the originating MCP request.

The MCP SDK preserves the originating HTTP request on each protocol message. Reading its bearer header makes identity ownership explicit and prevents a different parsed request context from being exchanged downstream.

## Impact

Operator-approved Grocy writes now exchange the operator bearer that haku-console actually attached. Machine calls continue to exchange Haku's bearer, and background execution retains the existing parsed-token fallback.

## Validation

- `pre-commit run --files mcp_infra/authentik_auth/auth.py mcp_infra/authentik_auth/test_auth.py grocy_mcp/README.md`
- `bbr test //mcp_infra/authentik_auth:test_auth //grocy_mcp:test_server`
  - BuildBuddy invocation: `81075fe7-fc56-4df3-88f2-bfa613d5b36c`
