### PR TITLE
haku/console: let tool-call card text reclaim full width below the badge

### DIFF
--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -256,6 +256,26 @@
   padding: 0.75rem;
 }
 
+/* The card's identity header: title + action line + rationale/error subheads. The status badge
+   and Brief/Full selector float top-right (`haku-card-head-actions`) so the text wraps under them
+   on the first line(s) and reclaims the full card width below, rather than every line being
+   narrowed to leave the badge's column empty. `flow-root` contains the float within the header. */
+.haku-card-head {
+  display: flow-root;
+}
+
+.haku-card-head-actions {
+  float: right;
+  margin-left: var(--mantine-spacing-sm);
+  margin-bottom: 0.35rem;
+}
+
+/* The tight vertical rhythm the flex Stack used to give the stacked text lines (the float is the
+   first child, so the title — the first non-float line — takes no top margin). */
+.haku-card-head > :not(.haku-card-head-actions) + :not(.haku-card-head-actions) {
+  margin-top: 2px;
+}
+
 .haku-shell-countdown {
   display: flex;
   flex-direction: column;

--- a/haku/console/frontend/tool_call_card.tsx
+++ b/haku/console/frontend/tool_call_card.tsx
@@ -38,43 +38,44 @@ export function ToolCallCard({
   return (
     <section className="haku-shell-card">
       <Stack gap="sm">
-        <Group justify="space-between" align="flex-start" gap="sm" wrap="nowrap">
-          <Stack gap={2} style={{ minWidth: 0 }}>
-            <Text fw={600} size="sm">
-              {fields.title}
-            </Text>
-            <ToolActionLine serverId={fields.serverId} toolName={fields.toolName} args={args} />
-            {fields.rationale && <Text size="xs">{fields.rationale}</Text>}
-            {error && (
-              <Text size="xs" c="red">
-                {error}
-              </Text>
-            )}
-            {fields.denialReason && (
-              <Text size="xs" c="dimmed">
-                Denied: {fields.denialReason}
-              </Text>
-            )}
-            {fields.approvalPolicyId && (
-              <Text size="xs" c="dimmed">
-                Auto-approved by {fields.approvalPolicyId}
-              </Text>
-            )}
-            {fields.autoApprovalEvaluation && (
-              <Text size="xs" c="dimmed">
-                Auto-approval: {fields.autoApprovalEvaluation}
-              </Text>
-            )}
-          </Stack>
-          {/* Status badge left of the Brief/Full selector, anchored top-right: detail expands
-              below, so the selector never moves out from under the pointer. */}
-          <Group gap="xs" align="center" wrap="nowrap" style={{ flexShrink: 0 }}>
+        {/* The badge + Brief/Full selector float to the top-right so the title and subheads wrap
+            under them on the first line(s) and reclaim the full width below, instead of the whole
+            text column being narrowed for every line. Anchored top so detail expands below and the
+            selector stays put under the pointer. Block flow (not a flex Stack) so text wraps
+            around the float; `haku-card-head` supplies the tight inter-line rhythm. */}
+        <div className="haku-card-head">
+          <Group className="haku-card-head-actions" gap="xs" align="center" wrap="nowrap">
             <Badge color={status.color} variant="light">
               {status.label}
             </Badge>
             <VariantControl variant={variant} onChange={onVariantChange} />
           </Group>
-        </Group>
+          <Text fw={600} size="sm">
+            {fields.title}
+          </Text>
+          <ToolActionLine serverId={fields.serverId} toolName={fields.toolName} args={args} />
+          {fields.rationale && <Text size="xs">{fields.rationale}</Text>}
+          {error && (
+            <Text size="xs" c="red">
+              {error}
+            </Text>
+          )}
+          {fields.denialReason && (
+            <Text size="xs" c="dimmed">
+              Denied: {fields.denialReason}
+            </Text>
+          )}
+          {fields.approvalPolicyId && (
+            <Text size="xs" c="dimmed">
+              Auto-approved by {fields.approvalPolicyId}
+            </Text>
+          )}
+          {fields.autoApprovalEvaluation && (
+            <Text size="xs" c="dimmed">
+              Auto-approval: {fields.autoApprovalEvaluation}
+            </Text>
+          )}
+        </div>
         <ToolArgumentsField
           serverId={fields.serverId}
           toolName={fields.toolName}


### PR DESCRIPTION
## Problem

In the tool-call card (`tool_call_card.tsx`), the status badge + Brief/Full selector were a flex sibling of the *entire* text column (`<Group justify="space-between">`). Flex `space-between` narrows the text column to leave room for the badge on **every** line — so the title, action line, and the multi-line error/description all wrapped early, leaving an empty column on the right even for lines nowhere near the badge.

This showed up as wasted space to the right of the description/error text on any card whose text ran longer than the badge's single row (e.g. the `ERROR` cards in the approvals drawer and history view).

## Fix

- **`haku/console/frontend/tool_call_card.tsx`**: float the badge/selector group to the top-right and render the header text as normal block flow (not a Mantine `Stack` — flex containers don't wrap around floats). The text now wraps *under* the badge on the first line(s) and reclaims the full card width below it. The badge stays anchored top so switching to Full still grows content below it.
- **`haku/console/frontend/styles.src.css`**: added `.haku-card-head` (a `flow-root` container that contains the float), `.haku-card-head-actions` (the floated badge group with left/bottom spacing), and a sibling-margin rule that restores the tight inter-line rhythm the flex `Stack` used to provide.

## Testing

`bbr test //haku/console/frontend/...` passes (tsc, vitest, and the screenshots generator). Downloaded and eyeballed the `chrome` (approvals drawer) and `history` scenes in both light and dark themes: the wrapping text now spans full width, the badge is cleanly anchored top-right, and nothing overflows or collides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKcVK3SpUPJ5AzdAoNz6qB)_