### PR TITLE
Type Haku screenshot preview fixtures

### DIFF
--- a/debug/haku_contract_recreation_drift_2026_07_11.md
+++ b/debug/haku_contract_recreation_drift_2026_07_11.md
@@ -273,33 +273,6 @@ Consolidation:
 - use a full clone or deepen/fetch until the stored pin resolves; and
 - test through `Settings` and bootstrap with at least two relevant commits.
 
-### O. Screenshot history fixtures have independently drifted from production tool contracts
-
-Severity: medium
-
-Owner:
-
-- actual preview contracts in `haku/console/frontend/tool_previews/google_calendar.tsx`, `kubectl.tsx`, and `grocy.tsx`
-- recent-call construction in `haku/console/frontend/approval_state.ts:111-114`
-
-Recreation:
-
-- `haku/console/frontend/screenshots/sample_data.ts`
-
-Observed divergence:
-
-- base `stock_add` uses obsolete `{product_id, amount}` arguments;
-- the Calendar history row supplies string `start`/`end` values instead of `EventDateTime` objects;
-- the kubectl row uses stale `kubectl.delete_pod` identifiers rather than `kubectl-passthrough-mcp.pods_delete`;
-- the history fixture's four rows therefore exercise generic JSON rather than custom previews; and
-- `hideAtMs=12000` is an absolute timestamp instead of `now + TTL`, so the screenshot says "Auto-hides now."
-
-Consolidation:
-
-- export typed fixture factories beside each preview registration;
-- assert that every intended custom fixture makes `toolPreview(...)` non-null; and
-- construct recent records through `makeRecentToolCall` at render time.
-
 ## Additional confirmed drift and lower-priority seams
 
 ### Source and prompt duplication
@@ -367,7 +340,7 @@ The audit checked and ruled out several tempting false positives:
 4. C and M — wake-boundary synchronization and valid history.
 5. G and H — repair security/source capability contracts.
 6. I and J — shared approval controller and correct Calendar presentation.
-7. K, L, and O — remove remaining method, routing, and fixture shadows.
+7. K and L — remove remaining method and routing shadows.
 8. P through T — close the extension traps before enabling the affected features.
 
 ## Audit disposition

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -462,6 +462,7 @@ js_library(
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
         "//:node_modules/react-dom",
+        "//haku/console/frontend/tool_previews",
     ],
 )
 
