### PR TITLE
Allow bbapi (any subcommand) in execpolicy SSOT; point execpolicy docs at `codex execpolicy check`

### DIFF
--- a/nix/home/allowed-commands.nix
+++ b/nix/home/allowed-commands.nix
@@ -129,6 +129,19 @@ let
         "search"
         "tree"
       ];
+
+  # bbapi — BuildBuddy API CLI. Almost entirely read-only (invocations,
+  # targets, artifacts, logs, cache scorecard, trends, executions, AI
+  # analysis); the one side-effecting subcommand is `workflow run`, which
+  # triggers a CI workflow execution. Needs network (app.buildbuddy.io), so
+  # it must run outside the sandbox — the prefix allow rule is treated as
+  # sandbox-bypassing by both Claude Code and Codex execpolicy.
+  bbapiCommands = [
+    {
+      type = "prefix";
+      cmd = "bbapi";
+    }
+  ];
 in
 {
   # All allowed commands (no sudo - these are user-accessible commands)
@@ -163,7 +176,8 @@ in
       }
     ]
     ++ wrappedCommands
-    ++ cargoMetadataCommands;
+    ++ cargoMetadataCommands
+    ++ bbapiCommands;
 
   # TODO: Add build system queries:
   # { type = "prefix"; cmd = "bazelisk fetch"; }

--- a/nix/home/codex/default.nix
+++ b/nix/home/codex/default.nix
@@ -251,8 +251,8 @@ in
 
         Local checks:
 
-        - `codex-execpolicy check --pretty --rules "$CODEX_HOME/rules/default.rules" -- git status`
-        - `codex-execpolicy check --pretty --rules "$CODEX_HOME/rules/default.rules" -- bash -lc 'git status'`
+        - `codex execpolicy check --pretty --rules "$CODEX_HOME/rules/default.rules" -- git status`
+        - `codex execpolicy check --pretty --rules "$CODEX_HOME/rules/default.rules" -- bash -lc 'git status'`
 
         Notes:
 

--- a/nix/home/codex/execpolicy-rules.nix
+++ b/nix/home/codex/execpolicy-rules.nix
@@ -28,8 +28,8 @@ let
     #   prefix_rule(pattern=["rm"], decision="forbidden", justification="destructive; use a safer alternative")
     #
     # Test this file locally:
-    #   codex-execpolicy check --pretty --rules "$CODEX_HOME/rules/default.rules" -- git status
-    #   codex-execpolicy check --pretty --rules "$CODEX_HOME/rules/default.rules" -- bash -lc 'git status'
+    #   codex execpolicy check --pretty --rules "$CODEX_HOME/rules/default.rules" -- git status
+    #   codex execpolicy check --pretty --rules "$CODEX_HOME/rules/default.rules" -- bash -lc 'git status'
     #
     # Codex treats matching `decision="allow"` rules as sandbox-bypassing for
     # the matched command prefix, so keep this file limited to safe commands.

--- a/nix/home/tests/codex-execpolicy-rules.nix
+++ b/nix/home/tests/codex-execpolicy-rules.nix
@@ -106,7 +106,7 @@ in
   };
 
   test_has_header_pointer_to_checker = {
-    expr = lib.hasInfix "codex-execpolicy check --pretty" generated.text;
+    expr = lib.hasInfix "codex execpolicy check --pretty" generated.text;
     expected = true;
   };
 }


### PR DESCRIPTION
## What

Two small `nix/` changes for the Codex execpolicy setup.

### 1. Allow `bbapi` (any subcommand) for Codex + Claude
Adds a `bbapi` prefix entry to `nix/home/allowed-commands.nix` — the shared always-allowed commands SSOT. Both Codex (`execpolicy` `default.rules`, whose `allow` rules bypass the sandbox) and Claude Code (`permissions.allow`) derive from it, so either agent can now run any `bbapi *` subcommand without a prompt, including outside the sandbox.

`bbapi` is the BuildBuddy API CLI — almost entirely read-only queries (invocations, targets, artifacts, logs, cache scorecard, trends, executions, AI analysis). The one side-effecting subcommand is `workflow run`, which triggers a CI workflow execution.

### 2. Point execpolicy docs at the command that actually exists
The generated `~/.codex/rules/README.md` and the `default.rules` header told users to run `codex-execpolicy check ...`, but that standalone binary isn't shipped — nixpkgs' `codex` package builds only `codex` and `codex-code-mode-host` (its `cargoBuildFlags` scopes to those two packages). The same functionality ships as a subcommand of the `codex` binary: `codex execpolicy check` (identical `codex_execpolicy` crate). Updates both generated docs and the test that asserted on the old name.

## Verification
- `nix-instantiate --eval --strict nix/home/tests/codex-execpolicy-rules.nix` → all 11 tests pass, including the 62-rule count invariant (reflects the `bbapi` addition) and `test_has_header_pointer_to_checker`.
- Confirmed `codex execpolicy check --rules ... -- <cmd>` runs and returns the expected JSON.
- `nixfmt`, `statix`, and the repo pre-commit / commit-msg hooks all pass on both commits.

## Notes
- Both commits carry `BAZEL_TEST_INVOCATIONS=none:` — these are nix-expression changes; the relevant assertion (`codex-execpolicy-rules.nix`) is a nix expression run via `nix-instantiate`, not a Bazel target. No Bazel target covers these files.
- Takes effect after `home-manager switch`.
