### PR TITLE
ci: unbreak devel — drop committed conflict markers + dead gmail-labeling image entry

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -99,11 +99,6 @@ jobs:
             }
           - { image: "@ducktape_manifold_mcp_server//:image", image_name: manifold-mcp-server, test_target: "" }
           - {
-              image: "//haku/gmail_labeling:image",
-              image_name: gmail-labeling,
-              test_target: "//haku/gmail_labeling/... //gmail_api/...",
-            }
-          - {
               image: "//x/postscanmail_mcp_server:image",
               image_name: postscanmail-mcp-server,
               test_target: "//x/postscanmail_mcp_server/...",

--- a/haku/plans/multi_agent.md
+++ b/haku/plans/multi_agent.md
@@ -48,17 +48,15 @@ New local-inference follow-up: <local_dispatch_zone.md>. It adapts the existing 
 perimeter to Ollama-hosted models and adds an active-model scheduler so local workers do
 not thrash model residency by running agents across multiple models at once.
 
-<<<<<<< Updated upstream
 New application follow-up: <kitchen_stocking_subagent.md>. Fleshes out the grocery-order
 bounded-write MCP line above into a first design pass for a kitchen/household-stocking
 subagent (operator, 2026-07-11) — a candidate first real workload for the oai or local zone,
 using the existing `grocy_mcp/eval` harness (already model-agnostic) to pick the tier.
-=======
+
 Capability-oriented follow-up: <capability_dispatch.md>. It generalizes zone dispatch into
 model + prompt + reviewed capability-profile launches, integrates dispatch through
 haku-console/MCP, and sketches Google-data, public-coding, garden, and specialist profiles
 without conflating provider trust with tool authority.
->>>>>>> Stashed changes
 
 ## The oai zone (step 5)
 


### PR DESCRIPTION
Devel has two standing CI failures, both pre-existing (not from #3071/#3072):

1. **Pre-commit checks red since `8091141` (09:25Z)**: that commit ("Add Haku multi-agent plan") committed a literal stash-pop conflict block into `haku/plans/multi_agent.md`; prettier rewrites the `>>>>>>> Stashed changes` line on every run, so the hook always "makes changes" and fails. Resolved by keeping both paragraphs — the pre-existing `kitchen_stocking_subagent.md` follow-up and the stashed `capability_dispatch.md` one. Heads-up: `haku/plans/capability_dispatch.md` itself isn't committed anywhere — presumably still in your stash; the paragraph now points at a file that doesn't exist yet.

2. **CI workflow red on every devel push in visible history**: `push-images / Push gmail-labeling` fails with `no targets found beneath 'haku/gmail_labeling'`. No `haku/gmail_labeling` directory exists, and the matrix entry is the only reference to it in the entire repo — nothing under `cluster/` and no live workload consumes a `gmail-labeling` image. Dropped the matrix entry; if the component comes back, the entry returns with the code.

With both fixes the latest devel CI run's failure set (exactly 1 job of 30 + the pre-commit workflow) goes to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TtTn5QxUz8CVd3mS8VA9F

---
_Generated by [Claude Code](https://claude.ai/code/session_011TtTn5QxUz8CVd3mS8VA9F)_