### PR TITLE
wyrm2: swap GDM → SDDM for same-user multi-seat (seat-game)

### DIFF
--- a/debug/atlas/direct_display_bringup.md
+++ b/debug/atlas/direct_display_bringup.md
@@ -483,13 +483,264 @@ user session cleanly kills sway + Steam + waybar and drops back to the greeter
 (field 3 is USER). The `systemd --user` manager session (no seat) lingers
 benignly.
 
+## 2026-07-11: GDM greeter freeze + two-greeter accumulation
+
+**Symptom**: GDM seat-game greeter freezes on login; display stays frozen with each
+re-attempt; display-manager restart required to recover.
+
+**Device topology** (confirmed via udevadm, /sys/class/drm):
+
+| Device | Driver     | PCI     | Seat      | Notes                                                     |
+| ------ | ---------- | ------- | --------- | --------------------------------------------------------- |
+| card0  | nvidia     | 01:00.0 | seat-game | Display GPU; DP-1 connected                               |
+| card1  | virtio-pci | 00:01.0 | seat0     | SPICE virtual display                                     |
+| card2  | nvidia     | 02:00.0 | seat0     | Compute GPU; `mutter-device-ignore`; no connected display |
+
+(card1 lands numerically "between" the two NVIDIA cards because DRM enumeration
+follows driver-load order, not PCI address order.)
+
+**Phase 1 — original single-greeter freeze (21:29 UTC):**
+
+- Only ONE greeter was running at this point (gnome-shell started by GDM 3305 at 20:45).
+- User authenticated; GDM emitted `session-opened` at 21:29:25; no
+  `ReadyForSessionToStart` came back within 60 s → "Session was cancelled" at 21:30:26.
+- sway-session.log has **zero seat-game entries** — sway never launched. The block is
+  entirely at the GDM greeter level (gnome-shell never calling `ReadyForSessionToStart`).
+- `enable-animations=false` dconf is correctly applied (verified earlier) but apparently
+  insufficient to make gnome-shell skip the render-loop dependency for the
+  ReadyForSessionToStart callback. Frame clock stall (NVIDIA vblank not delivered?) or
+  some other render-side block is the residual unknown.
+- Sunshine (PID 233050) was later found running as `gdm-greeter-3` inside the greeter
+  session — its role in the freeze is unconfirmed (was not present during the 21:29
+  attempt per the log timeline, but appeared afterward).
+
+**Phase 2 — two-greeter accumulation (from 22:15 onward):**
+
+After the 21:30 session cancellation, GDM killed the PAM session worker (PID 97927) but
+**left gnome-shell 3455 running**. It sat in a zombie/frozen state for 45 minutes.
+
+At 22:15:36 gnome-shell 3455 finally disconnected from GDM. The seat-game display (c2)
+had two internal session objects associated with it — one for the greeter program
+(gnome-shell 3455) and one for the gdm-launch-environment wrapper (PID 3321). Both
+dying in the same event loop tick caused two independent `GdmDisplay: initiating
+display self-destruct` sequences, and `GdmLocalDisplayFactory` created a new seat-game
+display for each one:
+
+1. gnome-shell 3455 disconnects → `GdmDisplay: Greeter exited` → self-destruct #1 →
+   factory adds DISPLAY_NEW_1 (status: PREPARING)
+2. Self-destruct #1 sends SIGTERM to gdm-launch-environment worker PID 3321
+3. PID 3321 dies → `GdmLaunchEnvironment: conversation stopped` → `GdmDisplay: Greeter
+stopped` → self-destruct #2 → factory adds DISPLAY_NEW_2
+
+`GdmLocalDisplayFactory` has no dedup: it creates a new display for each "seat failed"
+signal without checking whether one is already being prepared for the same seat. Both
+new displays land on seat-game → two simultaneous greeter gnome-shell processes both
+opening card0 for KMS.
+
+```
+# loginctl during the two-greeter state
+c5 60578 gdm-greeter   seat-game 240655 greeter
+c6 60580 gdm-greeter-2 seat-game 240663 greeter
+# Both gnome-shell PIDs have card0 open with identical flags (02104002)
+```
+
+Only one can hold the DRM master token; the other can't render. The display appears
+frozen because whichever gnome-shell lost the DRM master token can't display anything.
+
+The root of the cascade is the original 21:29 freeze: gnome-shell 3455 was never killed
+after the session cancellation, so when it eventually died it triggered both cleanup paths
+simultaneously. If GDM had killed the greeter at 21:30 along with the session worker, the
+two paths would have died together under a controlled `finish display` and no new displays
+would have been created (same as how the seat0 background display was cleanly destroyed at
+20:46 without spawning a replacement).
+
+**Recovery**: `systemctl restart display-manager` (kills seat0 sway session; user
+must reconnect SPICE). Alternatively kill one duplicate first:
+`loginctl terminate-session c6` — if GDM doesn't respawn it, the remaining greeter
+is clean.
+
+### 2026-07-11 23:09 — non-destructive recovery: park the seat (WORKED)
+
+By 22:39 the two-greeter pile had self-healed to a single greeter: one gnome-shell
+exited, both self-destruct paths fired, but `create_display`'s dedup
+("Ensure we don't create the same display more than once",
+`gdm-local-display-factory.c:960` in 49.2) caught the second request and reused the
+surviving session (journal: "session c5 found, activating").
+
+To drop the remaining (frozen) greeter **without touching seat0**, we made seat-game
+non-graphical so GDM has nothing to respawn onto. Source facts (GDM 49.2 +
+systemd 258, clones in `/code/github.com/{GNOME/gdm,systemd/systemd}`):
+
+- Both greeter-restart paths (`GDM_DISPLAY_FAILED` and `GDM_DISPLAY_FINISHED` in
+  `on_display_status_changed`) go through `ensure_display_for_seat()`, which for
+  non-seat0 seats returns early when `sd_seat_can_graphical() == 0`. With
+  CanGraphical=no, respawn is impossible regardless of how the greeter dies.
+- `on_seat_properties_changed` (CanGraphical → false) and `on_seat_removed` both call
+  `delete_display()` → display store unref → `gdm_display_dispose` → SIGTERM to the
+  launch-environment process group. So flipping CanGraphical also _initiates_ a clean
+  teardown.
+- **Gotcha**: logind never clears a live Device's master flag —
+  `manager_add_device()` (`logind-core.c`): `/* we support adding master-flags, but
+not removing them */`. Removing only `TAG-="master-of-seat"` changes udev state but
+  logind keeps `CanGraphical=yes` forever. The flag only clears when the Device is
+  **freed**, which `manager_process_seat_device()` does when the device loses the
+  `seat` current-tag (sticky `TAGS=` keep the uevent routable to logind's tag-filtered
+  monitor — that's the designed purpose of sticky tags).
+
+Procedure (as root on wyrm2):
+
+```bash
+cat > /run/udev/rules.d/98-park-seat-game.rules <<'EOF'
+SUBSYSTEM=="drm", KERNEL=="card[0-9]*", KERNELS=="0000:01:00.0", TAG-="seat", TAG-="master-of-seat"
+EOF
+udevadm control --reload
+udevadm trigger --action=change --subsystem-match=drm \
+  --parent-match=/sys/devices/pci0000:00/0000:00:1c.0/0000:01:00.0
+```
+
+Result: logind freed the card0 Device, seat-game disappeared, GDM logged
+`delete_display` → SIGTERM to greeter pgroup → session worker exited status 0 →
+greeter dyn-user deallocated — and **no** "display for seat seat-game requested"
+afterward. seat0 sway session untouched; no process holds `/dev/dri/card0`.
+
+**Unpark** (spawns one fresh greeter — do this when ready to debug the freeze):
+
+```bash
+rm /run/udev/rules.d/98-park-seat-game.rules
+udevadm control --reload
+udevadm trigger --action=change --subsystem-match=drm \
+  --parent-match=/sys/devices/pci0000:00/0000:00:1c.0/0000:01:00.0
+```
+
+The rule lives in `/run`, so a reboot also unparks. `ID_SEAT` stays `seat-game`
+(from `/etc/udev/rules.d/72-seat-game.rules`), so card0 never migrates to seat0
+where sway could hotplug-grab it.
+
+**Next diagnostic steps (not yet done):**
+
+- With a clean single greeter, attach a D-Bus monitor for the `ReadyForSessionToStart`
+  signal: `dbus-monitor --system "type=method_call,interface=org.gnome.DisplayManager.Session"`.
+- Also send `kill -USR1 <gnome-shell-pid>` immediately after `session-opened` to
+  capture a JS backtrace of where gnome-shell is blocked.
+- Check if disabling Sunshine in the greeter config changes the freeze behavior.
+
+### 2026-07-11 23:24 — freeze caught live: it's the conflicting-session dialog
+
+Fresh greeter (c7, gnome-shell 486153) after unparking. Login attempt at 23:24
+(GNOME session type): auth succeeded, `session-opened` emitted 23:24:17, then no
+`GdmManager: Will start session when ready` — the known freeze, caught with
+instrumentation attached this time.
+
+Live evidence:
+
+- `eu-stack -p 486153`: main thread idle in `ppoll` inside `g_main_loop_run` —
+  **not** wedged in any NVIDIA/DRM ioctl. All threads idle.
+- In-process JS dump (`gdb -p 486153 -batch -ex 'call (void) gjs_dumpstack()'` —
+  non-fatal, unlike the SIGTRAP/SIGABRT crash dumper; note gnome-shell has **no**
+  SIGUSR1 stack handler, the earlier SIGUSR1 plan was wrong): single frame at
+  `init.js:21` (main-loop hook). JS ran to completion and is waiting for an event.
+- No JS errors in the greeter journal.
+
+Root cause (gnome-shell 49.4 `js/gdm/loginDialog.js`): `_onSessionOpened` calls
+`_findConflictingSession(sessionId)`, which scans logind for any wayland/x11
+session in state active/online **owned by the same user**. If found, it opens
+`ConflictingSessionDialog` ("user is already logged in — force stop?") and returns
+**without** calling `StartSessionWhenReady`, waiting for dialog input.
+`_CONFLICTING_SESSION_DIALOG_TIMEOUT = 60` — after 60 s the dialog closes and the
+auth prompt resets; GDM's own 60 s `session-opened` timer fires around the same
+time → "Session was cancelled".
+
+The seat0 sway/SPICE session (user agentydragon, type wayland, active since 20:46)
+has been running during **every** freeze — so every seat-game login raised this
+dialog. Whether the dialog actually painted on the FV43U is the remaining question:
+if it did not (stale login-prompt frame stays on screen), there is _also_ a
+repaint/frame-clock issue; if it did, the "freeze" was just an unanswered dialog.
+
+Consequence: to log into seat-game as the same user, either answer the dialog
+(force-stop kills the seat0 session) or log out of the seat0 sway session first —
+then no conflict exists and the login should proceed directly.
+
+### 2026-07-11 — greetd ruled out for seat-game
+
+Considered swapping seat-game's greeter to greetd (no conflict check). Rejected after
+reading greetd source (`/code/github.com/kennylevinsen/greetd`):
+
+- **Hardcoded seat**: `greetd/src/session/worker.rs:216` puts `XDG_SEAT=seat0` in the
+  PAM env for every session it starts — no config override. greetd can only ever
+  create seat0 sessions; it cannot target seat-game.
+- **VT-based**: `greetd/src/terminal/mod.rs` drives sessions via `KDGRAPHICS`/`KDTEXT`
+  ioctls on `/dev/ttyN`. seat-game has `CAN_TTY=0` (no VTs), so there is no terminal
+  for greetd to manage there.
+
+greetd is single-seat/seat0/VT-oriented. (Note: a later source review found SDDM and
+LightDM _do_ support per-logind-seat multi-seat and have no same-user veto — see
+<greeter_multiseat_research.md>. Only greetd is disqualified on the VT/seat0 axis.)
+Options that remain, to run two simultaneous same-machine graphical sessions:
+
+1. **Separate user for the gaming seat** (e.g. `games`): zero patching. GDM's multi-seat
+   greeter is _designed_ for two different users at once — no conflict dialog fires
+   because `_findConflictingSession` matches only same-user sessions. Cost: a second
+   home/config.
+2. **Patch the gnome-shell greeter**: make `_findConflictingSession`
+   (`js/gdm/loginDialog.js`) skip sessions on a different `Seat` than the greeter's.
+   Keeps same-user-both-seats. Cost: a gnome-shell rebuild (the JS lives in a gresource
+   bundle, so it's a source patch + repackage, not a drop-in file).
+3. **Greeterless autologin on seat-game**: a custom launcher (PAM + `pam_systemd` with
+   `XDG_SEAT=seat-game`) that execs sway directly, with GDM no longer managing that seat.
+   GDM has no per-seat exclude, so this means taking seat-game out of GDM's view — most
+   bespoke of the three.
+
+### 2026-07-12 — decision: swap GDM → SDDM (staged, switch pending)
+
+Chose SDDM over the alternatives. Rationale from <greeter_multiseat_research.md>: SDDM
+does per-logind-seat multi-seat, sets `XDG_SEAT` per seat, gates VT usage on seat0 (so
+the VT-less seat-game is fine), supports a Wayland greeter, and — unlike GDM — has **no
+same-user conflict check**. So the same user can hold a live session on seat0 (SPICE)
+and seat-game (physical) at once with no dialog. The seat-game session is sway (no fixed
+D-Bus names), so it never collides with the seat0 GNOME session on the shared per-user
+bus.
+
+Staged in `nix/nixos/hosts/wyrm2/default.nix`:
+
+- `services.displayManager.gdm.enable = lib.mkForce false` (gdm.enable is set in the
+  shared `gui.nix`; force-disabled here so other hosts keep GDM).
+- `services.displayManager.sddm = { enable = true; wayland.enable = true; }`.
+- Removed the GDM-greeter dconf tweaks (idle-delay=0, enable-animations=false).
+
+Validated at eval only (no switch yet): resolved `gdm.enable=false`,
+`sddm.enable=true`, `sddm.wayland.enable=true`, and the `display-manager` unit's start
+script references `sddm`. Two build hiccups were **unrelated infra**, not this change:
+`nixos-rebuild` didn't pass the `fetch-closure` experimental feature; then the root-only
+attic netrc (`/run/secrets/rendered/attic-netrc`) gave a 401 to a non-root eval. The
+real `sudo nixos-rebuild switch` runs as root and reads that netrc, so gaffer/attic
+fetch is fine there.
+
+**Switch is deferred — the user will run it.** `sudo nixos-rebuild switch --flake
+~/code/ducktape#wyrm2`. It restarts display-manager → the seat0 SPICE desktop dies and
+SDDM comes up. A failed build aborts before activation (safe); root SSH survives
+regardless. Revert = uncomment the GDM lines + rebuild.
+
+**Open risks to check after the switch:**
+
+- **SDDM Wayland greeter on the NVIDIA seat-game** — unverified. The greeter compositor
+  (`Wayland.CompositorCommand`, default weston) must acquire DRM master as a
+  `greeter`-class session on card0. If it won't come up, fall back to per-seat autologin
+  (skip the greeter and launch sway directly) or SDDM's X11 greeter.
+- **No-blank for the FV43U KVM** — the GDM `idle-delay=0` guarantee is gone. If the KVM
+  reverts to USB-C because the seat-game greeter blanks, add an equivalent no-DPMS to the
+  SDDM greeter compositor / sway `swayidle`.
+
 ## Open questions
 
+- **Did the ConflictingSessionDialog ever render on the physical display?** If not,
+  there is a separate repaint stall in the greeter (frame-clock / NVIDIA), on top of
+  the dialog logic. Distinguish by logging out of seat0 sway and retrying login —
+  a fade-then-session-start means rendering is fine.
+- **Sunshine in greeter session**: Sunshine runs as `gdm-greeter-*` user when the seat
+  is unoccupied. Investigate whether it should be suppressed during greeter mode.
 - **Harden the session-teardown leak** so re-logins stop colliding: logind
   `KillUserProcesses` scoped to the seat-game session, or a session-exit hook that
   reaps the compositor/Steam. Currently manual (also bit the sway seat).
 - Is the spare USB A→B cable actually good? (First-port "cable is bad"
   errors vs. port flakiness — untested since the mux never engaged.)
 - Does the FV43U KVM binding survive monitor power cycles?
-- Does mutter handle nvidia-primary + virtio-secondary cleanly (SPICE
-  desktop must stay usable — hard requirement)?

--- a/debug/atlas/greeter_multiseat_research.md
+++ b/debug/atlas/greeter_multiseat_research.md
@@ -1,0 +1,155 @@
+# Greeter multi-seat capabilities — research report
+
+**Question:** which display managers / greeters can run **two simultaneous graphical
+sessions for the same user on the same machine**, one per logind seat (specifically:
+seat0 = SPICE virtual display, seat-game = physical RTX 5090 + keyboard on wyrm2)?
+
+**Date:** 2026-07-11. **Method:** source reading. Cloned into `/code/github.com/`:
+GDM 49.2 (`GNOME/gdm`), gnome-shell 49.4 (`GNOME/gnome-shell`), greetd
+(`kennylevinsen/greetd`), LightDM (`canonical/lightdm`), SDDM (`sddm/sddm`), systemd
+v258 (`systemd/systemd`). Line numbers below are from those checkouts.
+
+## The two independent axes
+
+The problem decomposes into two things a DM must satisfy, and they are **independent**:
+
+1. **VT-less multi-seat**: can it spawn a greeter/session on a _non-seat0_ logind seat?
+   Non-seat0 seats have no VTs (`CAN_TTY=0`) — see <direct_display_bringup.md> for the
+   VT/seat relationship. A DM whose session model is "allocate a VT, `chvt` to it"
+   cannot drive such a seat. This requires following logind's `ListSeats` / `SeatNew` /
+   `SeatRemoved` and handing off DRM master via logind session-activation, not VTs.
+2. **Same-user policy**: does it _refuse_ to start a session for a user who already has
+   an active graphical session elsewhere? Only one DM does. This is the wyrm2 blocker.
+
+Almost every DM fails axis 1 (VT/seat0-only) — that's the real scarcity, not axis 2.
+
+## Summary
+
+| DM                 | VT-less multi-seat | Per-seat greeter | Same-user veto | Wayland greeter        | Verdict for wyrm2                                 |
+| ------------------ | ------------------ | ---------------- | -------------- | ---------------------- | ------------------------------------------------- |
+| **GDM**            | ✅ yes             | ✅ yes           | ❌ **blocks**  | ✅ (gnome-shell)       | Works but vetoes same-user                        |
+| **SDDM**           | ✅ yes             | ✅ yes           | ✅ none        | ⚠️ via compositor cmd  | Best candidate; verify Wayland-on-2nd-NVIDIA-seat |
+| **LightDM**        | ✅ yes             | ✅ yes           | ✅ none        | ⚠️ weak (greeters X11) | Candidate; per-seat autologin dodges greeter      |
+| **greetd**         | ❌ seat0 hardcoded | ❌ no            | ✅ none        | ✅ (any wl greeter)    | Cannot reach seat-game                            |
+| ly / emptty / nodm | ❌ tty-only        | ❌ no            | ✅ none        | ❌ (tty/X)             | Single seat0 only                                 |
+
+✅ = supports / no obstacle. "Same-user veto ✅ none" means it does **not** block — good.
+
+## Per-DM findings
+
+### GDM 49.2 — multi-seat ✅, but same-user veto ❌
+
+- **Multi-seat**: `GdmLocalDisplayFactory` enumerates seats via logind `ListSeats`
+  (`gdm-local-display-factory.c:1029`) and subscribes to `SeatNew`/`SeatRemoved` /
+  seat property changes (`:1403`+). `ensure_display_for_seat()` spawns a greeter per
+  graphical seat. This is why seat-game gets its own greeter today.
+- **No per-seat exclude**: there is no config key to make GDM ignore a seat. It claims
+  every seat with `CanGraphical=yes`. (Confirmed: no such key in `data/*.in` schemas.)
+- **Same-user veto**: lives in the **gnome-shell greeter**, not the GDM daemon.
+  `js/gdm/loginDialog.js` `_onSessionOpened` (`:1291`) calls `_findConflictingSession`,
+  which matches _any_ active wayland/x11 logind session owned by the same user
+  (regardless of seat), and if found opens `ConflictingSessionDialog` and returns
+  without calling `StartSessionWhenReady`. `_CONFLICTING_SESSION_DIALOG_TIMEOUT = 60`
+  coincides with GDM's own session-start timeout → "Session was cancelled". No gsetting
+  or env disables it. Introduced for _remote_-session hijack protection (dialog text is
+  all about remote vs local); the local multi-seat case is collateral.
+- **Verdict**: the only DM that fails purely on axis 2. Everything else it does is right.
+
+### SDDM — multi-seat ✅, no same-user veto ✅ (strongest candidate)
+
+- **Multi-seat**: `SeatManager` calls `ListSeats` and connects `SeatNew`/`SeatRemoved`
+  (`src/daemon/SeatManager.cpp:106,119,120`). `logindSeatAdded` → `createSeat(name)`
+  for **every** graphical logind seat (`:63-68`), not just seat0.
+- **Per-seat env**: `XDG_SEAT` is set to `seat()->name()` for both greeter and session
+  (`Greeter.cpp:211`, `Display.cpp:458`) — not hardcoded.
+- **VT-less on non-seat0**: `CanTTY` / VT is explicitly gated on seat0 —
+  `Seat.cpp:144` returns TTY-capable only when `name == "seat0"`; `XDG_VTNR` is set only
+  when `seat()->name() == "seat0"` (`Greeter.cpp:214`); the VT jump is guarded by
+  `terminalId() > 0` (`Seat.cpp:125-128`). So non-seat0 seats run without touching VTs.
+- **No same-user veto**: grep for "already logged"/"conflicting"/"already running"
+  across `src/` returns nothing. SDDM will start a session for a user who is already
+  logged in elsewhere.
+- **Wayland greeter**: `WaylandDisplayServer` runs a compositor from
+  `Wayland.CompositorCommand` (default weston) and runs `sddm-greeter` inside it
+  (`Display.cpp:135-136`). **Risk**: that compositor must come up on the second NVIDIA
+  seat — unverified here.
+- **Verdict**: architecturally does exactly what's wanted. Practical unknown is only the
+  Wayland-greeter compositor on a second NVIDIA seat. Per-seat **autologin** would skip
+  the greeter compositor entirely and remove that risk.
+
+### LightDM — multi-seat ✅, no same-user veto ✅ (candidate; weaker Wayland)
+
+- **Multi-seat**: the multi-seat DM by lineage (Ubuntu thin-client era). Config supports
+  `[Seat:*]`, `[Seat:seat0]`, `[Seat:seat-thin-client*]` glob sections
+  (`data/lightdm.conf:44-86`). `login1.c` handles `SeatNew`/`SeatRemoved` (`:227,239`)
+  and `CanGraphical`/`CanMultiSession` changes (`:201-203`); `lightdm.c`
+  `add_login1_seat`/`update_login1_seat` (`:401`+) creates a Seat per graphical logind
+  seat, reading `can_multi_session` / `can_tty`.
+- **Per-seat env**: `XDG_SEAT` = `seat_get_name(seat)` (`seat.c:408`,
+  `seat-local.c:229,238`) — per seat, not hardcoded.
+- **No same-user veto**: no "already logged in / refuse" logic; the only "already
+  active" hit (`lightdm.c:507`) is _session reuse/activation_, not a refusal.
+- **Wayland**: `wayland-session.c` exists and `seat.c:974` defaults a session to wayland
+  when a `wayland-sessions` dir is present. **But** `seat-local.c:191-197`
+  (`create_wayland_session`) sets a VT on the session from `vt_get_active()`, and
+  LightDM's _greeters_ (lightdm-gtk-greeter, slick-greeter, web-greeter) are X11. Its
+  Wayland-greeter story is weaker than SDDM's.
+- **Per-seat autologin**: `[Seat:seat-game]` with `autologin-user=` / `autologin-session=`
+  is a first-class feature — this **skips the greeter** on that seat entirely (no
+  compositor, no dialog), launching sway directly. This is LightDM's cleanest fit here.
+- **Verdict**: viable, especially via per-seat autologin. Wayland _greeter_ is the weak
+  spot; autologin sidesteps it.
+
+### greetd — cannot reach seat-game ❌
+
+- **Hardcoded seat0**: `greetd/src/session/worker.rs:216` puts the literal
+  `"XDG_SEAT=seat0"` into the PAM env of every session it starts. No config override.
+- **VT-based**: `greetd/src/terminal/mod.rs` drives sessions via `KDGRAPHICS`/`KDTEXT`
+  ioctls on `/dev/ttyN`. seat-game has no VTs.
+- **No same-user veto** (irrelevant — it can't target the seat at all).
+- **Verdict**: deliberately minimal seat0/VT tool. Dead on arrival for non-seat0 seats.
+  (It _is_ a perfect fit for seat0 itself, e.g. if pairing greetd-on-seat0 with a
+  bespoke launcher on seat-game.)
+
+### ly / emptty / nodm — single seat0/tty only ❌
+
+Not source-verified in this pass (medium confidence, from their design): these are
+minimal TUI/console greeters that run on a single `/dev/ttyN` on seat0. No logind
+seat-following, no per-seat concept. Same-user is unrestricted, but they can't reach a
+non-seat0 seat. Excluded.
+
+## What this means for wyrm2 (seat-game)
+
+The scarcity is axis 1 (VT-less multi-seat), and **three** DMs clear it: GDM, SDDM,
+LightDM. GDM is disqualified _only_ by its gnome-shell same-user veto, which has no
+per-seat exclude and no off switch short of patching gnome-shell. So the realistic
+"same user, both seats, no dialog" paths are:
+
+1. **SDDM**, replacing GDM for both seats. Greeter on seat0, per-seat handling for
+   seat-game. Verify the Wayland greeter compositor starts on the second NVIDIA seat, or
+   use seat-game autologin to skip it.
+2. **LightDM**, replacing GDM for both seats, with `[Seat:seat-game]` **autologin** to
+   sway (skips the greeter → skips every greeter-side risk) and a normal greeter (or
+   autologin) on seat0.
+3. **Patch GDM's gnome-shell greeter** — keep GDM, make `_findConflictingSession` skip
+   different-seat sessions. Smallest behavioral change, but a gnome-shell rebuild to
+   maintain across GNOME bumps.
+4. **Different user** for seat-game — GDM as-is, zero code (out of scope for this report,
+   which is about _same_-user).
+
+Note the wyrm2 second session is **sway**, not GNOME, so the genuine per-user singleton
+limit (one shared user bus / `systemd --user` per uid; GNOME claims fixed D-Bus names)
+does **not** apply — GNOME-on-seat0 + sway-on-seat-game coexist for one user. See the
+`programs.sway` comment in `nix/nixos/hosts/wyrm2/default.nix` and
+<direct_display_bringup.md>.
+
+## Open / unverified
+
+- **SDDM & LightDM Wayland greeter on a second NVIDIA seat**: neither verified live. The
+  compositor (SDDM: `Wayland.CompositorCommand`; LightDM: weak) must acquire DRM master
+  on card0 as a `greeter`-class session on seat-game. Per-seat **autologin** avoids this
+  entirely and is the lower-risk route for both.
+- **Migration cost**: moving off GDM means re-homing the seat0 SPICE GNOME session under
+  the new DM (session launch is straightforward; the seat0 greeter rendering on QXL/virtio
+  is not NVIDIA and should be easy).
+- ly/emptty/nodm not source-checked (excluded on design; low stakes).

--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -136,25 +136,35 @@ in
   # Podman
   virtualisation.podman.enable = true;
 
-  # GNOME 49 dropped X11 sessions — Wayland is the only option.
-  # NixOS auto-disables Wayland for NVIDIA, but the display is QXL (not NVIDIA).
-  services.displayManager.gdm.wayland = true;
-  # Verbose GDM logging while debugging the seat-game session launch
-  # (sessions die without their Exec ever running). Remove when solved.
-  services.displayManager.gdm.debug = true;
-  # Greeter must never blank/DPMS-off: a dark DP output makes the FV43U's KVM
-  # auto-revert to USB-C before the seat-game keyboard can wake anything
-  # (see debug/atlas/direct_display_bringup.md).
-  programs.dconf.profiles.gdm.databases = [
-    {
-      settings."org/gnome/desktop/session".idle-delay = lib.gvariant.mkUint32 0;
-      # No greeter animations: the seat-game greeter's login fade stalls
-      # (frame clock hangs → the animation-completion callback that calls
-      # StartSession never fires → "frozen greeter" instead of session
-      # start). With animations off the callback runs immediately.
-      settings."org/gnome/desktop/interface".enable-animations = false;
-    }
-  ];
+  # Display manager: SDDM, not GDM. GDM refuses to start a second graphical
+  # session for a user already logged in elsewhere (its gnome-shell greeter's
+  # _findConflictingSession check, machine-wide, no per-seat exclude) — which
+  # blocked same-user multi-seat login on seat-game while the seat0 SPICE
+  # session was active. SDDM follows logind seats (per-seat greeter), sets
+  # XDG_SEAT per seat, and has no same-user veto. See
+  # debug/atlas/greeter_multiseat_research.md and direct_display_bringup.md.
+  #
+  # gdm.enable is set in the shared gui.nix module, so it is force-disabled
+  # here rather than removed (other hosts still use GDM).
+  services.displayManager.gdm.enable = lib.mkForce false;
+  services.displayManager.sddm = {
+    enable = true;
+    # Wayland greeter (GNOME 49 is Wayland-only; the seat0 greeter renders on
+    # QXL/virtio, not NVIDIA). SDDM runs the greeter under a Wayland compositor.
+    wayland.enable = true;
+  };
+
+  # GDM greeter dconf tweaks removed with the GDM→SDDM swap:
+  # - idle-delay=0 kept the DP output awake so the FV43U KVM would not revert to
+  #   USB-C before the seat-game keyboard could wake it. TODO: re-establish the
+  #   no-blank guarantee for the SDDM seat-game greeter (weston idle) if the KVM
+  #   reverts again — see debug/atlas/direct_display_bringup.md.
+  # - enable-animations=false was a wrong theory for the "frozen greeter": the
+  #   real cause was the conflicting-session dialog, now gone with GDM.
+  #
+  #   Old GDM-specific wiring, for reference if reverting:
+  #   services.displayManager.gdm.wayland = true;
+  #   services.displayManager.gdm.debug = true;
 
   # Sway session for the game seat (seat-game, on the display 5090). A real WM to
   # game + debug from, run as agentydragon — non-GNOME, so it doesn't clash with


### PR DESCRIPTION
## What

Swap wyrm2's display manager from **GDM** to **SDDM** so the same user can hold
two simultaneous graphical sessions — seat0 (SPICE virtual display) and seat-game
(physical RTX 5090 + keyboard) — at once.

## Why

GDM's gnome-shell greeter refuses to start a second graphical session for a user
who is already logged in elsewhere (`_findConflictingSession` in
`js/gdm/loginDialog.js` — machine-wide, no per-seat exclude, no config toggle). With
the seat0 SPICE session active, every seat-game login stalled on an unanswered
"you're already logged in" dialog and timed out as "Session was cancelled".

A source review of the multi-seat-capable DMs (new report:
`debug/atlas/greeter_multiseat_research.md`) found SDDM:

- follows logind seats (`SeatManager` → `createSeat` per graphical seat),
- sets `XDG_SEAT` per seat and gates VT usage on seat0 (so the VT-less seat-game works),
- supports a Wayland greeter, and
- has **no** same-user conflict check.

The seat-game session is sway (no fixed D-Bus names), so it doesn't collide with the
seat0 GNOME session on the shared per-user bus.

## Changes

- `nix/nixos/hosts/wyrm2/default.nix`: force-disable `gdm` (enabled in shared
  `gui.nix`), enable `sddm` with `wayland.enable`, drop the GDM-greeter dconf tweaks.
- `debug/atlas/greeter_multiseat_research.md`: new — DM multi-seat capability matrix
  with source citations (GDM/SDDM/LightDM/greetd).
- `debug/atlas/direct_display_bringup.md`: freeze root-cause (conflicting-session
  dialog, caught live via `eu-stack` + `gjs_dumpstack`), the udev seat-park
  non-destructive recovery, the greetd dead-end, and the SDDM decision.

## Status / testing

Validated at **eval only** (`gdm.enable=false`, `sddm.enable=true`,
`sddm.wayland.enable=true`, display-manager start script references `sddm`). The
`nixos-rebuild switch` is **deferred to the user** — it restarts display-manager and
drops the live SPICE desktop.

**Open risks to verify after switching:**
- SDDM Wayland greeter compositor coming up on the NVIDIA seat-game (fallback:
  per-seat autologin, or X11 greeter).
- No-blank guarantee for the FV43U KVM (the GDM `idle-delay=0` tweak is gone).