### PR TITLE
Render common operator tools in Haku console

### DIFF
--- a/haku/console/export_mcp_tool_schemas.py
+++ b/haku/console/export_mcp_tool_schemas.py
@@ -39,10 +39,14 @@ _SERVER_TOOL_ALLOWLIST: dict[str, frozenset[str]] = {
             "stock_add",
             "stock_consume",
             "stock_entry_edit",
+            "stock_get",
             "products_create",
+            "products_list",
+            "quantity_units_list",
             "products_edit",
             "shopping_list_get",
             "shopping_list_items_add",
+            "shopping_list_items_remove",
             "shopping_list_item_edit",
         }
     )

--- a/haku/console/export_mcp_tool_schemas.py
+++ b/haku/console/export_mcp_tool_schemas.py
@@ -38,6 +38,7 @@ _SERVER_TOOL_ALLOWLIST: dict[str, frozenset[str]] = {
         {
             "stock_add",
             "stock_consume",
+            "stock_entry_edit",
             "products_create",
             "products_edit",
             "shopping_list_get",

--- a/haku/console/frontend/screenshots/sample_data.test.ts
+++ b/haku/console/frontend/screenshots/sample_data.test.ts
@@ -8,10 +8,6 @@ import { PREVIEW_SAMPLES, SAMPLE_PENDING, SAMPLE_TOOL_CALLS, sampleRecentToolCal
 
 const CUSTOM_HISTORY_IDS = new Set(["tc_1", "tc_2", "tc_3"]);
 const CUSTOM_PENDING_IDS = new Set(["tc_p2"]);
-// Gallery entries whose *arguments* intentionally hit the raw-JSON fallback (no request widget).
-const INTENTIONAL_ARGS_FALLBACKS = new Set(["grocy-sf.shopping_list_items_remove"]);
-// The one gallery entry whose *result* intentionally hits the raw-JSON result fallback.
-const INTENTIONAL_RESULT_FALLBACK = "grocy-sf.shopping_list_items_remove";
 
 function expectCustomPreview(serverId: string, toolName: string, args: Record<string, unknown>): void {
   for (const variant of ["compact", "detailed"] as const) {
@@ -34,18 +30,13 @@ describe("screenshot tool-call fixtures", () => {
     }
   });
 
-  it("dispatches every gallery fixture except the intentional raw-JSON examples", () => {
+  it("dispatches every gallery fixture", () => {
     for (const { serverId, toolName, args } of PREVIEW_SAMPLES) {
-      const key = `${serverId}.${toolName}`;
-      if (INTENTIONAL_ARGS_FALLBACKS.has(key)) {
-        expect(toolPreview(serverId, toolName, args, "compact")).toBeNull();
-      } else {
-        expectCustomPreview(serverId, toolName, args);
-      }
+      expectCustomPreview(serverId, toolName, args);
     }
   });
 
-  it("dispatches every gallery result payload to a custom result preview, except the intentional fallback", () => {
+  it("dispatches every gallery result payload to a custom result preview", () => {
     const withResults = PREVIEW_SAMPLES.filter(({ result }) => result != null);
     // Covers every server with a result widget plus both fallback paths.
     expect(withResults.length).toBeGreaterThanOrEqual(5);
@@ -55,11 +46,7 @@ describe("screenshot tool-call fixtures", () => {
       expect(payload, key).not.toBeNull();
       for (const variant of ["compact", "detailed"] as const) {
         const node = toolResultPreview(serverId, toolName, payload, variant);
-        if (key === INTENTIONAL_RESULT_FALLBACK) {
-          expect(node, key).toBeNull();
-        } else {
-          expect(node, `${key} (${variant})`).not.toBeNull();
-        }
+        expect(node, `${key} (${variant})`).not.toBeNull();
       }
     }
   });

--- a/haku/console/frontend/screenshots/sample_data.ts
+++ b/haku/console/frontend/screenshots/sample_data.ts
@@ -529,17 +529,15 @@ const CUSTOM_PREVIEW_SAMPLES = [
   },
 ] satisfies (RegisteredToolPreviewFixture & { title: string; result?: StoredToolResult })[];
 
-const FALLBACK_PREVIEW_SAMPLE: PreviewSample = {
-  // No widget for this (server, tool), arguments or result — the generic raw-JSON fallbacks
-  // (compact clamps the arguments; the result shows only in detailed, as a labelled field).
+const SHOPPING_REMOVE_PREVIEW_SAMPLE = {
   title: "Remove purchased shopping-list items",
   serverId: "grocy-sf",
   toolName: "shopping_list_items_remove",
-  args: { ids: [3, 7, 12, 15, 21, 34, 42, 55] },
+  args: { item_ids: [3, 7, 12, 15, 21, 34, 42, 55] },
   result: callToolResult([
     { kind: "ok", item_id: 3, product_name: "Milk", amount: 1, qu_name: "Carton" },
     { kind: "ok", item_id: 7, product_name: "Spinach", amount: 200, qu_name: "Gram" },
   ]),
-};
+} satisfies RegisteredToolPreviewFixture & { title: string; result: StoredToolResult };
 
-export const PREVIEW_SAMPLES: PreviewSample[] = [...CUSTOM_PREVIEW_SAMPLES, FALLBACK_PREVIEW_SAMPLE];
+export const PREVIEW_SAMPLES: PreviewSample[] = [...CUSTOM_PREVIEW_SAMPLES, SHOPPING_REMOVE_PREVIEW_SAMPLE];

--- a/haku/console/frontend/tool_rendering/grocy/requests.test.ts
+++ b/haku/console/frontend/tool_rendering/grocy/requests.test.ts
@@ -35,6 +35,18 @@ describe("grocyPreviews", () => {
     }
   });
 
+  it("renders stock_entry_edit partial updates and cleared fields, in both variants", () => {
+    for (const variant of ["compact", "detailed"] as const) {
+      expect(
+        renderPreview(
+          grocyPreviews.stock_entry_edit,
+          { items: [{ entry_id: 189, price: 9.99, location: "Pantry", open: true, clear_fields: ["note"] }] },
+          variant
+        )
+      ).not.toBeNull();
+    }
+  });
+
   it("renders shopping_list_get in both variants", () => {
     for (const variant of ["compact", "detailed"] as const) {
       expect(renderPreview(grocyPreviews.shopping_list_get, { shopping_list: "Weekly" }, variant)).not.toBeNull();

--- a/haku/console/frontend/tool_rendering/grocy/requests.test.ts
+++ b/haku/console/frontend/tool_rendering/grocy/requests.test.ts
@@ -47,6 +47,17 @@ describe("grocyPreviews", () => {
     }
   });
 
+  it("renders stock/list/system reads and shopping-list removal", () => {
+    const cases = [
+      [grocyPreviews.stock_get, { products: ["Oats"], locations: [2] }],
+      [grocyPreviews.products_list, { detail: "brief" }],
+      [grocyPreviews.quantity_units_list, { detail: "full" }],
+      [grocyPreviews.get_system_info, {}],
+      [grocyPreviews.shopping_list_items_remove, { item_ids: [3, 7] }],
+    ] as const;
+    for (const [preview, args] of cases) expect(renderPreview(preview, args, "detailed")).not.toBeNull();
+  });
+
   it("renders shopping_list_get in both variants", () => {
     for (const variant of ["compact", "detailed"] as const) {
       expect(renderPreview(grocyPreviews.shopping_list_get, { shopping_list: "Weekly" }, variant)).not.toBeNull();

--- a/haku/console/frontend/tool_rendering/grocy/requests.tsx
+++ b/haku/console/frontend/tool_rendering/grocy/requests.tsx
@@ -37,6 +37,7 @@ export const GROCY_SERVER_ID = "grocy-sf";
 // come through as `string | number`; a `date` field as `string`; a `set` as an array.
 const zStockAddArgs = mcpToolSchema(GROCY_SERVER_ID, "stock_add");
 const zStockConsumeArgs = mcpToolSchema(GROCY_SERVER_ID, "stock_consume");
+const zStockEntryEditArgs = mcpToolSchema(GROCY_SERVER_ID, "stock_entry_edit");
 const zProductsCreateArgs = mcpToolSchema(GROCY_SERVER_ID, "products_create");
 const zProductsEditArgs = mcpToolSchema(GROCY_SERVER_ID, "products_edit");
 const zShoppingListGetArgs = mcpToolSchema(GROCY_SERVER_ID, "shopping_list_get");
@@ -45,6 +46,7 @@ const zShoppingListItemEditArgs = mcpToolSchema(GROCY_SERVER_ID, "shopping_list_
 
 type StockAddArgs = z.infer<typeof zStockAddArgs>;
 type StockConsumeArgs = z.infer<typeof zStockConsumeArgs>;
+type StockEntryEditArgs = z.infer<typeof zStockEntryEditArgs>;
 type ProductsCreateArgs = z.infer<typeof zProductsCreateArgs>;
 type ProductsEditArgs = z.infer<typeof zProductsEditArgs>;
 type ShoppingListGetArgs = z.infer<typeof zShoppingListGetArgs>;
@@ -53,6 +55,7 @@ type ShoppingListItemEditArgs = z.infer<typeof zShoppingListItemEditArgs>;
 
 type AddItem = StockAddArgs["items"][number];
 type ConsumeItem = StockConsumeArgs["items"][number];
+type StockEntryEditItem = StockEntryEditArgs["items"][number];
 type CreateProductItem = ProductsCreateArgs["items"][number];
 type EditProductItem = ProductsEditArgs["items"][number];
 type ShoppingItem = ShoppingListItemsAddArgs["items"][number];
@@ -326,6 +329,59 @@ function ChangeLine({ change }: { change: FieldChange }) {
   );
 }
 
+function StockEntryEditRow({
+  item,
+  reference,
+  variant,
+}: {
+  item: StockEntryEditItem;
+  reference: GrocyReferenceResponse | null;
+  variant: PreviewVariant;
+}) {
+  const changes: FieldChange[] = [];
+  const add = (key: string, label: string, value: unknown) => {
+    if (value != null) changes.push({ key, label, old: null, next: String(value) });
+  };
+  add("amount", "amount", item.amount);
+  add("best_before_date", "best before", item.best_before_date);
+  add("purchased_date", "purchased", item.purchased_date);
+  add("price", "price", item.price);
+  if (item.location != null) {
+    changes.push({
+      key: "location",
+      label: "location",
+      old: null,
+      next: resolveName(reference?.locations, item.location),
+    });
+  }
+  if (item.open != null) add("open", "opened", item.open ? "yes" : "no");
+  add("note", "note", item.note);
+  for (const field of item.clear_fields ?? []) {
+    changes.push({ key: `clear_${field}`, label: field.replaceAll("_", " "), old: null, next: CLEARED });
+  }
+  const shown = variant === "compact" ? changes.slice(0, 2) : changes;
+  return (
+    <Stack gap={2}>
+      <Text fw={600}>Stock entry #{item.entry_id}</Text>
+      {shown.map((change) => (
+        <ChangeLine key={change.key} change={change} />
+      ))}
+      <MoreLine count={changes.length - shown.length} />
+    </Stack>
+  );
+}
+
+function StockEntryEditPreview({ args, variant }: PreviewProps<StockEntryEditArgs>) {
+  return (
+    <GrocyItemsPreview
+      items={args.items}
+      variant={variant}
+      gap={6}
+      renderRow={(item, reference, v) => <StockEntryEditRow item={item} reference={reference} variant={v} />}
+    />
+  );
+}
+
 type NameMap = { id: number; name: string }[] | undefined;
 
 // The old value to show for a field: `null` while the reference loads (so no old side renders),
@@ -575,6 +631,9 @@ export const grocyPreviews = {
   })),
   stock_consume: definePreview(zStockConsumeArgs, StockConsumePreview, (a) => ({
     text: `Grocy: Remove ${plural(a.items.length, "item")} from stock`,
+  })),
+  stock_entry_edit: definePreview(zStockEntryEditArgs, StockEntryEditPreview, (a) => ({
+    text: `Grocy: Edit ${a.items.length} stock ${a.items.length === 1 ? "entry" : "entries"}`,
   })),
   products_create: definePreview(zProductsCreateArgs, ProductsCreatePreview, (a) => ({
     text: `Grocy: Create ${plural(a.items.length, "product")}`,

--- a/haku/console/frontend/tool_rendering/grocy/requests.tsx
+++ b/haku/console/frontend/tool_rendering/grocy/requests.tsx
@@ -22,7 +22,7 @@
 
 import { Badge, Group, Stack, Text } from "@mantine/core";
 import { Fragment, type ReactNode, useEffect, useState } from "react";
-import type { z } from "zod";
+import { z } from "zod";
 
 import { fetchGrocyReference, type GrocyReferenceResponse } from "../../grocy_client.ts";
 import { mcpToolSchema } from "../../mcp_tool_schema.ts";
@@ -38,19 +38,29 @@ export const GROCY_SERVER_ID = "grocy-sf";
 const zStockAddArgs = mcpToolSchema(GROCY_SERVER_ID, "stock_add");
 const zStockConsumeArgs = mcpToolSchema(GROCY_SERVER_ID, "stock_consume");
 const zStockEntryEditArgs = mcpToolSchema(GROCY_SERVER_ID, "stock_entry_edit");
+const zStockGetArgs = mcpToolSchema(GROCY_SERVER_ID, "stock_get");
+const zProductsListArgs = mcpToolSchema(GROCY_SERVER_ID, "products_list");
+const zQuantityUnitsListArgs = mcpToolSchema(GROCY_SERVER_ID, "quantity_units_list");
+const zGetSystemInfoArgs = z.strictObject({});
 const zProductsCreateArgs = mcpToolSchema(GROCY_SERVER_ID, "products_create");
 const zProductsEditArgs = mcpToolSchema(GROCY_SERVER_ID, "products_edit");
 const zShoppingListGetArgs = mcpToolSchema(GROCY_SERVER_ID, "shopping_list_get");
 const zShoppingListItemsAddArgs = mcpToolSchema(GROCY_SERVER_ID, "shopping_list_items_add");
+const zShoppingListItemsRemoveArgs = mcpToolSchema(GROCY_SERVER_ID, "shopping_list_items_remove");
 const zShoppingListItemEditArgs = mcpToolSchema(GROCY_SERVER_ID, "shopping_list_item_edit");
 
 type StockAddArgs = z.infer<typeof zStockAddArgs>;
 type StockConsumeArgs = z.infer<typeof zStockConsumeArgs>;
 type StockEntryEditArgs = z.infer<typeof zStockEntryEditArgs>;
+type StockGetArgs = z.infer<typeof zStockGetArgs>;
+type ProductsListArgs = z.infer<typeof zProductsListArgs>;
+type QuantityUnitsListArgs = z.infer<typeof zQuantityUnitsListArgs>;
+type GetSystemInfoArgs = z.infer<typeof zGetSystemInfoArgs>;
 type ProductsCreateArgs = z.infer<typeof zProductsCreateArgs>;
 type ProductsEditArgs = z.infer<typeof zProductsEditArgs>;
 type ShoppingListGetArgs = z.infer<typeof zShoppingListGetArgs>;
 type ShoppingListItemsAddArgs = z.infer<typeof zShoppingListItemsAddArgs>;
+type ShoppingListItemsRemoveArgs = z.infer<typeof zShoppingListItemsRemoveArgs>;
 type ShoppingListItemEditArgs = z.infer<typeof zShoppingListItemEditArgs>;
 
 type AddItem = StockAddArgs["items"][number];
@@ -382,6 +392,48 @@ function StockEntryEditPreview({ args, variant }: PreviewProps<StockEntryEditArg
   );
 }
 
+function StockGetPreview({ args }: PreviewProps<StockGetArgs>) {
+  const { reference, error } = useGrocyReference();
+  const products = (args.products ?? []).map((value) => resolveName(reference?.products, value));
+  const locations = (args.locations ?? []).map((value) => resolveName(reference?.locations, value));
+  return (
+    <Stack gap={2}>
+      <Text>{products.length === 0 && locations.length === 0 ? "All current stock" : "Filtered current stock"}</Text>
+      {products.length > 0 && (
+        <Text size="sm" c="dimmed">
+          Products: {products.join(", ")}
+        </Text>
+      )}
+      {locations.length > 0 && (
+        <Text size="sm" c="dimmed">
+          Locations: {locations.join(", ")}
+        </Text>
+      )}
+      <GrocyReferenceLoadError error={error} />
+    </Stack>
+  );
+}
+
+function DetailPreview({ detail, noun }: { detail: "brief" | "full"; noun: string }) {
+  return <Text>{detail === "full" ? `Full ${noun} records` : `${noun[0].toUpperCase()}${noun.slice(1)} names`}</Text>;
+}
+
+function ProductsListPreview({ args }: PreviewProps<ProductsListArgs>) {
+  return <DetailPreview detail={args.detail ?? "brief"} noun="product" />;
+}
+
+function QuantityUnitsListPreview({ args }: PreviewProps<QuantityUnitsListArgs>) {
+  return <DetailPreview detail={args.detail ?? "brief"} noun="quantity unit" />;
+}
+
+function GetSystemInfoPreview(_: PreviewProps<GetSystemInfoArgs>) {
+  return <Text>Grocy server version and system details</Text>;
+}
+
+function ShoppingListItemsRemovePreview({ args }: PreviewProps<ShoppingListItemsRemoveArgs>) {
+  return <Text>Shopping-list item IDs: {args.item_ids.join(", ")}</Text>;
+}
+
 type NameMap = { id: number; name: string }[] | undefined;
 
 // The old value to show for a field: `null` while the reference loads (so no old side renders),
@@ -635,6 +687,14 @@ export const grocyPreviews = {
   stock_entry_edit: definePreview(zStockEntryEditArgs, StockEntryEditPreview, (a) => ({
     text: `Grocy: Edit ${a.items.length} stock ${a.items.length === 1 ? "entry" : "entries"}`,
   })),
+  stock_get: definePreview(zStockGetArgs, StockGetPreview, () => ({ text: "Grocy: View stock" })),
+  products_list: definePreview(zProductsListArgs, ProductsListPreview, () => ({ text: "Grocy: List products" })),
+  quantity_units_list: definePreview(zQuantityUnitsListArgs, QuantityUnitsListPreview, () => ({
+    text: "Grocy: List quantity units",
+  })),
+  get_system_info: definePreview(zGetSystemInfoArgs, GetSystemInfoPreview, () => ({
+    text: "Grocy: View system information",
+  })),
   products_create: definePreview(zProductsCreateArgs, ProductsCreatePreview, (a) => ({
     text: `Grocy: Create ${plural(a.items.length, "product")}`,
   })),
@@ -646,6 +706,10 @@ export const grocyPreviews = {
   })),
   shopping_list_items_add: definePreview(zShoppingListItemsAddArgs, ShoppingListItemsAddPreview, (a) => ({
     text: `Grocy: Add ${plural(a.items.length, "item")} to shopping list`,
+  })),
+  shopping_list_items_remove: definePreview(zShoppingListItemsRemoveArgs, ShoppingListItemsRemovePreview, (a) => ({
+    text: `Grocy: Remove ${plural(a.item_ids.length, "shopping-list item")}`,
+    destructive: true,
   })),
   shopping_list_item_edit: definePreview(zShoppingListItemEditArgs, ShoppingListItemEditPreview, () => ({
     text: "Grocy: Edit shopping list item",

--- a/haku/console/frontend/tool_rendering/grocy/responses.test.ts
+++ b/haku/console/frontend/tool_rendering/grocy/responses.test.ts
@@ -85,6 +85,40 @@ describe("grocyResultPreviews", () => {
     }
   });
 
+  it("renders Grocy read and shopping-list removal results", () => {
+    const cases = [
+      [
+        grocyResultPreviews.stock_get,
+        [
+          {
+            product_name: "Oats",
+            amount: 500,
+            amount_opened: 0,
+            qu_name: "Gram",
+            location_name: "Pantry",
+            best_before_date: null,
+          },
+        ],
+      ],
+      [grocyResultPreviews.products_list, [{ id: 1, name: "Oats" }]],
+      [grocyResultPreviews.quantity_units_list, [{ id: 2, name: "Gram", name_plural: "Grams" }]],
+      [grocyResultPreviews.get_system_info, { grocy_version: "4.5.0" }],
+      [
+        grocyResultPreviews.shopping_list_get,
+        {
+          name: "Weekly",
+          description: null,
+          items: [{ item_id: 3, product_name: "Oats", amount: 2, qu_name: "Pack", note: null, done: false }],
+        },
+      ],
+      [
+        grocyResultPreviews.shopping_list_items_remove,
+        [{ kind: "ok", item_id: 3, product_name: "Oats", amount: 2, qu_name: "Pack" }],
+      ],
+    ] as const;
+    for (const [preview, result] of cases) expect(renderResultPreview(preview, result, "detailed")).not.toBeNull();
+  });
+
   it("returns null for a malformed ok row instead of rendering it as a failure", () => {
     // kind "ok" without the ok-row fields must fail the whole parse (→ raw JSON fallback),
     // not fall through to the failed-row branch and paint a success red.

--- a/haku/console/frontend/tool_rendering/grocy/responses.test.ts
+++ b/haku/console/frontend/tool_rendering/grocy/responses.test.ts
@@ -59,6 +59,32 @@ describe("grocyResultPreviews", () => {
     }
   });
 
+  it("renders stock_entry_edit rows with the updated entry and changed fields", () => {
+    for (const variant of ["compact", "detailed"] as const) {
+      expect(
+        renderResultPreview(
+          grocyResultPreviews.stock_entry_edit,
+          [
+            {
+              kind: "ok",
+              entry: {
+                entry_id: 189,
+                product_name: "Avocado Oil",
+                amount: 500,
+                qu_name: "Milliliter",
+                location_name: "Pantry",
+                best_before_date: "2027-01-15",
+                open: true,
+              },
+              changes: { price: { old: 8.99, new: 9.99 }, open: { old: false, new: true } },
+            },
+          ],
+          variant
+        )
+      ).not.toBeNull();
+    }
+  });
+
   it("returns null for a malformed ok row instead of rendering it as a failure", () => {
     // kind "ok" without the ok-row fields must fail the whole parse (→ raw JSON fallback),
     // not fall through to the failed-row branch and paint a success red.

--- a/haku/console/frontend/tool_rendering/grocy/responses.tsx
+++ b/haku/console/frontend/tool_rendering/grocy/responses.tsx
@@ -51,14 +51,30 @@ const zShoppingListItemOkRow = z.looseObject({
   qu_name: z.string().nullish(),
 });
 
+const zStockEntryEditOkRow = z.looseObject({
+  kind: z.literal("ok"),
+  entry: z.looseObject({
+    entry_id: z.number(),
+    product_name: z.string(),
+    amount: z.number(),
+    qu_name: z.string(),
+    location_name: z.string(),
+    best_before_date: z.string().nullish(),
+    open: z.boolean(),
+  }),
+  changes: z.record(z.string(), z.looseObject({ old: z.unknown(), new: z.unknown() })).nullish(),
+});
+
 const zStockAddResult = z.array(z.union([zStockAddOkRow, zFailedRow]));
 const zProductsCreateResult = z.array(z.union([zProductsCreateOkRow, zFailedRow]));
 const zShoppingListItemsAddResult = z.array(z.union([zShoppingListItemOkRow, zFailedRow]));
+const zStockEntryEditResult = z.array(z.union([zStockEntryEditOkRow, zFailedRow]));
 
 type FailedRow = z.infer<typeof zFailedRow>;
 type StockAddOkRow = z.infer<typeof zStockAddOkRow>;
 type ProductsCreateOkRow = z.infer<typeof zProductsCreateOkRow>;
 type ShoppingListItemOkRow = z.infer<typeof zShoppingListItemOkRow>;
+type StockEntryEditOkRow = z.infer<typeof zStockEntryEditOkRow>;
 
 // The zFailedRow refine guarantees a non-"ok" kind at runtime, but zod types it as plain
 // `string` (and TS doesn't narrow a generic union by discriminant), so the ok/failed split
@@ -236,9 +252,53 @@ function ShoppingListItemsAddResultView({
   );
 }
 
+function StockEntryEditResultRow({ row }: { row: StockEntryEditOkRow }) {
+  return (
+    <Stack gap={2}>
+      <Group gap={6}>
+        <Text span fw={600}>
+          {row.entry.product_name}
+        </Text>
+        <Text span>
+          {row.entry.amount} {row.entry.qu_name}
+        </Text>
+        <Text span c="dimmed">
+          in {row.entry.location_name} · entry #{row.entry.entry_id}
+        </Text>
+        {row.entry.open && (
+          <Badge size="sm" variant="outline">
+            opened
+          </Badge>
+        )}
+      </Group>
+      {row.changes && (
+        <Text size="sm" c="dimmed">
+          Changed:{" "}
+          {Object.keys(row.changes)
+            .map((field) => field.replaceAll("_", " "))
+            .join(", ")}
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+function StockEntryEditResultView({ result, variant }: ResultPreviewProps<z.infer<typeof zStockEntryEditResult>>) {
+  return (
+    <BatchResultView
+      rows={result}
+      variant={variant}
+      verb="edited"
+      rowName={(row) => row.entry.product_name}
+      RowView={StockEntryEditResultRow}
+    />
+  );
+}
+
 /** Per-tool result widgets for the `grocy-sf` server's list-returning batch tools. */
 export const grocyResultPreviews = {
   stock_add: defineResultPreview(zStockAddResult, StockAddResultView),
+  stock_entry_edit: defineResultPreview(zStockEntryEditResult, StockEntryEditResultView),
   products_create: defineResultPreview(zProductsCreateResult, ProductsCreateResultView),
   shopping_list_items_add: defineResultPreview(zShoppingListItemsAddResult, ShoppingListItemsAddResultView),
 } satisfies Record<string, ToolResultPreview>;

--- a/haku/console/frontend/tool_rendering/grocy/responses.tsx
+++ b/haku/console/frontend/tool_rendering/grocy/responses.tsx
@@ -64,11 +64,40 @@ const zStockEntryEditOkRow = z.looseObject({
   }),
   changes: z.record(z.string(), z.looseObject({ old: z.unknown(), new: z.unknown() })).nullish(),
 });
+const zStockEntryRow = z.looseObject({
+  product_name: z.string(),
+  amount: z.number(),
+  amount_opened: z.number(),
+  qu_name: z.string(),
+  location_name: z.string(),
+  best_before_date: z.string().nullish(),
+});
+const zNamedRow = z.looseObject({ id: z.number(), name: z.string() });
+const zQuantityUnitRow = zNamedRow.extend({ name_plural: z.string().nullish() });
+const zShoppingListGetResult = z.looseObject({
+  name: z.string(),
+  description: z.string().nullish(),
+  items: z.array(
+    z.looseObject({
+      item_id: z.number(),
+      product_name: z.string().nullish(),
+      amount: z.number(),
+      qu_name: z.string().nullish(),
+      note: z.string().nullish(),
+      done: z.boolean(),
+    })
+  ),
+});
 
 const zStockAddResult = z.array(z.union([zStockAddOkRow, zFailedRow]));
 const zProductsCreateResult = z.array(z.union([zProductsCreateOkRow, zFailedRow]));
 const zShoppingListItemsAddResult = z.array(z.union([zShoppingListItemOkRow, zFailedRow]));
 const zStockEntryEditResult = z.array(z.union([zStockEntryEditOkRow, zFailedRow]));
+const zStockGetResult = z.array(zStockEntryRow);
+const zProductsListResult = z.array(zNamedRow);
+const zQuantityUnitsListResult = z.array(zQuantityUnitRow);
+const zSystemInfoResult = z.looseObject({});
+const zShoppingListItemsRemoveResult = z.array(z.union([zShoppingListItemOkRow, zFailedRow]));
 
 type FailedRow = z.infer<typeof zFailedRow>;
 type StockAddOkRow = z.infer<typeof zStockAddOkRow>;
@@ -295,10 +324,123 @@ function StockEntryEditResultView({ result, variant }: ResultPreviewProps<z.infe
   );
 }
 
+function StockGetResultView({ result, variant }: ResultPreviewProps<z.infer<typeof zStockGetResult>>) {
+  const rows = variant === "compact" ? result.slice(0, COMPACT_ITEM_LIMIT) : result;
+  return (
+    <Stack gap={4}>
+      <Text size="sm" fw={600}>
+        {result.length} stock {result.length === 1 ? "item" : "items"}
+      </Text>
+      {rows.map((row, i) => (
+        <Group gap={6} key={i}>
+          <Text span fw={600}>
+            {row.product_name}
+          </Text>
+          <Text span>
+            {row.amount} {row.qu_name}
+          </Text>
+          <Text span c="dimmed">
+            in {row.location_name}
+          </Text>
+          {row.amount_opened > 0 && (
+            <Badge size="sm" variant="outline">
+              {row.amount_opened} opened
+            </Badge>
+          )}
+        </Group>
+      ))}
+      <MoreLine count={result.length - rows.length} />
+    </Stack>
+  );
+}
+
+function NamedRowsResultView({ result, variant }: ResultPreviewProps<z.infer<typeof zProductsListResult>>) {
+  const rows = variant === "compact" ? result.slice(0, COMPACT_ITEM_LIMIT) : result;
+  return (
+    <Stack gap={2}>
+      <Text size="sm" fw={600}>
+        {result.length} found
+      </Text>
+      {rows.map((row) => (
+        <Text key={row.id} size="sm">
+          {row.name}{" "}
+          <Text span c="dimmed">
+            #{row.id}
+          </Text>
+        </Text>
+      ))}
+      <MoreLine count={result.length - rows.length} />
+    </Stack>
+  );
+}
+
+function QuantityUnitsResultView({ result, variant }: ResultPreviewProps<z.infer<typeof zQuantityUnitsListResult>>) {
+  return <NamedRowsResultView result={result} variant={variant} />;
+}
+
+function ShoppingListGetResultView({ result, variant }: ResultPreviewProps<z.infer<typeof zShoppingListGetResult>>) {
+  const rows = variant === "compact" ? result.items.slice(0, COMPACT_ITEM_LIMIT) : result.items;
+  return (
+    <Stack gap={4}>
+      <Text fw={600}>
+        {result.name} · {result.items.length} items
+      </Text>
+      {rows.map((row) => (
+        <Group gap={6} key={row.item_id}>
+          <Text span td={row.done ? "line-through" : undefined}>
+            {row.product_name ?? row.note ?? "(note)"}
+          </Text>
+          <Text span c="dimmed">
+            × {row.amount}
+            {row.qu_name ? ` ${row.qu_name}` : ""} · #{row.item_id}
+          </Text>
+        </Group>
+      ))}
+      <MoreLine count={result.items.length - rows.length} />
+    </Stack>
+  );
+}
+
+function SystemInfoResultView({ result }: ResultPreviewProps<z.infer<typeof zSystemInfoResult>>) {
+  return (
+    <Stack gap={2}>
+      {Object.entries(result).map(([key, value]) => (
+        <Text size="sm" key={key}>
+          <Text span c="dimmed">
+            {key.replaceAll("_", " ")}:{" "}
+          </Text>
+          {String(value)}
+        </Text>
+      ))}
+    </Stack>
+  );
+}
+
+function ShoppingListItemsRemoveResultView({
+  result,
+  variant,
+}: ResultPreviewProps<z.infer<typeof zShoppingListItemsRemoveResult>>) {
+  return (
+    <BatchResultView
+      rows={result}
+      variant={variant}
+      verb="removed"
+      rowName={shoppingItemName}
+      RowView={ShoppingListItemsAddResultRow}
+    />
+  );
+}
+
 /** Per-tool result widgets for the `grocy-sf` server's list-returning batch tools. */
 export const grocyResultPreviews = {
   stock_add: defineResultPreview(zStockAddResult, StockAddResultView),
   stock_entry_edit: defineResultPreview(zStockEntryEditResult, StockEntryEditResultView),
+  stock_get: defineResultPreview(zStockGetResult, StockGetResultView),
+  products_list: defineResultPreview(zProductsListResult, NamedRowsResultView),
+  quantity_units_list: defineResultPreview(zQuantityUnitsListResult, QuantityUnitsResultView),
+  get_system_info: defineResultPreview(zSystemInfoResult, SystemInfoResultView),
+  shopping_list_get: defineResultPreview(zShoppingListGetResult, ShoppingListGetResultView),
+  shopping_list_items_remove: defineResultPreview(zShoppingListItemsRemoveResult, ShoppingListItemsRemoveResultView),
   products_create: defineResultPreview(zProductsCreateResult, ProductsCreateResultView),
   shopping_list_items_add: defineResultPreview(zShoppingListItemsAddResult, ShoppingListItemsAddResultView),
 } satisfies Record<string, ToolResultPreview>;

--- a/haku/console/frontend/tool_rendering/kubectl/requests.test.ts
+++ b/haku/console/frontend/tool_rendering/kubectl/requests.test.ts
@@ -10,6 +10,16 @@ describe("kubectlPreviews", () => {
     ).not.toBeNull();
   });
 
+  it("renders pods_log target and options", () => {
+    expect(
+      renderPreview(
+        kubectlPreviews.pods_log,
+        { name: "api-0", namespace: "prod", container: "api", previous: true, tail: 50 },
+        "detailed"
+      )
+    ).not.toBeNull();
+  });
+
   it("renders resources_create_or_update in both variants (compact clamps the manifest)", () => {
     const manifest = Array.from({ length: 20 }, (_, i) => `line-${i}: value`).join("\n");
     for (const variant of ["compact", "detailed"] as const) {

--- a/haku/console/frontend/tool_rendering/kubectl/requests.tsx
+++ b/haku/console/frontend/tool_rendering/kubectl/requests.tsx
@@ -33,10 +33,18 @@ const zPodsDeleteArgs = z.object({
   name: z.string(),
   namespace: z.string().optional(),
 });
+const zPodsLogArgs = z.object({
+  name: z.string(),
+  namespace: z.string().optional(),
+  container: z.string().optional(),
+  previous: z.boolean().optional(),
+  tail: z.number().int().optional(),
+});
 
 type ResourcesCreateOrUpdateArgs = z.infer<typeof zResourcesCreateOrUpdateArgs>;
 type ResourcesDeleteArgs = z.infer<typeof zResourcesDeleteArgs>;
 type PodsDeleteArgs = z.infer<typeof zPodsDeleteArgs>;
+type PodsLogArgs = z.infer<typeof zPodsLogArgs>;
 
 function ResourcesApplyPreview({ args, variant }: PreviewProps<ResourcesCreateOrUpdateArgs>) {
   const resource = variant === "compact" ? clampBlock(args.resource, 3) : args.resource;
@@ -91,6 +99,21 @@ function PodsDeletePreview({ args }: PreviewProps<PodsDeleteArgs>) {
   return <DeleteTargetPreview kind="Pod" name={args.name} namespace={args.namespace} gracePeriodSeconds={undefined} />;
 }
 
+function PodsLogPreview({ args }: PreviewProps<PodsLogArgs>) {
+  return (
+    <Stack gap={2}>
+      <Group gap={6} className="haku-shell-mono">
+        <Text fw={600}>{args.name}</Text>
+        {args.namespace && <Text c="dimmed">in {args.namespace}</Text>}
+        {args.container && <Text c="dimmed">container {args.container}</Text>}
+      </Group>
+      <Text size="sm" c="dimmed">
+        {args.previous ? "Previous container logs" : "Current logs"} · last {args.tail ?? 100} lines
+      </Text>
+    </Stack>
+  );
+}
+
 /** Per-tool preview widgets for the `kubectl-passthrough-mcp` server's highest-stakes tools
  * (apply and delete). */
 export const kubectlPreviews = {
@@ -105,4 +128,5 @@ export const kubectlPreviews = {
     text: "kubectl: Delete Pod",
     destructive: true,
   })),
+  pods_log: definePreview(zPodsLogArgs, PodsLogPreview, () => ({ text: "kubectl: View Pod logs" })),
 } satisfies Record<string, ToolPreview>;

--- a/haku/console/frontend/tool_rendering/tana/requests.test.ts
+++ b/haku/console/frontend/tool_rendering/tana/requests.test.ts
@@ -11,6 +11,7 @@ describe("tanaPreviews", () => {
       ["trash_node", { nodeId: "node" }],
       ["edit_node", { nodeId: "node", name: { old_string: "Old", new_string: "New" } }],
       ["move_node", { nodeId: "node", targetNodeId: "target", position: "end", keepSourceReference: false }],
+      ["set_field_option", { nodeId: "node", attributeId: "status", optionId: "done", mode: "replace" }],
     ];
     for (const [tool, args] of cases) {
       for (const variant of ["compact", "detailed"] as const) {

--- a/haku/console/frontend/tool_rendering/tana/requests.tsx
+++ b/haku/console/frontend/tool_rendering/tana/requests.tsx
@@ -38,12 +38,19 @@ const zMoveNodeArgs = z.object({
   referenceNodeId: z.string().optional(),
   keepSourceReference: z.boolean().default(false),
 });
+const zSetFieldOptionArgs = z.object({
+  nodeId: z.string(),
+  attributeId: z.string(),
+  optionId: z.string(),
+  mode: z.enum(["replace", "append"]).default("replace"),
+});
 
 type ImportTanaPasteArgs = z.infer<typeof zImportTanaPasteArgs>;
 type GetOrCreateCalendarNodeArgs = z.infer<typeof zGetOrCreateCalendarNodeArgs>;
 type TrashNodeArgs = z.infer<typeof zTrashNodeArgs>;
 type EditNodeArgs = z.infer<typeof zEditNodeArgs>;
 type MoveNodeArgs = z.infer<typeof zMoveNodeArgs>;
+type SetFieldOptionArgs = z.infer<typeof zSetFieldOptionArgs>;
 
 function tanaNodeUrl(nodeId: string): string {
   return `https://app.tana.inc?nodeid=${encodeURIComponent(nodeId)}`;
@@ -175,6 +182,23 @@ function MoveNodePreview({ args }: PreviewProps<MoveNodeArgs>) {
   );
 }
 
+function SetFieldOptionPreview({ args }: PreviewProps<SetFieldOptionArgs>) {
+  const previews = useTanaNodePreviews([args.nodeId, args.attributeId, args.optionId]);
+  return (
+    <Stack gap={4}>
+      <Group gap={6}>
+        <TanaNodeLink nodeId={args.nodeId} previews={previews} />
+        <Text c="dimmed">field</Text>
+        <TanaNodeLink nodeId={args.attributeId} previews={previews} />
+      </Group>
+      <Group gap={6}>
+        <Badge variant="outline">{args.mode}</Badge>
+        <TanaNodeLink nodeId={args.optionId} previews={previews} />
+      </Group>
+    </Stack>
+  );
+}
+
 export const tanaPreviews = {
   import_tana_paste: definePreview(zImportTanaPasteArgs, ImportTanaPastePreview, () => ({
     text: "Tana: Import content",
@@ -185,4 +209,7 @@ export const tanaPreviews = {
   trash_node: definePreview(zTrashNodeArgs, TrashNodePreview, () => ({ text: "Tana: Trash node", destructive: true })),
   edit_node: definePreview(zEditNodeArgs, EditNodePreview, () => ({ text: "Tana: Edit node" })),
   move_node: definePreview(zMoveNodeArgs, MoveNodePreview, () => ({ text: "Tana: Move node" })),
+  set_field_option: definePreview(zSetFieldOptionArgs, SetFieldOptionPreview, (a) => ({
+    text: `Tana: ${a.mode === "append" ? "Append" : "Set"} field option`,
+  })),
 } satisfies Record<string, ToolPreview>;

--- a/haku/console/test_export_mcp_tool_schemas.py
+++ b/haku/console/test_export_mcp_tool_schemas.py
@@ -39,12 +39,16 @@ async def test_exports_every_server_and_tool() -> None:
     assert list(schema["properties"]["grocy-sf"]["properties"]) == [
         "products_create",
         "products_edit",
+        "products_list",
+        "quantity_units_list",
         "shopping_list_get",
         "shopping_list_item_edit",
         "shopping_list_items_add",
+        "shopping_list_items_remove",
         "stock_add",
         "stock_consume",
         "stock_entry_edit",
+        "stock_get",
     ]
     for server in schema["properties"].values():
         assert server["additionalProperties"] is False
@@ -69,6 +73,8 @@ async def test_grocy_schemas_are_inlined_and_validate() -> None:
     Draft202012Validator(grocy["stock_entry_edit"]).validate(
         {"items": [{"entry_id": 189, "price": 9.99, "location": "Pantry", "clear_fields": ["note"]}]}
     )
+    Draft202012Validator(grocy["stock_get"]).validate({"products": ["Oats"], "locations": [2]})
+    Draft202012Validator(grocy["shopping_list_items_remove"]).validate({"item_ids": [3, 7]})
     Draft202012Validator(grocy["products_edit"]).validate(
         {"items": [{"product": 42, "min_stock_amount": 500, "clear_fields": ["description"]}]}
     )

--- a/haku/console/test_export_mcp_tool_schemas.py
+++ b/haku/console/test_export_mcp_tool_schemas.py
@@ -44,6 +44,7 @@ async def test_exports_every_server_and_tool() -> None:
         "shopping_list_items_add",
         "stock_add",
         "stock_consume",
+        "stock_entry_edit",
     ]
     for server in schema["properties"].values():
         assert server["additionalProperties"] is False
@@ -64,6 +65,9 @@ async def test_grocy_schemas_are_inlined_and_validate() -> None:
 
     Draft202012Validator(grocy["stock_add"]).validate(
         {"items": [{"product": "Rolled oats", "amount": 2, "qu": "pack", "location": "Pantry"}]}
+    )
+    Draft202012Validator(grocy["stock_entry_edit"]).validate(
+        {"items": [{"entry_id": 189, "price": 9.99, "location": "Pantry", "clear_fields": ["note"]}]}
     )
     Draft202012Validator(grocy["products_edit"]).validate(
         {"items": [{"product": 42, "min_stock_amount": 500, "clear_fields": ["description"]}]}


### PR DESCRIPTION
## What changed

- add a custom approval preview for `grocy-sf.stock_entry_edit`
- show entry IDs, proposed field changes, cleared fields, and resolved location names
- add a custom result preview with the updated quantity, location, opened state, and changed fields
- add Grocy previews for stock/list/system reads and shopping-list item removal
- add request previews for Kubernetes Pod logs and Tana field-option mutations
- retain the existing custom rendering for Google Calendar event creation, Grocy product creation, and shopping-list additions
- include reflected Grocy tools in the generated frontend tool-schema catalog

## Why

Several frequently used operator tools fell back to raw JSON in Haku Console, making requests and results harder to review safely.

## Validation

- `bbr test //haku/console:test_export_mcp_tool_schemas //haku/console/frontend:tsc_test //haku/console/frontend:bridge_test`
- pre-commit hooks