@@ -533,6 +534,7 @@ tsc_bin.tsc_test(
         "mcp_tool_schema.test.ts",
         "open_external.test.ts",
         "routing.test.ts",
+        "screenshots/sample_data.test.ts",
         "screenshot_capture.test.ts",
         # Ambient types for the @tabler/icons-react per-icon subpath imports (icons.tsx).
         "tabler_icons.d.ts",
@@ -570,6 +572,7 @@ vitest_bin.vitest_test(
         "open_external.test.ts",
         "routing.test.ts",
         "screenshot_capture.test.ts",
+        "screenshots/sample_data.test.ts",
         "vitest.config.ts",
         ":approval_state",
         ":bridge",
@@ -579,6 +582,7 @@ vitest_bin.vitest_test(
         ":open_external",
         ":routing",
         ":screenshot_capture",
+        ":screenshot_harness_lib",
         "//:node_modules",
         "//:node_modules/@haku/console-bridge",
         "//haku/console/frontend/tool_previews:gmail_test",

--- a/haku/console/frontend/screenshots/harness.tsx
+++ b/haku/console/frontend/screenshots/harness.tsx
@@ -17,7 +17,7 @@ import { hakuTheme } from "../theme.ts";
 import { approvalDisplayFields } from "../approval_state.ts";
 import { ToolCallCard } from "../tool_call_card.tsx";
 import { ToolCallsPage } from "../tool_calls_page.tsx";
-import { PREVIEW_SAMPLES, SAMPLE_PENDING, SAMPLE_RECENT } from "./sample_data.ts";
+import { PREVIEW_SAMPLES, SAMPLE_PENDING, sampleRecentToolCalls } from "./sample_data.ts";
 
 const noop = () => {};
 
@@ -69,14 +69,13 @@ function PreviewGallery() {
   );
 }
 
-const chromeProps: ShellChromeProps = {
+const chromeProps: Omit<ShellChromeProps, "recentToolCalls"> = {
   approvalsOpen: true,
   onApprovalsOpenChange: noop,
   pendingApprovals: SAMPLE_PENDING,
   geolocationApprovals: [],
   screenshotApprovals: [],
   decidingApprovalIds: [],
-  recentToolCalls: SAMPLE_RECENT,
   onApproveTool: noop,
   onDenyTool: noop,
   onApproveGeolocation: noop,
@@ -109,7 +108,7 @@ function sceneElement(scene: string) {
       // settings + approvals) over the panel column. Approvals starts open; render.mjs clicks
       // the live and location buttons so several panels show stacked by Y (the point of the
       // layout).
-      return <ShellChrome {...chromeProps} />;
+      return <ShellChrome {...chromeProps} recentToolCalls={sampleRecentToolCalls(Date.now())} />;
     case "previews":
       return <PreviewGallery />;
     // The history page; render.mjs expands its first rows into their detailed state (opening the

--- a/haku/console/frontend/screenshots/sample_data.test.ts
+++ b/haku/console/frontend/screenshots/sample_data.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { recentToolCallTtlMs } from "../approval_state.ts";
+import { toolPreview } from "../tool_previews/index.tsx";
+import { PREVIEW_SAMPLES, SAMPLE_PENDING, SAMPLE_TOOL_CALLS, sampleRecentToolCalls } from "./sample_data.ts";
+
+const CUSTOM_HISTORY_IDS = new Set(["tc_1", "tc_2", "tc_3"]);
+const CUSTOM_PENDING_IDS = new Set(["tc_p2"]);
+const INTENTIONAL_FALLBACK = "grocy-sf.shopping_list_items_remove";
+
+function expectCustomPreview(serverId: string, toolName: string, args: Record<string, unknown>): void {
+  for (const variant of ["compact", "detailed"] as const) {
+    expect(toolPreview(serverId, toolName, args, variant), `${serverId}.${toolName} (${variant})`).not.toBeNull();
+  }
+}
+
+describe("screenshot tool-call fixtures", () => {
+  it("dispatches every intended history and approval fixture to a custom preview", () => {
+    const customHistory = SAMPLE_TOOL_CALLS.filter(({ tool_call_id }) => CUSTOM_HISTORY_IDS.has(tool_call_id));
+    const customPending = SAMPLE_PENDING.filter(({ tool_call_id }) => CUSTOM_PENDING_IDS.has(tool_call_id));
+    expect(customHistory).toHaveLength(CUSTOM_HISTORY_IDS.size);
+    expect(customPending).toHaveLength(CUSTOM_PENDING_IDS.size);
+
+    for (const record of customHistory) {
+      expectCustomPreview(record.server_id, record.tool_name, record.arguments ?? {});
+    }
+    for (const approval of customPending) {
+      expectCustomPreview(approval.server_id, approval.tool_name, approval.arguments ?? {});
+    }
+  });
+
+  it("dispatches every gallery fixture except the intentional raw-JSON example", () => {
+    for (const { serverId, toolName, args } of PREVIEW_SAMPLES) {
+      const key = `${serverId}.${toolName}`;
+      if (key === INTENTIONAL_FALLBACK) {
+        expect(toolPreview(serverId, toolName, args, "compact")).toBeNull();
+      } else {
+        expectCustomPreview(serverId, toolName, args);
+      }
+    }
+  });
+
+  it("constructs recent calls relative to the render clock", () => {
+    const nowMs = 20_000;
+    const [recent] = sampleRecentToolCalls(nowMs);
+    expect(recent.hideAtMs).toBe(nowMs + (recentToolCallTtlMs(recent.record.status) ?? 0));
+  });
+});

--- a/haku/console/frontend/screenshots/sample_data.ts
+++ b/haku/console/frontend/screenshots/sample_data.ts
@@ -1,17 +1,54 @@
 // Deterministic sample data for the screenshot scenes (harness.tsx) and the API stub
 // (mock_api.ts). Kept separate so both share one source of truth.
-import type { RecentToolCall } from "../approval_state.ts";
+import { makeRecentToolCall, type RecentToolCall } from "../approval_state.ts";
 import type { McpOperatorAuthStatus, PendingApproval, ToolCallRecord } from "../client.ts";
+import type { RegisteredToolPreviewFixture } from "../tool_previews/index.tsx";
+
+const STOCK_ADD_HISTORY_FIXTURE = {
+  serverId: "grocy-sf",
+  toolName: "stock_add",
+  args: { items: [{ product: "Rolled oats", amount: 2, qu: "pack", location: "Pantry" }] },
+} satisfies RegisteredToolPreviewFixture;
+
+const CALENDAR_HISTORY_FIXTURE = {
+  serverId: "google_calendar",
+  toolName: "create_calendar_event",
+  args: {
+    summary: "Dentist",
+    start: { date_time: "2026-07-12T09:00:00", time_zone: "America/Los_Angeles" },
+    end: { date_time: "2026-07-12T10:00:00", time_zone: "America/Los_Angeles" },
+  },
+} satisfies RegisteredToolPreviewFixture;
+
+const KUBECTL_HISTORY_FIXTURE = {
+  serverId: "kubectl-passthrough-mcp",
+  toolName: "pods_delete",
+  args: { namespace: "haku-sandbox", name: "worker-6f9c2" },
+} satisfies RegisteredToolPreviewFixture;
+
+const STOCK_ADD_PENDING_FIXTURE = {
+  serverId: "grocy-sf",
+  toolName: "stock_add",
+  args: {
+    items: [
+      { product: "Rolled oats", amount: 2, qu: "pack", location: "Pantry" },
+      { product: "Almond butter", amount: 1, qu: "jar", location: "Pantry" },
+      { product: "Frozen berries", amount: 3, qu: "bag", location: "Freezer" },
+      { product: "Oat milk", amount: 6, qu: "carton", location: "Fridge" },
+      { product: "Dark chocolate", amount: 4, qu: "bar", location: "Pantry" },
+    ],
+  },
+} satisfies RegisteredToolPreviewFixture;
 
 function toolCall(overrides: Partial<ToolCallRecord> & Pick<ToolCallRecord, "tool_call_id">): ToolCallRecord {
   return {
-    server_id: "grocy-sf",
-    tool_name: "stock_add",
+    server_id: STOCK_ADD_HISTORY_FIXTURE.serverId,
+    tool_name: STOCK_ADD_HISTORY_FIXTURE.toolName,
     caller_principal: "haku-agent-api-token",
     status: "ok",
     created_at: "2026-07-09T14:32:00Z",
     updated_at: "2026-07-09T14:32:04Z",
-    arguments: { items: [{ product_id: 42, amount: 2 }] },
+    arguments: STOCK_ADD_HISTORY_FIXTURE.args,
     rationale: "Thrive box delivered; adding its items to inventory.",
     title: null,
     result: { content: [{ type: "text", text: "stock_add:42:2" }], isError: false },
@@ -35,27 +72,27 @@ export const SAMPLE_TOOL_CALLS: ToolCallRecord[] = [
   toolCall({ tool_call_id: "tc_1", title: "Add Thrive box items to Grocy", status: "ok" }),
   toolCall({
     tool_call_id: "tc_2",
-    server_id: "google_calendar",
-    tool_name: "create_calendar_event",
+    server_id: CALENDAR_HISTORY_FIXTURE.serverId,
+    tool_name: CALENDAR_HISTORY_FIXTURE.toolName,
     title: "Create calendar event: Dentist",
     status: "error",
     rationale: "Booked a dentist appointment from the confirmation email.",
     error: "Calendar API returned 403: insufficient scope for calendar.events.",
     result: null,
     caller_principal: "operator",
-    arguments: { summary: "Dentist", start: "2026-07-12T09:00:00", end: "2026-07-12T10:00:00" },
+    arguments: CALENDAR_HISTORY_FIXTURE.args,
   }),
   toolCall({
     tool_call_id: "tc_3",
-    server_id: "kubectl",
-    tool_name: "delete_pod",
+    server_id: KUBECTL_HISTORY_FIXTURE.serverId,
+    tool_name: KUBECTL_HISTORY_FIXTURE.toolName,
     title: "Delete crashlooping pod",
     status: "denied",
     rationale: "The worker pod has been CrashLoopBackOff for 20 minutes; restart it.",
     denial_reason: "Not without a rollout plan — investigate the crash first.",
     result: null,
     caller_principal: "operator",
-    arguments: { namespace: "haku-sandbox", pod: "worker-6f9c2" },
+    arguments: KUBECTL_HISTORY_FIXTURE.args,
   }),
 ];
 
@@ -73,30 +110,22 @@ export const SAMPLE_PENDING: PendingApproval[] = [
   {
     // A many-item grocy stock_add — exercises the compact widget's "first few + … +N more".
     tool_call_id: "tc_p2",
-    server_id: "grocy-sf",
-    tool_name: "stock_add",
+    server_id: STOCK_ADD_PENDING_FIXTURE.serverId,
+    tool_name: STOCK_ADD_PENDING_FIXTURE.toolName,
     title: "Add Thrive box items to Grocy",
     caller_principal: "haku-agent-api-token",
     rationale: "Thrive box delivered; adding its items to inventory.",
-    arguments: {
-      items: [
-        { product: "Rolled oats", amount: 2, qu: "pack", location: "Pantry" },
-        { product: "Almond butter", amount: 1, qu: "jar", location: "Pantry" },
-        { product: "Frozen berries", amount: 3, qu: "bag", location: "Freezer" },
-        { product: "Oat milk", amount: 6, qu: "carton", location: "Fridge" },
-        { product: "Dark chocolate", amount: 4, qu: "bar", location: "Pantry" },
-      ],
-    },
+    arguments: STOCK_ADD_PENDING_FIXTURE.args,
     created_at: "2026-07-09T14:41:00Z",
   },
 ];
 
-export const SAMPLE_RECENT: RecentToolCall[] = [
-  {
-    record: toolCall({ tool_call_id: "tc_r1", title: "Add Thrive box items to Grocy", status: "ok" }),
-    hideAtMs: 12_000,
-  },
-];
+export function sampleRecentToolCalls(nowMs: number): RecentToolCall[] {
+  const record = toolCall({ tool_call_id: "tc_r1", title: "Add Thrive box items to Grocy", status: "ok" });
+  const recent = makeRecentToolCall(record, nowMs);
+  if (!recent) throw new Error(`Expected terminal screenshot fixture, got ${record.status}`);
+  return [recent];
+}
 
 export const SAMPLE_MCP: McpOperatorAuthStatus[] = [
   {
@@ -142,15 +171,18 @@ export const SAMPLE_CALENDAR_SUMMARY = {
   html_link: "https://calendar.google.com/calendar/u/0/r?cid=ZmFtaWx5QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20",
 };
 
-// Every implemented tool-call preview, for the `previews` gallery scene (harness.tsx renders
-// each in both compact and detailed). Real server ids + tool names so the registry dispatches
-// to each widget; the final entry has no widget, exercising the raw-JSON fallback.
-export const PREVIEW_SAMPLES: {
+type PreviewSample = {
   title: string;
   serverId: string;
   toolName: string;
   args: Record<string, unknown>;
-}[] = [
+};
+
+// Every implemented tool-call preview, for the `previews` gallery scene (harness.tsx renders
+// each in both compact and detailed). The registered entries are a discriminated union derived
+// from the registry's actual Zod schemas, so a stale id or argument is a type error. The final
+// entry intentionally has no widget and exercises the raw-JSON fallback.
+const CUSTOM_PREVIEW_SAMPLES = [
   {
     title: "Add Thrive box items to stock",
     serverId: "grocy-sf",
@@ -312,11 +344,14 @@ export const PREVIEW_SAMPLES: {
       keepSourceReference: true,
     },
   },
-  {
-    // No widget for this (server, tool) — the generic raw-JSON fallback (compact clamps).
-    title: "Remove purchased shopping-list items",
-    serverId: "grocy-sf",
-    toolName: "shopping_list_items_remove",
-    args: { ids: [3, 7, 12, 15, 21, 34, 42, 55] },
-  },
-];
+] satisfies (RegisteredToolPreviewFixture & { title: string })[];
+
+const FALLBACK_PREVIEW_SAMPLE: PreviewSample = {
+  // No widget for this (server, tool) — the generic raw-JSON fallback (compact clamps).
+  title: "Remove purchased shopping-list items",
+  serverId: "grocy-sf",
+  toolName: "shopping_list_items_remove",
+  args: { ids: [3, 7, 12, 15, 21, 34, 42, 55] },
+};
+
+export const PREVIEW_SAMPLES: PreviewSample[] = [...CUSTOM_PREVIEW_SAMPLES, FALLBACK_PREVIEW_SAMPLE];

--- a/haku/console/frontend/tool_previews/BUILD.bazel
+++ b/haku/console/frontend/tool_previews/BUILD.bazel
@@ -128,6 +128,7 @@ js_library(
         ":tana",
         ":variant",
         "//:node_modules/react",
+        "//:node_modules/zod",
     ],
 )
 

--- a/haku/console/frontend/tool_previews/entry.tsx
+++ b/haku/console/frontend/tool_previews/entry.tsx
@@ -12,8 +12,8 @@ import type { PreviewProps, PreviewVariant } from "./variant.tsx";
  * Delete Pod"). `destructive` colors it as a danger cue (irreversible deletes). */
 export type ToolAction = { text: string; destructive?: boolean };
 
-export type ToolPreview = {
-  schema: z.ZodTypeAny;
+export type ToolPreview<S extends z.ZodTypeAny = z.ZodTypeAny> = {
+  schema: S;
   // Stored with `never` args: the schema-specific type is checked at the `definePreview` call
   // site and erased here so a heterogeneous `Record<string, ToolPreview>` holds every tool's
   // entry. `renderPreview`/`describeAction` are the one place that feed them the parsed output.
@@ -30,7 +30,7 @@ export function definePreview<S extends z.ZodTypeAny>(
   schema: S,
   Widget: (props: PreviewProps<z.infer<S>>) => ReactNode,
   describe?: (args: z.infer<S>) => ToolAction
-): ToolPreview {
+): ToolPreview<S> {
   const render = (args: z.infer<S>, variant: PreviewVariant): ReactNode => <Widget args={args} variant={variant} />;
   return { schema, render: render as ToolPreview["render"], describe: describe as ToolPreview["describe"] };
 }

--- a/haku/console/frontend/tool_previews/index.tsx
+++ b/haku/console/frontend/tool_previews/index.tsx
@@ -6,6 +6,7 @@
 // file never grows a hand-maintained `??` chain. `variant` picks the compact vs detailed rendering.
 
 import type { ReactNode } from "react";
+import type { z } from "zod";
 
 import { describeAction, renderPreview, type ToolAction, type ToolPreview } from "./entry.tsx";
 import { GMAIL_SERVER_ID, gmailPreviews } from "./gmail.tsx";
@@ -16,14 +17,31 @@ import { KUBECTL_SERVER_ID, kubectlPreviews } from "./kubectl.tsx";
 import { TANA_RW_SERVER_ID, tanaPreviews } from "./tana.tsx";
 import type { PreviewVariant } from "./variant.tsx";
 
-const REGISTRY: Record<string, Record<string, ToolPreview>> = {
+const REGISTRY = {
   [GMAIL_SERVER_ID]: gmailPreviews,
   [GOOGLE_CALENDAR_SERVER_ID]: googleCalendarPreviews,
   [GROCY_SERVER_ID]: grocyPreviews,
   [HAKU_ROUTINE_SERVER_ID]: hakuRoutinePreviews,
   [KUBECTL_SERVER_ID]: kubectlPreviews,
   [TANA_RW_SERVER_ID]: tanaPreviews,
-};
+} as const satisfies Record<string, Record<string, ToolPreview>>;
+
+type PreviewRegistry = typeof REGISTRY;
+const RUNTIME_REGISTRY: Record<string, Record<string, ToolPreview>> = REGISTRY;
+
+/** A fixture whose server, tool, and arguments are tied to one registered preview schema.
+ * In-process schemas originate in FastMCP's tools/list catalog; remote-server previews retain
+ * their hand-authored Zod contract. `satisfies RegisteredToolPreviewFixture` therefore makes
+ * fixture drift a TypeScript error without widening the fixture's literal values. `z.output`
+ * is intentional: the generated adapter pins `ZodType<GeneratedArguments>` as its output type,
+ * while Zod 4 leaves that generic type's input as `unknown`. */
+export type RegisteredToolPreviewFixture = {
+  [ServerId in keyof PreviewRegistry]: {
+    [ToolName in keyof PreviewRegistry[ServerId]]: PreviewRegistry[ServerId][ToolName] extends ToolPreview<infer Schema>
+      ? { serverId: ServerId; toolName: ToolName; args: z.output<Schema> }
+      : never;
+  }[keyof PreviewRegistry[ServerId]];
+}[keyof PreviewRegistry];
 
 export function toolPreview(
   serverId: string,
@@ -31,7 +49,7 @@ export function toolPreview(
   args: Record<string, unknown>,
   variant: PreviewVariant
 ): ReactNode | null {
-  const preview = REGISTRY[serverId]?.[toolName];
+  const preview = RUNTIME_REGISTRY[serverId]?.[toolName];
   return preview ? renderPreview(preview, args, variant) : null;
 }
 
@@ -42,6 +60,6 @@ export function toolActionDescription(
   toolName: string,
   args: Record<string, unknown>
 ): ToolAction | null {
-  const preview = REGISTRY[serverId]?.[toolName];
+  const preview = RUNTIME_REGISTRY[serverId]?.[toolName];
   return preview ? describeAction(preview, args) : null;
 }

--- a/props/specimens/ducktape/2026-07-11-00/issues/untyped-screenshot-fixtures.yaml
+++ b/props/specimens/ducktape/2026-07-11-00/issues/untyped-screenshot-fixtures.yaml
@@ -1,0 +1,11 @@
+rationale: |
+  The screenshot data recreates tool contracts as untyped records instead of checking them against the registered preview schemas. Its default Grocy call uses obsolete `product_id` arguments, its Calendar row supplies strings instead of `EventDateTime` objects, and its kubectl row names a different server and tool; all three therefore exercise generic JSON instead of their custom previews. The recent-call fixture also hard-codes an expired absolute `hideAtMs`. Bind custom fixtures to the preview schemas, assert that they dispatch to a custom preview, and construct recent calls through the production TTL helper.
+should_flag: true
+occurrences:
+  - occurrence_id: occ-0
+    files:
+      haku/console/frontend/screenshots/sample_data.ts:
+        - [6, 22]
+        - [24, 60]
+        - [94, 99]
+        - [145, 300]


### PR DESCRIPTION
## Summary

- preserve each registered preview's concrete Zod schema type and export a discriminated fixture union from the registry
- make screenshot history and gallery fixtures satisfy the generated FastMCP-derived schemas, with an erased view only for runtime string lookup
- correct stale Grocy, Calendar, and kubectl samples and compute recent-tool-call expiry relative to render time
- test custom-preview dispatch and exact recent-call TTL behavior
- record the specimen issue and remove resolved finding O from the audit report

## Validation

- bbr test //haku/console/frontend:bridge_test //haku/console/frontend:tsc_test //props/specimens/ducktape/2026-07-11-00:test_specimen
- forced-fresh //haku/console/frontend:screenshots_test with remote cache reads disabled
- visually inspected all 8 screenshot outputs in light and dark themes, including all five slices of each long preview-gallery image