### PR TITLE
Allow `bbr test` prefix in Codex/Claude execpolicy SSOT

### DIFF
--- a/nix/home/allowed-commands.nix
+++ b/nix/home/allowed-commands.nix
@@ -64,6 +64,13 @@ let
 
   bazelCommands = prefixCommandProduct bazelExecutables bazelSubcommands;
 
+  # bbr test — BuildBuddy RBE test wrapper, the repo's preferred test runner
+  # (AGENTS.md: "Prefer bbr for build/test/query"). Same safety profile as the
+  # already-allowed `bazel test`/`bazelisk test` (writes only to build
+  # artifacts); runs outside the sandbox (Bazel RBE network) like other
+  # Bazel-family commands. Scoped to `test` only; build/query stay prompt-gated.
+  bbrTestCommands = prefixCommandProduct [ "bbr" ] [ "test" ];
+
   # Generate "nix develop <flag> <cmd>" variants for both --command and -c flags.
   nixDevelopWrapped =
     commands:
@@ -149,6 +156,7 @@ in
     gitReadOnlyCommands
     ++ ghReadOnlyCommands
     ++ bazelCommands
+    ++ bbrTestCommands
     ++ nixDevelopBazelCommands
     ++ nixCommands
     ++ [


### PR DESCRIPTION
## What

Add a `bbr test` prefix entry to `nix/home/allowed-commands.nix` (the shared always-allowed commands SSOT). Both Codex (`execpolicy` `default.rules`, sandbox-bypassing allow) and Claude Code (`permissions.allow`) derive from it, so either agent can now run any `bbr test ...` invocation without a prompt, including outside the sandbox.

## Why
`bbr test` is the repo's preferred test runner (AGENTS.md: *"Prefer bbr for build/test/query"*). It shares the safety profile of the already-allowed `bazel test` / `bazelisk test` (writes only to build artifacts under `bazel-out/`), so it fits the SSOT's read-only/build-artifact criteria.

Scoped to `test` only, per request — `bbr build` / `bbr query` remain prompt-gated. Like other Bazel-family commands, it runs outside the sandbox (BuildBuddy RBE network).

## Verification
- `nix-instantiate --eval --strict nix/home/tests/codex-execpolicy-rules.nix` → all tests pass; `test_rule_count_matches_prefix_entries` auto-tracks to 63 (was 62).
- Confirmed generated outputs: Claude `Bash(bbr test:*)`, Codex `prefix_rule(pattern=["bbr","test"], decision="allow")`.

## Notes
- `BAZEL_TEST_INVOCATIONS=none:` — nix expression change; no Bazel target covers nix config.
- Takes effect after `home-manager switch`.
