### PR TITLE
Label FastMCP argument-schema drift in Haku specimen

### DIFF
--- a/debug/haku_contract_recreation_drift_2026_07_11.md
+++ b/debug/haku_contract_recreation_drift_2026_07_11.md
@@ -32,33 +32,6 @@ The common remedy is not simply more unit tests. The recreated behavior should b
 
 ## Confirmed current divergence
 
-### A. FastMCP argument schemas and frontend preview schemas disagree
-
-Severity: high
-
-Owner:
-
-- `haku/console/tools/gmail.py:62-68,122-141`
-- `haku/console/tools/google_calendar.py:45-83`
-
-Recreation:
-
-- `haku/console/tools/gmail_client.py:37-66`
-- `haku/console/tools/google_calendar_client.py:51-66`
-- fake OpenAPI schema endpoints in `haku/console/tools/gmail.py:211-228` and `haku/console/tools/google_calendar.py:114-129`
-- generated Zod consumers in `haku/console/frontend/tool_previews/gmail.tsx` and `google_calendar.tsx`
-
-The actual FastMCP signatures accept explicit JSON `null` for Gmail `add`, `remove`, and `cc`, and Calendar `reminders` and `attendees`. The separately exported Pydantic/OpenAPI models allow an array or omission, but not explicit `null`.
-
-Consequently, a call accepted by the actual MCP tool can fail the generated Zod validator. `renderPreview` then selects the generic JSON fallback, losing the custom preview and title. This is the same user-visible failure class as the screenshot-gallery defect.
-
-Consolidation:
-
-- generate frontend validators from each built FastMCP tool's actual `inputSchema`; or
-- make the FastMCP tool consume the same argument model used for OpenAPI generation.
-
-Remove the fake schema-example endpoints. Add a parity test against actual `tools/list` schemas and explicit-null cases.
-
 ### B. Dispatch database state recreates Kubernetes Job lifecycle incompletely
 
 Severity: high

--- a/props/specimens/ducktape/2026-07-11-00/issues/mcp-argument-schema-drift.yaml
+++ b/props/specimens/ducktape/2026-07-11-00/issues/mcp-argument-schema-drift.yaml
@@ -1,0 +1,34 @@
+rationale: |
+  The frontend argument validators are generated from separate Pydantic example models rather than the FastMCP tools' actual input schemas. The Gmail tool signatures accept explicit null for `add`, `remove`, and `cc`, while the example models require arrays; the Calendar signature likewise accepts null for `reminders` and `attendees` while its example model requires arrays. Calls accepted by FastMCP can therefore fail the generated Zod schemas used by the custom previews and fall back to generic JSON. Export the built FastMCP tools' input schemas so execution and rendering share one contract.
+should_flag: true
+occurrences:
+  - occurrence_id: occ-0
+    files:
+      haku/console/tools/gmail.py:
+        - [62, 68]
+        - [122, 141]
+        - [211, 228]
+      haku/console/tools/gmail_client.py:
+        - [37, 66]
+      haku/console/frontend/tool_previews/gmail.tsx:
+        - [1, 24]
+        - [168, 175]
+    note: "Gmail write-tool schemas"
+    critic_scopes_expected_to_recall:
+      - [haku/console/tools/gmail.py, haku/console/tools/gmail_client.py]
+      - [haku/console/tools/gmail.py, haku/console/frontend/tool_previews/gmail.tsx]
+
+  - occurrence_id: occ-1
+    files:
+      haku/console/tools/google_calendar.py:
+        - [45, 83]
+        - [114, 129]
+      haku/console/tools/google_calendar_client.py:
+        - [51, 66]
+      haku/console/frontend/tool_previews/google_calendar.tsx:
+        - [1, 22]
+        - [210, 215]
+    note: "Google Calendar create-event schema"
+    critic_scopes_expected_to_recall:
+      - [haku/console/tools/google_calendar.py, haku/console/tools/google_calendar_client.py]
+      - [haku/console/tools/google_calendar.py, haku/console/frontend/tool_previews/google_calendar.tsx]


### PR DESCRIPTION
## What changed

- added a Props issue label for the frozen FastMCP/frontend argument-schema drift
- cited the actual tool signatures, duplicate Pydantic/OpenAPI models, and frontend preview consumers already present in the snapshot
- removed resolved finding A from the live drift audit

## Why

At the reference commit, the separately exported Pydantic models rejected explicit `null` values accepted by the real FastMCP tools. The generated frontend validators could therefore miss the custom preview and fall back to raw JSON. The snapshot already contained the complete owner/recreation path, so no additional frozen source files were needed.

## Impact

The historical defect remains available as review-training ground truth while the live audit now tracks only unresolved findings.

## Validation

- `pre-commit run --files debug/haku_contract_recreation_drift_2026_07_11.md props/specimens/ducktape/2026-07-11-00/issues/mcp-argument-schema-drift.yaml`
- `bbr test //props/specimens/ducktape/2026-07-11-00:test_specimen`