### PR TITLE
haku-console: auto-approve read-only grocy-sf + tana calendar-node calls

### DIFF
--- a/haku/console/auto_approval.py
+++ b/haku/console/auto_approval.py
@@ -15,6 +15,49 @@ logger = logging.getLogger(__name__)
 
 HAKU_AGENT_PRINCIPAL = "haku-agent-api-token"
 GMAIL_AUTO_APPROVAL_ID = "v1"
+UNCONDITIONAL_AUTO_APPROVAL_ID = "unconditional_v1"
+
+# Remote (operator_oauth) server ids — must match the console config
+# (`cluster/k8s/haku/console/config.yaml`).
+GROCY_SF_SERVER_ID = "grocy-sf"
+TANA_RW_SERVER_ID = "tana-rw"
+
+# The reviewed read-only subset of grocy-sf's tools (get/list only — every create/edit/delete/add/
+# consume/set/transfer/undo/merge/clear/upload stays approval-gated).
+GROCY_READ_TOOLS = frozenset(
+    {
+        "entities_get",
+        "entities_list",
+        "file_get",
+        "get_below_minimum_stock",
+        "get_current_user",
+        "get_db_changed_time",
+        "get_expired_stock",
+        "get_expiring_stock",
+        "get_product_stock",
+        "get_system_info",
+        "list_volatile_stock",
+        "locations_list",
+        "product_groups_list",
+        "products_list",
+        "quantity_units_list",
+        "shopping_list_get",
+        "shopping_lists_list",
+        "stock_entries_list",
+        "stock_get",
+    }
+)
+# tana-rw tools auto-approved regardless of arguments. `get_or_create_calendar_node` is idempotent
+# (it just resolves/creates a date container), so it is safe to auto-allow.
+TANA_AUTO_APPROVE_TOOLS = frozenset({"get_or_create_calendar_node"})
+
+# (server_id -> tools) auto-approved for the Haku agent regardless of arguments. These are remote
+# operator_oauth servers with no in-process schema, so their arguments are validated by the upstream
+# at execution time (not here).
+UNCONDITIONAL_AUTO_APPROVE: dict[str, frozenset[str]] = {
+    GROCY_SF_SERVER_ID: GROCY_READ_TOOLS,
+    TANA_RW_SERVER_ID: TANA_AUTO_APPROVE_TOOLS,
+}
 
 
 async def auto_approve_tool_call(
@@ -29,12 +72,19 @@ async def auto_approve_tool_call(
 ) -> tuple[str | None, str | None]:
     """Return the approving policy ID and an audit-safe evaluation string.
 
-    The existing FastMCP tool is the input-contract source of truth. Its published
-    schema is synthesized from the callable signature and validated here before the
-    Gmail-specific semantic boundary is evaluated. Any schema, lookup, or policy
-    error is logged and fails closed.
+    Unconditionally allowlisted read-only/safe tools (grocy-sf reads, tana
+    `get_or_create_calendar_node`) approve regardless of arguments. Gmail calls go through the
+    existing boundary: the FastMCP tool's published schema is validated before the label-prefix
+    semantic check. Any schema, lookup, or policy error is logged and fails closed.
     """
-    if caller_principal != HAKU_AGENT_PRINCIPAL or server_id != GMAIL_SERVER_ID:
+    if caller_principal != HAKU_AGENT_PRINCIPAL:
+        return None, None
+    # Remote read-only/safe allowlist (grocy-sf reads, tana get_or_create_calendar_node): these are
+    # operator_oauth servers with no in-process schema, so the upstream validates arguments at
+    # execution time rather than here.
+    if tool_name in UNCONDITIONAL_AUTO_APPROVE.get(server_id, frozenset()):
+        return UNCONDITIONAL_AUTO_APPROVAL_ID, f"approved: {server_id}/{tool_name} is allowlisted read-only/safe"
+    if server_id != GMAIL_SERVER_ID:
         return None, None
     if tool_name not in {
         "threads_list",

--- a/haku/console/test_auto_approval.py
+++ b/haku/console/test_auto_approval.py
@@ -6,7 +6,14 @@ import pytest
 import pytest_bazel
 
 from gmail_api.labels import GmailLabel, LabelType
-from haku.console.auto_approval import GMAIL_AUTO_APPROVAL_ID, auto_approve_tool_call
+from haku.console.auto_approval import (
+    GMAIL_AUTO_APPROVAL_ID,
+    GROCY_READ_TOOLS,
+    GROCY_SF_SERVER_ID,
+    TANA_RW_SERVER_ID,
+    UNCONDITIONAL_AUTO_APPROVAL_ID,
+    auto_approve_tool_call,
+)
 from haku.console.tools.gmail import build_mcp
 
 
@@ -105,6 +112,47 @@ async def test_lookup_errors_are_logged_and_fail_closed(caplog: pytest.LogCaptur
         )
     assert "auto-approval evaluation failed" in caplog.text
     assert "gmail unavailable" in caplog.text
+
+
+async def _remote_decision(server_id: str, tool_name: str, arguments: dict, *, caller: str = "haku-agent-api-token"):
+    # Remote (operator_oauth) servers have no in-process schema, so gmail/mcp are unused.
+    return await auto_approve_tool_call(
+        caller_principal=caller,
+        server_id=server_id,
+        tool_name=tool_name,
+        arguments=arguments,
+        label_prefix="haku/",
+        gmail=None,
+        mcp=None,
+    )
+
+
+@pytest.mark.parametrize("tool_name", sorted(GROCY_READ_TOOLS))
+async def test_grocy_reads_are_auto_approved(tool_name: str) -> None:
+    policy_id, evaluation = await _remote_decision(GROCY_SF_SERVER_ID, tool_name, {})
+    assert policy_id == UNCONDITIONAL_AUTO_APPROVAL_ID
+    assert evaluation is not None
+    assert "read-only/safe" in evaluation
+
+
+async def test_grocy_mutations_are_not_auto_approved() -> None:
+    # A mutating grocy tool is not in the read allowlist, so it stays manual (grocy-sf ≠ gmail path).
+    assert await _remote_decision(GROCY_SF_SERVER_ID, "stock_add", {"items": []}) == (None, None)
+
+
+async def test_tana_calendar_node_is_auto_approved() -> None:
+    policy_id, _evaluation = await _remote_decision(
+        TANA_RW_SERVER_ID, "get_or_create_calendar_node", {"date": "2026-07-12"}
+    )
+    assert policy_id == UNCONDITIONAL_AUTO_APPROVAL_ID
+
+
+async def test_tana_other_tools_are_not_auto_approved() -> None:
+    assert await _remote_decision(TANA_RW_SERVER_ID, "create_tag", {"name": "X"}) == (None, None)
+
+
+async def test_remote_allowlist_only_for_haku_agent() -> None:
+    assert await _remote_decision(GROCY_SF_SERVER_ID, "stock_get", {}, caller="operator") == (None, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extends haku-console's reviewed auto-approval decision (`auto_approval.py`) so the **Haku agent**'s calls to a fixed read-only/safe allowlist skip the operator click — alongside the existing gmail reads + `haku/`-prefixed label ops.

New unconditional grants (haku-agent-only, regardless of arguments):

- **grocy-sf** — the read subset (get/list): `entities_get/list`, `file_get`, the stock/expiry/volatile reads, `products_list`, `shopping_list_get`/`shopping_lists_list`, `locations_list`, `product_groups_list`, `quantity_units_list`, `stock_entries_list`/`stock_get`, plus the meta reads `get_system_info` / `get_current_user` / `get_db_changed_time` (19 tools). Every mutating tool (create/edit/delete/add/consume/set/transfer/undo/merge/clear/upload) stays operator-gated.
- **tana-rw** — `get_or_create_calendar_node` only (an idempotent date-container resolver).

These are remote `operator_oauth` servers with no in-process schema, so their arguments are validated by the upstream at execution time rather than in the decision; the gmail path (in-process schema validation + `haku/` label-prefix boundary) is unchanged, and the `caller_principal == haku-agent-api-token` gate is unchanged.

### Tests
`bbr test //haku/console:test_auto_approval` — green (lint + mypy on). Adds parametrized coverage that every grocy read tool + tana `get_or_create_calendar_node` auto-approves, that grocy mutations / other tana tools stay manual, and that the allowlist applies only to the Haku agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019tW4iVjWuMngn9sx8BZjq8)_