### PR TITLE
Document garden maintenance follow-up and propagation graph model

### DIFF
--- a/haku/plans/multi_agent.md
+++ b/haku/plans/multi_agent.md
@@ -58,6 +58,18 @@ model + prompt + reviewed capability-profile launches, integrates dispatch throu
 haku-console/MCP, and sketches Google-data, public-coding, garden, and specialist profiles
 without conflating provider trust with tool authority.
 
+Garden-maintenance follow-up (haku-state, 2026-07-12 — lives in state, not here, since it's
+Haku's own method): operator asked for a principled model of the propagation checklists as a
+graph, motivated in part by this doc's subagent-boundary question. The resulting design —
+[`plans/propagation_graph_model.md`](https://git.allegedly.works/haku/haku-state/src/branch/main/plans/propagation_graph_model.md)
+maps propagation-graph edges onto the trust tiers this doc defines (same-trust in-session
+subagent vs. zone worker, by whether the edge touches private content) and treats a
+cross-boundary edge as needing one of the two sync mechanisms already built here (tool-call
+approval, dispatch-plane result polling) — plus four concrete maintenance-subagent proposals in
+[`plans/garden_maintenance_subagents.md`](https://git.allegedly.works/haku/haku-state/src/branch/main/plans/garden_maintenance_subagents.md),
+all reasoned to be same-trust-tier (in-session, not zone-dispatchable) since they read private
+haku-state content.
+
 ## The oai zone (step 5)
 
 The middle trust level the two-level design lacked: OpenAI, subscription-billed, trusted


### PR DESCRIPTION
## Summary
Added documentation of the garden-maintenance follow-up work, including references to the propagation graph model design and concrete maintenance-subagent proposals that were developed in the haku-state repository.

## Changes
- Added a new section documenting the garden-maintenance follow-up (dated 2026-07-12) that explains:
  - The operator's request for a principled model of propagation checklists as a graph
  - How the resulting propagation graph design maps edges onto the trust tiers defined in this document
  - The relationship between cross-boundary edges and existing sync mechanisms (tool-call approval and dispatch-plane result polling)
  - References to detailed designs in the haku-state repository:
    - `plans/propagation_graph_model.md` - the graph model design
    - `plans/garden_maintenance_subagents.md` - four concrete maintenance-subagent proposals
  - Rationale for why maintenance subagents are classified as same-trust-tier (in-session) due to their access to private haku-state content

## Implementation Details
The addition clarifies the relationship between the multi-agent architecture defined in this document and the garden maintenance work, showing how trust tier boundaries and sync mechanisms apply to the propagation graph model.

https://claude.ai/code/session_01HcpwEpqPS8NKnGwcSXhCqL