### PR TITLE
Standardize Haku tool rendering markup

### DIFF
--- a/haku/console/frontend/AGENTS.md
+++ b/haku/console/frontend/AGENTS.md
@@ -70,6 +70,26 @@ with the rarely-useful parts folded away:
   together).
 - One idea per line.
 
+**Use the shared visual grammar; do not invent per-tool typography.**
+
+- Tool-preview body text is Mantine `Text size="sm"`. Set it explicitly, including `span`
+  fragments, so a renderer never falls back to Mantine's larger default. A bold identity/title
+  is still `size="sm"`; hierarchy comes from `fw={600}`, not a larger font.
+- Supporting or failure text is also `size="sm"` plus `c="dimmed"` or the semantic failure
+  color. Reserve `size="xs"` for genuinely tertiary UI such as `MoreLine`, a low-priority link,
+  or card-level rationale/metadata outside the tool widget.
+- Preview badges are `size="sm"`. Use `variant="outline"` for attributes and `variant="light"`
+  for semantic state. Do not use badge size as a heading hierarchy.
+- Use the shared `Field` component for labelled values instead of hand-building `Label: value`
+  rows. Use `mono` for opaque identifiers and `icon` only when the icon is unambiguous. A call's
+  primary identity remains an unlabelled bold `Text`, per the vertical-space rule above.
+- Use `Stack gap="xs"` for separate fields/sections, numeric gaps `2` or `4` only within a
+  tightly related multi-line item, and `Group gap={6}` for inline fragments. Do not introduce
+  one-off margins or font-size CSS in a server renderer.
+- Reuse `MoreLine`, `COMPACT_ITEM_LIMIT`, `Field`, the date/time formatters, and the existing
+  batch/result helpers before adding another local equivalent. If a pattern occurs in more than
+  one server, promote it to `tool_rendering/` rather than copying it.
+
 **Consistent vocabulary.**
 
 - The **action** is a one-line description on the card's identity line (`tool_action_line.tsx`),

--- a/haku/console/frontend/AGENTS.md
+++ b/haku/console/frontend/AGENTS.md
@@ -72,14 +72,14 @@ with the rarely-useful parts folded away:
 
 **Use the shared visual grammar; do not invent per-tool typography.**
 
-- Tool-preview body text is Mantine `Text size="sm"`. Set it explicitly, including `span`
-  fragments, so a renderer never falls back to Mantine's larger default. A bold identity/title
-  is still `size="sm"`; hierarchy comes from `fw={600}`, not a larger font.
-- Supporting or failure text is also `size="sm"` plus `c="dimmed"` or the semantic failure
+- Tool-preview body copy uses `PreviewText`, including `span` fragments. Its `sm` default keeps
+  Mantine's larger application-level default from leaking into one server. Primary identities use
+  `PreviewTitle`; it stays on the same scale and creates hierarchy with weight, not font size.
+- Supporting or failure text uses `PreviewText` plus `c="dimmed"` or the semantic failure
   color. Reserve `size="xs"` for genuinely tertiary UI such as `MoreLine`, a low-priority link,
   or card-level rationale/metadata outside the tool widget.
-- Preview badges are `size="sm"`. Use `variant="outline"` for attributes and `variant="light"`
-  for semantic state. Do not use badge size as a heading hierarchy.
+- Preview badges use `PreviewBadge`, whose default is `sm`. Use `variant="outline"` for attributes
+  and `variant="light"` for semantic state. Do not use badge size as a heading hierarchy.
 - Use the shared `Field` component for labelled values instead of hand-building `Label: value`
   rows. Use `mono` for opaque identifiers and `icon` only when the icon is unambiguous. A call's
   primary identity remains an unlabelled bold `Text`, per the vertical-space rule above.

--- a/haku/console/frontend/json_preview.tsx
+++ b/haku/console/frontend/json_preview.tsx
@@ -1,7 +1,7 @@
 import hljs from "highlight.js/lib/core";
 import json from "highlight.js/lib/languages/json";
 
-import type { PreviewVariant } from "./tool_rendering/variant.tsx";
+import type { PreviewVariant } from "./tool_rendering/vocabulary.tsx";
 
 hljs.registerLanguage("json", json);
 

--- a/haku/console/frontend/tool_arguments_field.tsx
+++ b/haku/console/frontend/tool_arguments_field.tsx
@@ -1,7 +1,7 @@
 import { Field } from "./field.tsx";
 import { JsonPreview } from "./json_preview.tsx";
 import { toolPreview } from "./tool_rendering/index.tsx";
-import type { PreviewVariant } from "./tool_rendering/variant.tsx";
+import type { PreviewVariant } from "./tool_rendering/vocabulary.tsx";
 
 /** The arguments of a tool call: a per-tool-type widget (the tool_rendering/ per-server requests modules)
  * when one matches — rendered directly, since it's self-describing — else the generic

--- a/haku/console/frontend/tool_call_card.tsx
+++ b/haku/console/frontend/tool_call_card.tsx
@@ -5,7 +5,7 @@ import type { ApprovalDisplayFields } from "./approval_state.ts";
 import { ToolActionLine } from "./tool_action_line.tsx";
 import { ToolArgumentsField } from "./tool_arguments_field.tsx";
 import { ToolCallMeta } from "./tool_call_meta.tsx";
-import type { PreviewVariant } from "./tool_rendering/variant.tsx";
+import type { PreviewVariant } from "./tool_rendering/vocabulary.tsx";
 import { ToolResultField } from "./tool_result_field.tsx";
 import { VariantControl } from "./variant_control.tsx";
 

--- a/haku/console/frontend/tool_rendering/BUILD.bazel
+++ b/haku/console/frontend/tool_rendering/BUILD.bazel
@@ -13,7 +13,7 @@ package(default_visibility = ["//visibility:public"])
 # Leaf: no widget deps, so index.tsx and each widget import it without a cycle.
 js_library(
     name = "variant",
-    srcs = ["variant.tsx"],
+    srcs = ["vocabulary.tsx"],
     deps = [
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
@@ -99,6 +99,6 @@ js_library(
 
 js_library(
     name = "variant_test",
-    srcs = ["variant.test.ts"],
+    srcs = ["vocabulary.test.ts"],
     deps = [":variant"],
 )

--- a/haku/console/frontend/tool_rendering/entry.tsx
+++ b/haku/console/frontend/tool_rendering/entry.tsx
@@ -5,7 +5,7 @@
 import type { ReactNode } from "react";
 import type { z } from "zod";
 
-import type { PreviewProps, PreviewVariant } from "./variant.tsx";
+import type { PreviewProps, PreviewVariant } from "./vocabulary.tsx";
 
 /** A registered tool's own one-line action description for the card's identity line — a
  * server-labelled verb phrase computed from the parsed args ("Gmail: Draft email", "kubectl:

--- a/haku/console/frontend/tool_rendering/gmail/requests.tsx
+++ b/haku/console/frontend/tool_rendering/gmail/requests.tsx
@@ -25,7 +25,7 @@ import {
   PreviewText,
   PreviewTitle,
   type PreviewProps,
-} from "../variant.tsx";
+} from "../vocabulary.tsx";
 
 export const GMAIL_SERVER_ID = "gmail";
 

--- a/haku/console/frontend/tool_rendering/gmail/requests.tsx
+++ b/haku/console/frontend/tool_rendering/gmail/requests.tsx
@@ -72,12 +72,12 @@ function ThreadLabelChanges({ args }: { args: ModifyGmailThreadLabelsArgs }) {
   return (
     <Group gap={6} align="center">
       {args.add?.map((name) => (
-        <Badge key={`+${name}`} variant="light" color="teal">
+        <Badge size="sm" key={`+${name}`} variant="light" color="teal">
           + {name}
         </Badge>
       ))}
       {args.remove?.map((name) => (
-        <Badge key={`-${name}`} variant="light" color="red">
+        <Badge size="sm" key={`-${name}`} variant="light" color="red">
           − {name}
         </Badge>
       ))}
@@ -153,10 +153,14 @@ function CreateGmailDraftPreview({ args, variant }: PreviewProps<CreateGmailDraf
   const detailed = variant === "detailed";
   return (
     <Stack gap={6}>
-      <Text fw={600}>{args.subject}</Text>
+      <Text size="sm" fw={600}>
+        {args.subject}
+      </Text>
       <Field icon={<MailIcon size={15} />} label="Recipients">
         {args.to.join(", ")}
-        {detailed && args.cc && args.cc.length > 0 && <Text span c="dimmed">{` · cc ${args.cc.join(", ")}`}</Text>}
+        {detailed && args.cc && args.cc.length > 0 && (
+          <Text size="sm" span c="dimmed">{` · cc ${args.cc.join(", ")}`}</Text>
+        )}
       </Field>
       {detailed ? <pre className="haku-shell-json">{args.body}</pre> : <CompactBody body={args.body} />}
       {args.thread_id && (

--- a/haku/console/frontend/tool_rendering/gmail/requests.tsx
+++ b/haku/console/frontend/tool_rendering/gmail/requests.tsx
@@ -7,7 +7,7 @@
 // below are built from the FastMCP input schemas advertised by tools/list. Execution still owns
 // cross-field rules that JSON Schema cannot express, such as add/remove label overlap.
 
-import { Anchor, Badge, Group, Loader, Stack, Text } from "@mantine/core";
+import { Anchor, Group, Loader, Stack } from "@mantine/core";
 import { useEffect, useState } from "react";
 import type { z } from "zod";
 
@@ -16,7 +16,16 @@ import { fetchGmailThreadPreviews, type GmailThreadPreview } from "../../gmail_c
 import { MailIcon } from "../../icons.tsx";
 import { mcpToolSchema } from "../../mcp_tool_schema.ts";
 import { definePreview, type ToolPreview } from "../entry.tsx";
-import { COMPACT_ITEM_LIMIT, firstLines, MoreLine, plural, type PreviewProps } from "../variant.tsx";
+import {
+  COMPACT_ITEM_LIMIT,
+  firstLines,
+  MoreLine,
+  plural,
+  PreviewBadge,
+  PreviewText,
+  PreviewTitle,
+  type PreviewProps,
+} from "../variant.tsx";
 
 export const GMAIL_SERVER_ID = "gmail";
 
@@ -42,11 +51,7 @@ function GmailThreadRow({
   showLabels: boolean;
 }) {
   if (!preview) {
-    return (
-      <Text size="sm" c="dimmed">
-        {threadId} (couldn't load preview)
-      </Text>
-    );
+    return <PreviewText c="dimmed">{threadId} (couldn't load preview)</PreviewText>;
   }
   return (
     <Stack gap={2}>
@@ -56,9 +61,9 @@ function GmailThreadRow({
       {showLabels && preview.current_label_names.length > 0 && (
         <Group gap={4}>
           {preview.current_label_names.map((name) => (
-            <Badge key={name} variant="outline" color="gray" size="sm">
+            <PreviewBadge key={name} variant="outline" color="gray">
               {name}
-            </Badge>
+            </PreviewBadge>
           ))}
         </Group>
       )}
@@ -72,14 +77,14 @@ function ThreadLabelChanges({ args }: { args: ModifyGmailThreadLabelsArgs }) {
   return (
     <Group gap={6} align="center">
       {args.add?.map((name) => (
-        <Badge size="sm" key={`+${name}`} variant="light" color="teal">
+        <PreviewBadge key={`+${name}`} variant="light" color="teal">
           + {name}
-        </Badge>
+        </PreviewBadge>
       ))}
       {args.remove?.map((name) => (
-        <Badge size="sm" key={`-${name}`} variant="light" color="red">
+        <PreviewBadge key={`-${name}`} variant="light" color="red">
           − {name}
-        </Badge>
+        </PreviewBadge>
       ))}
     </Group>
   );
@@ -116,9 +121,7 @@ function ModifyGmailThreadLabelsPreview({ args, variant }: PreviewProps<ModifyGm
     <Stack gap="xs">
       <ThreadLabelChanges args={args} />
       {error ? (
-        <Text size="sm" c="red">
-          {error}
-        </Text>
+        <PreviewText c="red">{error}</PreviewText>
       ) : previews === null ? (
         <Loader size="xs" />
       ) : (
@@ -138,10 +141,10 @@ function ModifyGmailThreadLabelsPreview({ args, variant }: PreviewProps<ModifyGm
 function CompactBody({ body }: { body: string }) {
   const { text, truncated } = firstLines(body, 2);
   return (
-    <Text size="sm" c="dimmed" style={{ whiteSpace: "pre-wrap" }}>
+    <PreviewText c="dimmed" style={{ whiteSpace: "pre-wrap" }}>
       {text}
       {truncated ? " …" : ""}
-    </Text>
+    </PreviewText>
   );
 }
 
@@ -153,13 +156,11 @@ function CreateGmailDraftPreview({ args, variant }: PreviewProps<CreateGmailDraf
   const detailed = variant === "detailed";
   return (
     <Stack gap={6}>
-      <Text size="sm" fw={600}>
-        {args.subject}
-      </Text>
+      <PreviewTitle>{args.subject}</PreviewTitle>
       <Field icon={<MailIcon size={15} />} label="Recipients">
         {args.to.join(", ")}
         {detailed && args.cc && args.cc.length > 0 && (
-          <Text size="sm" span c="dimmed">{` · cc ${args.cc.join(", ")}`}</Text>
+          <PreviewText span c="dimmed">{` · cc ${args.cc.join(", ")}`}</PreviewText>
         )}
       </Field>
       {detailed ? <pre className="haku-shell-json">{args.body}</pre> : <CompactBody body={args.body} />}

--- a/haku/console/frontend/tool_rendering/gmail/responses.tsx
+++ b/haku/console/frontend/tool_rendering/gmail/responses.tsx
@@ -7,7 +7,7 @@ import { Anchor, Group } from "@mantine/core";
 import { z } from "zod";
 
 import { defineResultPreview, type ResultPreviewProps, type ToolResultPreview } from "../result_entry.tsx";
-import { PreviewText } from "../variant.tsx";
+import { PreviewText } from "../vocabulary.tsx";
 
 // Gmail's compose view opens a draft directly by its id.
 function gmailDraftUrl(draftId: string): string {

--- a/haku/console/frontend/tool_rendering/gmail/responses.tsx
+++ b/haku/console/frontend/tool_rendering/gmail/responses.tsx
@@ -3,10 +3,11 @@
 // verbatim (gmail_api/messages.py's `Draft`, camelCase wire aliases); the draft `id` deep-links
 // into Gmail's drafts view, where the operator reviews and sends it.
 
-import { Anchor, Group, Text } from "@mantine/core";
+import { Anchor, Group } from "@mantine/core";
 import { z } from "zod";
 
 import { defineResultPreview, type ResultPreviewProps, type ToolResultPreview } from "../result_entry.tsx";
+import { PreviewText } from "../variant.tsx";
 
 // Gmail's compose view opens a draft directly by its id.
 function gmailDraftUrl(draftId: string): string {
@@ -25,9 +26,9 @@ function CreateGmailDraftResultView({ result, variant }: ResultPreviewProps<Draf
         Open draft in Gmail ↗
       </Anchor>
       {variant === "detailed" && (
-        <Text span size="xs" c="dimmed">
+        <PreviewText span size="xs" c="dimmed">
           draft {result.id}
-        </Text>
+        </PreviewText>
       )}
     </Group>
   );

--- a/haku/console/frontend/tool_rendering/google_calendar/requests.tsx
+++ b/haku/console/frontend/tool_rendering/google_calendar/requests.tsx
@@ -13,7 +13,7 @@ import { Field } from "../../field.tsx";
 import { BellIcon, CalendarIcon, ClockIcon, MapPinIcon, UsersIcon } from "../../icons.tsx";
 import { mcpToolSchema } from "../../mcp_tool_schema.ts";
 import { definePreview, type ToolPreview } from "../entry.tsx";
-import { PreviewText, PreviewTitle, type PreviewProps } from "../variant.tsx";
+import { PreviewText, PreviewTitle, type PreviewProps } from "../vocabulary.tsx";
 
 export const GOOGLE_CALENDAR_SERVER_ID = "google_calendar";
 

--- a/haku/console/frontend/tool_rendering/google_calendar/requests.tsx
+++ b/haku/console/frontend/tool_rendering/google_calendar/requests.tsx
@@ -4,7 +4,7 @@
 // schema below is built from the FastMCP input schema advertised by tools/list. Execution-only
 // Pydantic cross-field validators may be stricter than that structural schema.
 
-import { Anchor, Loader, Stack, Text } from "@mantine/core";
+import { Anchor, Loader, Stack } from "@mantine/core";
 import { useEffect, useState } from "react";
 import type { z } from "zod";
 
@@ -13,7 +13,7 @@ import { Field } from "../../field.tsx";
 import { BellIcon, CalendarIcon, ClockIcon, MapPinIcon, UsersIcon } from "../../icons.tsx";
 import { mcpToolSchema } from "../../mcp_tool_schema.ts";
 import { definePreview, type ToolPreview } from "../entry.tsx";
-import type { PreviewProps } from "../variant.tsx";
+import { PreviewText, PreviewTitle, type PreviewProps } from "../variant.tsx";
 
 export const GOOGLE_CALENDAR_SERVER_ID = "google_calendar";
 
@@ -162,9 +162,7 @@ function CalendarField({ calendarId }: { calendarId: string }) {
         </Anchor>
       ) : failed ? (
         // Name lookup failed (e.g. deleted calendar, wrong account) — fall back to the raw id.
-        <Text size="sm" span>
-          {calendarId}
-        </Text>
+        <PreviewText span>{calendarId}</PreviewText>
       ) : (
         <Loader size="xs" />
       )}
@@ -178,9 +176,7 @@ function CreateCalendarEventPreview({ args, variant }: PreviewProps<CreateCalend
   const when = formatEventDateTimeRange(args.start, args.end);
   return (
     <Stack gap={6}>
-      <Text size="sm" fw={600}>
-        {args.summary}
-      </Text>
+      <PreviewTitle>{args.summary}</PreviewTitle>
       <Field icon={<ClockIcon size={15} />} label="When">
         <span title={when.title}>{when.text}</span>
       </Field>
@@ -191,11 +187,7 @@ function CreateCalendarEventPreview({ args, variant }: PreviewProps<CreateCalend
               {args.location}
             </Field>
           )}
-          {args.description && (
-            <Text size="sm" c="dimmed">
-              {args.description}
-            </Text>
-          )}
+          {args.description && <PreviewText c="dimmed">{args.description}</PreviewText>}
           {args.calendar_id && args.calendar_id !== "primary" && <CalendarField calendarId={args.calendar_id} />}
           {args.reminders && args.reminders.length > 0 && (
             <Field icon={<BellIcon size={15} />} label="Reminders">

--- a/haku/console/frontend/tool_rendering/google_calendar/requests.tsx
+++ b/haku/console/frontend/tool_rendering/google_calendar/requests.tsx
@@ -157,12 +157,14 @@ function CalendarField({ calendarId }: { calendarId: string }) {
   return (
     <Field icon={<CalendarIcon size={15} />} label="Calendar">
       {summary ? (
-        <Anchor href={summary.html_link} target="_blank" rel="noreferrer">
+        <Anchor href={summary.html_link} target="_blank" rel="noreferrer" size="sm">
           {summary.summary}
         </Anchor>
       ) : failed ? (
         // Name lookup failed (e.g. deleted calendar, wrong account) — fall back to the raw id.
-        <Text span>{calendarId}</Text>
+        <Text size="sm" span>
+          {calendarId}
+        </Text>
       ) : (
         <Loader size="xs" />
       )}
@@ -176,7 +178,9 @@ function CreateCalendarEventPreview({ args, variant }: PreviewProps<CreateCalend
   const when = formatEventDateTimeRange(args.start, args.end);
   return (
     <Stack gap={6}>
-      <Text fw={600}>{args.summary}</Text>
+      <Text size="sm" fw={600}>
+        {args.summary}
+      </Text>
       <Field icon={<ClockIcon size={15} />} label="When">
         <span title={when.title}>{when.text}</span>
       </Field>

--- a/haku/console/frontend/tool_rendering/google_calendar/responses.tsx
+++ b/haku/console/frontend/tool_rendering/google_calendar/responses.tsx
@@ -9,7 +9,7 @@ import { Anchor, Stack } from "@mantine/core";
 import { z } from "zod";
 
 import { defineResultPreview, type ResultPreviewProps, type ToolResultPreview } from "../result_entry.tsx";
-import { PreviewText } from "../variant.tsx";
+import { PreviewText } from "../vocabulary.tsx";
 
 const zCreateCalendarEventResult = z.looseObject({
   event_id: z.string(),

--- a/haku/console/frontend/tool_rendering/google_calendar/responses.tsx
+++ b/haku/console/frontend/tool_rendering/google_calendar/responses.tsx
@@ -5,10 +5,11 @@
 // `{event_id, html_link}`. Unknown extra keys pass through; a missing field fails the parse
 // (→ raw JSON fallback).
 
-import { Anchor, Stack, Text } from "@mantine/core";
+import { Anchor, Stack } from "@mantine/core";
 import { z } from "zod";
 
 import { defineResultPreview, type ResultPreviewProps, type ToolResultPreview } from "../result_entry.tsx";
+import { PreviewText } from "../variant.tsx";
 
 const zCreateCalendarEventResult = z.looseObject({
   event_id: z.string(),
@@ -26,9 +27,9 @@ function CreateCalendarEventResultView({ result, variant }: ResultPreviewProps<C
         Open event in Google Calendar ↗
       </Anchor>
       {variant === "detailed" && (
-        <Text size="xs" c="dimmed">
+        <PreviewText size="xs" c="dimmed">
           event {result.event_id}
-        </Text>
+        </PreviewText>
       )}
     </Stack>
   );

--- a/haku/console/frontend/tool_rendering/grocy/BUILD.bazel
+++ b/haku/console/frontend/tool_rendering/grocy/BUILD.bazel
@@ -11,6 +11,7 @@ js_library(
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
         "//:node_modules/zod",
+        "//haku/console/frontend:field",
         "//haku/console/frontend:grocy_client",
         "//haku/console/frontend:mcp_tool_schema",
         "//haku/console/frontend/tool_rendering:entry",

--- a/haku/console/frontend/tool_rendering/grocy/requests.tsx
+++ b/haku/console/frontend/tool_rendering/grocy/requests.tsx
@@ -37,7 +37,7 @@ import {
   PreviewTitle,
   type PreviewProps,
   type PreviewVariant,
-} from "../variant.tsx";
+} from "../vocabulary.tsx";
 
 export const GROCY_SERVER_ID = "grocy-sf";
 

--- a/haku/console/frontend/tool_rendering/grocy/requests.tsx
+++ b/haku/console/frontend/tool_rendering/grocy/requests.tsx
@@ -24,6 +24,7 @@ import { Badge, Group, Stack, Text } from "@mantine/core";
 import { Fragment, type ReactNode, useEffect, useState } from "react";
 import { z } from "zod";
 
+import { Field } from "../../field.tsx";
 import { fetchGrocyReference, type GrocyReferenceResponse } from "../../grocy_client.ts";
 import { mcpToolSchema } from "../../mcp_tool_schema.ts";
 import { definePreview, type ToolPreview } from "../entry.tsx";
@@ -152,13 +153,13 @@ function GrocyItemsPreview<T>({
 function ProductAmount({ product, amount, qu }: { product: string; amount: number; qu: string }) {
   return (
     <Group gap={4}>
-      <Text span fw={600}>
+      <Text size="sm" span fw={600}>
         {product}
       </Text>
-      <Text span c="dimmed">
+      <Text size="sm" span c="dimmed">
         ×
       </Text>
-      <Text span>
+      <Text size="sm" span>
         {amount} {qu}
       </Text>
     </Group>
@@ -173,7 +174,7 @@ function StockAddRow({ item, reference }: { item: AddItem; reference: GrocyRefer
         amount={item.amount}
         qu={resolveName(reference?.quantity_units, item.qu)}
       />
-      <Text span c="dimmed">
+      <Text size="sm" span c="dimmed">
         → {resolveName(reference?.locations, item.location)}
       </Text>
       {item.best_before_date && (
@@ -204,7 +205,7 @@ function StockConsumeRow({ item, reference }: { item: ConsumeItem; reference: Gr
         amount={item.amount}
         qu={resolveName(reference?.quantity_units, item.qu)}
       />
-      <Text span c="dimmed">
+      <Text size="sm" span c="dimmed">
         from {resolveName(reference?.locations, item.location)}
       </Text>
       {item.spoiled && (
@@ -255,10 +256,10 @@ function ProductsCreateRow({
   return (
     <Stack gap={2}>
       <Group gap={6}>
-        <Text span fw={600}>
+        <Text size="sm" span fw={600}>
           {item.name}
         </Text>
-        <Text span c="dimmed">
+        <Text size="sm" span c="dimmed">
           stock in {stockQuName}, at {resolveName(reference?.locations, item.location)}
         </Text>
         {item.product_group != null && (
@@ -326,15 +327,17 @@ type FieldChange = { key: string; label: string; old: string | null; next: strin
 function ChangeLine({ change }: { change: FieldChange }) {
   return (
     <Text size="sm">
-      <Text span c="dimmed">
+      <Text size="sm" span c="dimmed">
         {change.label}:{" "}
       </Text>
       {change.old !== null && (
-        <Text span c="dimmed">
+        <Text size="sm" span c="dimmed">
           {change.old || "(empty)"} →{" "}
         </Text>
       )}
-      <Text span>{change.next}</Text>
+      <Text size="sm" span>
+        {change.next}
+      </Text>
     </Text>
   );
 }
@@ -372,7 +375,9 @@ function StockEntryEditRow({
   const shown = variant === "compact" ? changes.slice(0, 2) : changes;
   return (
     <Stack gap={2}>
-      <Text fw={600}>Stock entry #{item.entry_id}</Text>
+      <Text size="sm" fw={600}>
+        Stock entry #{item.entry_id}
+      </Text>
       {shown.map((change) => (
         <ChangeLine key={change.key} change={change} />
       ))}
@@ -397,25 +402,21 @@ function StockGetPreview({ args }: PreviewProps<StockGetArgs>) {
   const products = (args.products ?? []).map((value) => resolveName(reference?.products, value));
   const locations = (args.locations ?? []).map((value) => resolveName(reference?.locations, value));
   return (
-    <Stack gap={2}>
-      <Text>{products.length === 0 && locations.length === 0 ? "All current stock" : "Filtered current stock"}</Text>
-      {products.length > 0 && (
-        <Text size="sm" c="dimmed">
-          Products: {products.join(", ")}
-        </Text>
-      )}
-      {locations.length > 0 && (
-        <Text size="sm" c="dimmed">
-          Locations: {locations.join(", ")}
-        </Text>
-      )}
+    <Stack gap="xs">
+      {products.length === 0 && locations.length === 0 && <Text size="sm">All current stock</Text>}
+      {products.length > 0 && <Field label="Products">{products.join(", ")}</Field>}
+      {locations.length > 0 && <Field label="Locations">{locations.join(", ")}</Field>}
       <GrocyReferenceLoadError error={error} />
     </Stack>
   );
 }
 
 function DetailPreview({ detail, noun }: { detail: "brief" | "full"; noun: string }) {
-  return <Text>{detail === "full" ? `Full ${noun} records` : `${noun[0].toUpperCase()}${noun.slice(1)} names`}</Text>;
+  return (
+    <Text size="sm">
+      {detail === "full" ? `Full ${noun} records` : `${noun[0].toUpperCase()}${noun.slice(1)} names`}
+    </Text>
+  );
 }
 
 function ProductsListPreview({ args }: PreviewProps<ProductsListArgs>) {
@@ -427,11 +428,15 @@ function QuantityUnitsListPreview({ args }: PreviewProps<QuantityUnitsListArgs>)
 }
 
 function GetSystemInfoPreview(_: PreviewProps<GetSystemInfoArgs>) {
-  return <Text>Grocy server version and system details</Text>;
+  return <Text size="sm">Grocy server version and system details</Text>;
 }
 
 function ShoppingListItemsRemovePreview({ args }: PreviewProps<ShoppingListItemsRemoveArgs>) {
-  return <Text>Shopping-list item IDs: {args.item_ids.join(", ")}</Text>;
+  return (
+    <Field label="Shopping-list item IDs" mono>
+      {args.item_ids.join(", ")}
+    </Field>
+  );
 }
 
 type NameMap = { id: number; name: string }[] | undefined;
@@ -564,7 +569,9 @@ function ProductsEditRow({
   const shown = variant === "compact" ? changes.slice(0, 2) : changes;
   return (
     <Stack gap={2}>
-      <Text fw={600}>{resolveName(reference?.products, item.product)}</Text>
+      <Text size="sm" fw={600}>
+        {resolveName(reference?.products, item.product)}
+      </Text>
       <Stack gap={2}>
         {shown.map((change) => (
           <ChangeLine key={change.key} change={change} />
@@ -592,11 +599,11 @@ function ShoppingListGetPreview({ args }: PreviewProps<ShoppingListGetArgs>) {
   const { reference, error } = useGrocyReference();
   return (
     <Stack gap="xs">
-      <Text>
-        <Text span c="dimmed">
+      <Text size="sm">
+        <Text size="sm" span c="dimmed">
           List{" "}
         </Text>
-        <Text span fw={600}>
+        <Text size="sm" span fw={600}>
           {resolveName(reference?.shopping_lists, args.shopping_list)}
         </Text>
       </Text>
@@ -610,21 +617,21 @@ function ShoppingListAddRow({ item, reference }: { item: ShoppingItem; reference
     <Group gap={6}>
       {item.product != null ? (
         <Group gap={4}>
-          <Text span fw={600}>
+          <Text size="sm" span fw={600}>
             {resolveName(reference?.products, item.product)}
           </Text>
           {item.amount != null && item.amount !== 1 && (
-            <Text span c="dimmed">
+            <Text size="sm" span c="dimmed">
               × {item.amount}
             </Text>
           )}
         </Group>
       ) : (
-        <Text span fw={600}>
+        <Text size="sm" span fw={600}>
           {item.note}
         </Text>
       )}
-      <Text span c="dimmed">
+      <Text size="sm" span c="dimmed">
         → {resolveName(reference?.shopping_lists, item.shopping_list)}
       </Text>
       {item.product != null && item.note && (
@@ -665,7 +672,9 @@ function ShoppingListItemEditPreview({ args, variant }: PreviewProps<ShoppingLis
   const shown = variant === "compact" ? changes.slice(0, 2) : changes;
   return (
     <Stack gap={2}>
-      <Text fw={600}>Item #{args.item_id}</Text>
+      <Text size="sm" fw={600}>
+        Item #{args.item_id}
+      </Text>
       <Stack gap={2}>
         {shown.map((change) => (
           <ChangeLine key={change.key} change={change} />

--- a/haku/console/frontend/tool_rendering/grocy/requests.tsx
+++ b/haku/console/frontend/tool_rendering/grocy/requests.tsx
@@ -20,7 +20,7 @@
 // the edited product up by name/ID and resolves its old foreign keys through the same maps. While
 // the reference is still loading the old side is simply omitted (only the new value shows).
 
-import { Badge, Group, Stack, Text } from "@mantine/core";
+import { Group, Stack } from "@mantine/core";
 import { Fragment, type ReactNode, useEffect, useState } from "react";
 import { z } from "zod";
 
@@ -28,7 +28,16 @@ import { Field } from "../../field.tsx";
 import { fetchGrocyReference, type GrocyReferenceResponse } from "../../grocy_client.ts";
 import { mcpToolSchema } from "../../mcp_tool_schema.ts";
 import { definePreview, type ToolPreview } from "../entry.tsx";
-import { COMPACT_ITEM_LIMIT, MoreLine, plural, type PreviewProps, type PreviewVariant } from "../variant.tsx";
+import {
+  COMPACT_ITEM_LIMIT,
+  MoreLine,
+  plural,
+  PreviewBadge,
+  PreviewText,
+  PreviewTitle,
+  type PreviewProps,
+  type PreviewVariant,
+} from "../variant.tsx";
 
 export const GROCY_SERVER_ID = "grocy-sf";
 
@@ -112,11 +121,7 @@ function resolveProduct(products: GrocyProduct[] | undefined, value: string | nu
 
 function GrocyReferenceLoadError({ error }: { error: string | null }) {
   if (!error) return null;
-  return (
-    <Text size="sm" c="red">
-      Couldn't resolve product/location names: {error}
-    </Text>
-  );
+  return <PreviewText c="red">Couldn't resolve product/location names: {error}</PreviewText>;
 }
 
 // Shared skeleton for the item-list previews (stock add/consume, products create/edit, shopping
@@ -153,15 +158,15 @@ function GrocyItemsPreview<T>({
 function ProductAmount({ product, amount, qu }: { product: string; amount: number; qu: string }) {
   return (
     <Group gap={4}>
-      <Text size="sm" span fw={600}>
+      <PreviewText span fw={600}>
         {product}
-      </Text>
-      <Text size="sm" span c="dimmed">
+      </PreviewText>
+      <PreviewText span c="dimmed">
         ×
-      </Text>
-      <Text size="sm" span>
+      </PreviewText>
+      <PreviewText span>
         {amount} {qu}
-      </Text>
+      </PreviewText>
     </Group>
   );
 }
@@ -174,14 +179,10 @@ function StockAddRow({ item, reference }: { item: AddItem; reference: GrocyRefer
         amount={item.amount}
         qu={resolveName(reference?.quantity_units, item.qu)}
       />
-      <Text size="sm" span c="dimmed">
+      <PreviewText span c="dimmed">
         → {resolveName(reference?.locations, item.location)}
-      </Text>
-      {item.best_before_date && (
-        <Badge size="sm" variant="outline">
-          best before {item.best_before_date}
-        </Badge>
-      )}
+      </PreviewText>
+      {item.best_before_date && <PreviewBadge variant="outline">best before {item.best_before_date}</PreviewBadge>}
     </Group>
   );
 }
@@ -205,13 +206,13 @@ function StockConsumeRow({ item, reference }: { item: ConsumeItem; reference: Gr
         amount={item.amount}
         qu={resolveName(reference?.quantity_units, item.qu)}
       />
-      <Text size="sm" span c="dimmed">
+      <PreviewText span c="dimmed">
         from {resolveName(reference?.locations, item.location)}
-      </Text>
+      </PreviewText>
       {item.spoiled && (
-        <Badge size="sm" color="orange" variant="outline">
+        <PreviewBadge color="orange" variant="outline">
           spoiled
-        </Badge>
+        </PreviewBadge>
       )}
     </Group>
   );
@@ -256,14 +257,14 @@ function ProductsCreateRow({
   return (
     <Stack gap={2}>
       <Group gap={6}>
-        <Text size="sm" span fw={600}>
+        <PreviewText span fw={600}>
           {item.name}
-        </Text>
-        <Text size="sm" span c="dimmed">
+        </PreviewText>
+        <PreviewText span c="dimmed">
           stock in {stockQuName}, at {resolveName(reference?.locations, item.location)}
-        </Text>
+        </PreviewText>
         {item.product_group != null && (
-          <Badge size="sm">{resolveName(reference?.product_groups, item.product_group)}</Badge>
+          <PreviewBadge>{resolveName(reference?.product_groups, item.product_group)}</PreviewBadge>
         )}
       </Group>
       {/* Compact rows carry just the product's name + where it stocks; the secondary badge
@@ -271,35 +272,31 @@ function ProductsCreateRow({
       {variant === "compact" ? null : (
         <>
           <Group gap={6}>
-            <Badge size="sm" variant="outline" color="gray">
+            <PreviewBadge variant="outline" color="gray">
               shelf life: {formatDefaultBestBeforeDays(item.default_best_before_days)}
-            </Badge>
+            </PreviewBadge>
             {item.min_stock_amount != null && item.min_stock_amount !== 0 && (
-              <Badge size="sm" variant="outline" color="gray">
+              <PreviewBadge variant="outline" color="gray">
                 min stock: {item.min_stock_amount} {stockQuName}
-              </Badge>
+              </PreviewBadge>
             )}
             {purchaseQuName && purchaseQuName !== stockQuName && (
-              <Badge size="sm" variant="outline" color="gray">
+              <PreviewBadge variant="outline" color="gray">
                 purchased in {purchaseQuName}
-              </Badge>
+              </PreviewBadge>
             )}
             {consumeQuName && consumeQuName !== stockQuName && (
-              <Badge size="sm" variant="outline" color="gray">
+              <PreviewBadge variant="outline" color="gray">
                 consumed in {consumeQuName}
-              </Badge>
+              </PreviewBadge>
             )}
             {item.parent_product != null && (
-              <Badge size="sm" variant="outline" color="gray">
+              <PreviewBadge variant="outline" color="gray">
                 variant of {resolveName(reference?.products, item.parent_product)}
-              </Badge>
+              </PreviewBadge>
             )}
           </Group>
-          {item.description && (
-            <Text size="sm" c="dimmed">
-              {item.description}
-            </Text>
-          )}
+          {item.description && <PreviewText c="dimmed">{item.description}</PreviewText>}
         </>
       )}
     </Stack>
@@ -326,19 +323,17 @@ type FieldChange = { key: string; label: string; old: string | null; next: strin
 
 function ChangeLine({ change }: { change: FieldChange }) {
   return (
-    <Text size="sm">
-      <Text size="sm" span c="dimmed">
+    <PreviewText>
+      <PreviewText span c="dimmed">
         {change.label}:{" "}
-      </Text>
+      </PreviewText>
       {change.old !== null && (
-        <Text size="sm" span c="dimmed">
+        <PreviewText span c="dimmed">
           {change.old || "(empty)"} →{" "}
-        </Text>
+        </PreviewText>
       )}
-      <Text size="sm" span>
-        {change.next}
-      </Text>
-    </Text>
+      <PreviewText span>{change.next}</PreviewText>
+    </PreviewText>
   );
 }
 
@@ -375,9 +370,7 @@ function StockEntryEditRow({
   const shown = variant === "compact" ? changes.slice(0, 2) : changes;
   return (
     <Stack gap={2}>
-      <Text size="sm" fw={600}>
-        Stock entry #{item.entry_id}
-      </Text>
+      <PreviewTitle>Stock entry #{item.entry_id}</PreviewTitle>
       {shown.map((change) => (
         <ChangeLine key={change.key} change={change} />
       ))}
@@ -403,7 +396,7 @@ function StockGetPreview({ args }: PreviewProps<StockGetArgs>) {
   const locations = (args.locations ?? []).map((value) => resolveName(reference?.locations, value));
   return (
     <Stack gap="xs">
-      {products.length === 0 && locations.length === 0 && <Text size="sm">All current stock</Text>}
+      {products.length === 0 && locations.length === 0 && <PreviewText>All current stock</PreviewText>}
       {products.length > 0 && <Field label="Products">{products.join(", ")}</Field>}
       {locations.length > 0 && <Field label="Locations">{locations.join(", ")}</Field>}
       <GrocyReferenceLoadError error={error} />
@@ -413,9 +406,9 @@ function StockGetPreview({ args }: PreviewProps<StockGetArgs>) {
 
 function DetailPreview({ detail, noun }: { detail: "brief" | "full"; noun: string }) {
   return (
-    <Text size="sm">
+    <PreviewText>
       {detail === "full" ? `Full ${noun} records` : `${noun[0].toUpperCase()}${noun.slice(1)} names`}
-    </Text>
+    </PreviewText>
   );
 }
 
@@ -428,7 +421,7 @@ function QuantityUnitsListPreview({ args }: PreviewProps<QuantityUnitsListArgs>)
 }
 
 function GetSystemInfoPreview(_: PreviewProps<GetSystemInfoArgs>) {
-  return <Text size="sm">Grocy server version and system details</Text>;
+  return <PreviewText>Grocy server version and system details</PreviewText>;
 }
 
 function ShoppingListItemsRemovePreview({ args }: PreviewProps<ShoppingListItemsRemoveArgs>) {
@@ -569,9 +562,7 @@ function ProductsEditRow({
   const shown = variant === "compact" ? changes.slice(0, 2) : changes;
   return (
     <Stack gap={2}>
-      <Text size="sm" fw={600}>
-        {resolveName(reference?.products, item.product)}
-      </Text>
+      <PreviewTitle>{resolveName(reference?.products, item.product)}</PreviewTitle>
       <Stack gap={2}>
         {shown.map((change) => (
           <ChangeLine key={change.key} change={change} />
@@ -599,14 +590,14 @@ function ShoppingListGetPreview({ args }: PreviewProps<ShoppingListGetArgs>) {
   const { reference, error } = useGrocyReference();
   return (
     <Stack gap="xs">
-      <Text size="sm">
-        <Text size="sm" span c="dimmed">
+      <PreviewText>
+        <PreviewText span c="dimmed">
           List{" "}
-        </Text>
-        <Text size="sm" span fw={600}>
+        </PreviewText>
+        <PreviewText span fw={600}>
           {resolveName(reference?.shopping_lists, args.shopping_list)}
-        </Text>
-      </Text>
+        </PreviewText>
+      </PreviewText>
       <GrocyReferenceLoadError error={error} />
     </Stack>
   );
@@ -617,27 +608,27 @@ function ShoppingListAddRow({ item, reference }: { item: ShoppingItem; reference
     <Group gap={6}>
       {item.product != null ? (
         <Group gap={4}>
-          <Text size="sm" span fw={600}>
+          <PreviewText span fw={600}>
             {resolveName(reference?.products, item.product)}
-          </Text>
+          </PreviewText>
           {item.amount != null && item.amount !== 1 && (
-            <Text size="sm" span c="dimmed">
+            <PreviewText span c="dimmed">
               × {item.amount}
-            </Text>
+            </PreviewText>
           )}
         </Group>
       ) : (
-        <Text size="sm" span fw={600}>
+        <PreviewText span fw={600}>
           {item.note}
-        </Text>
+        </PreviewText>
       )}
-      <Text size="sm" span c="dimmed">
+      <PreviewText span c="dimmed">
         → {resolveName(reference?.shopping_lists, item.shopping_list)}
-      </Text>
+      </PreviewText>
       {item.product != null && item.note && (
-        <Text span size="sm" c="dimmed">
+        <PreviewText span c="dimmed">
           ({item.note})
-        </Text>
+        </PreviewText>
       )}
     </Group>
   );
@@ -672,9 +663,7 @@ function ShoppingListItemEditPreview({ args, variant }: PreviewProps<ShoppingLis
   const shown = variant === "compact" ? changes.slice(0, 2) : changes;
   return (
     <Stack gap={2}>
-      <Text size="sm" fw={600}>
-        Item #{args.item_id}
-      </Text>
+      <PreviewTitle>Item #{args.item_id}</PreviewTitle>
       <Stack gap={2}>
         {shown.map((change) => (
           <ChangeLine key={change.key} change={change} />

--- a/haku/console/frontend/tool_rendering/grocy/responses.tsx
+++ b/haku/console/frontend/tool_rendering/grocy/responses.tsx
@@ -7,11 +7,18 @@
 // lenient about extra keys, since the remote server's output schemas are not in the build-time
 // catalog and can grow fields under the console.
 
-import { Badge, Group, Stack, Text } from "@mantine/core";
+import { Group, Stack } from "@mantine/core";
 import type { ReactNode } from "react";
 import { z } from "zod";
 
-import { COMPACT_ITEM_LIMIT, MoreLine, type PreviewVariant } from "../variant.tsx";
+import {
+  COMPACT_ITEM_LIMIT,
+  MoreLine,
+  PreviewBadge,
+  PreviewText,
+  PreviewTitle,
+  type PreviewVariant,
+} from "../variant.tsx";
 import { defineResultPreview, type ResultPreviewProps, type ToolResultPreview } from "../result_entry.tsx";
 
 // A failed row: any kind other than "ok", with the server's error message. Matched after the
@@ -122,13 +129,13 @@ function splitRows<Ok extends { kind: "ok" }>(rows: readonly (Ok | FailedRow)[])
 function ResultSummary({ okCount, failedCount, verb }: { okCount: number; failedCount: number; verb: string }) {
   return (
     <Group gap={6}>
-      <Text span size="sm" fw={600}>
+      <PreviewText span fw={600}>
         {okCount} {verb}
-      </Text>
+      </PreviewText>
       {failedCount > 0 && (
-        <Text span size="sm" c="red">
+        <PreviewText span c="red">
           +{failedCount} failed
-        </Text>
+        </PreviewText>
       )}
     </Group>
   );
@@ -155,11 +162,7 @@ function BatchResultView<Ok extends { kind: "ok" }>({
     return (
       <Stack gap={2}>
         <ResultSummary okCount={ok.length} failedCount={failed.length} verb={verb} />
-        {shown.length > 0 && (
-          <Text size="sm" c="dimmed">
-            {shown.map(rowName).join(" · ")}
-          </Text>
-        )}
+        {shown.length > 0 && <PreviewText c="dimmed">{shown.map(rowName).join(" · ")}</PreviewText>}
         <MoreLine count={ok.length - shown.length} />
       </Stack>
     );
@@ -171,9 +174,9 @@ function BatchResultView<Ok extends { kind: "ok" }>({
         <RowView key={i} row={row} />
       ))}
       {failed.map((row, i) => (
-        <Text key={i} size="sm" c="red">
+        <PreviewText key={i} c="red">
           ✗ {row.error}
-        </Text>
+        </PreviewText>
       ))}
     </Stack>
   );
@@ -182,22 +185,18 @@ function BatchResultView<Ok extends { kind: "ok" }>({
 function StockAddResultRow({ row }: { row: StockAddOkRow }) {
   return (
     <Group gap={6}>
-      <Text size="sm" span fw={600}>
+      <PreviewText span fw={600}>
         {row.product_name}
-      </Text>
+      </PreviewText>
       {row.amount_delta != null && (
-        <Text size="sm" span>
+        <PreviewText span>
           +{row.amount_delta} {row.qu_name}
-        </Text>
+        </PreviewText>
       )}
-      <Text size="sm" span c="dimmed">
+      <PreviewText span c="dimmed">
         {row.new_amount != null ? `→ ${row.new_amount} ${row.qu_name} in ${row.location_name}` : row.location_name}
-      </Text>
-      {row.best_before_date && (
-        <Badge size="sm" variant="outline">
-          best before {row.best_before_date}
-        </Badge>
-      )}
+      </PreviewText>
+      {row.best_before_date && <PreviewBadge variant="outline">best before {row.best_before_date}</PreviewBadge>}
     </Group>
   );
 }
@@ -221,13 +220,13 @@ function productsCreateRowName(row: ProductsCreateOkRow): string {
 function ProductsCreateResultRow({ row }: { row: ProductsCreateOkRow }) {
   return (
     <Group gap={6}>
-      <Text size="sm" span fw={600}>
+      <PreviewText span fw={600}>
         {productsCreateRowName(row)}
-      </Text>
+      </PreviewText>
       {row.product_name != null && row.created_object_id != null && (
-        <Text size="sm" span c="dimmed">
+        <PreviewText span c="dimmed">
           #{row.created_object_id}
-        </Text>
+        </PreviewText>
       )}
     </Group>
   );
@@ -252,16 +251,16 @@ function shoppingItemName(row: ShoppingListItemOkRow): string {
 function ShoppingListItemsAddResultRow({ row }: { row: ShoppingListItemOkRow }) {
   return (
     <Group gap={4}>
-      <Text size="sm" span fw={600}>
+      <PreviewText span fw={600}>
         {shoppingItemName(row)}
-      </Text>
-      <Text size="sm" span c="dimmed">
+      </PreviewText>
+      <PreviewText span c="dimmed">
         ×
-      </Text>
-      <Text size="sm" span>
+      </PreviewText>
+      <PreviewText span>
         {row.amount}
         {row.qu_name ? ` ${row.qu_name}` : ""}
-      </Text>
+      </PreviewText>
     </Group>
   );
 }
@@ -285,28 +284,24 @@ function StockEntryEditResultRow({ row }: { row: StockEntryEditOkRow }) {
   return (
     <Stack gap={2}>
       <Group gap={6}>
-        <Text size="sm" span fw={600}>
+        <PreviewText span fw={600}>
           {row.entry.product_name}
-        </Text>
-        <Text size="sm" span>
+        </PreviewText>
+        <PreviewText span>
           {row.entry.amount} {row.entry.qu_name}
-        </Text>
-        <Text size="sm" span c="dimmed">
+        </PreviewText>
+        <PreviewText span c="dimmed">
           in {row.entry.location_name} · entry #{row.entry.entry_id}
-        </Text>
-        {row.entry.open && (
-          <Badge size="sm" variant="outline">
-            opened
-          </Badge>
-        )}
+        </PreviewText>
+        {row.entry.open && <PreviewBadge variant="outline">opened</PreviewBadge>}
       </Group>
       {row.changes && (
-        <Text size="sm" c="dimmed">
+        <PreviewText c="dimmed">
           Changed:{" "}
           {Object.keys(row.changes)
             .map((field) => field.replaceAll("_", " "))
             .join(", ")}
-        </Text>
+        </PreviewText>
       )}
     </Stack>
   );
@@ -328,25 +323,21 @@ function StockGetResultView({ result, variant }: ResultPreviewProps<z.infer<type
   const rows = variant === "compact" ? result.slice(0, COMPACT_ITEM_LIMIT) : result;
   return (
     <Stack gap={4}>
-      <Text size="sm" fw={600}>
+      <PreviewTitle>
         {result.length} stock {result.length === 1 ? "item" : "items"}
-      </Text>
+      </PreviewTitle>
       {rows.map((row, i) => (
         <Group gap={6} key={i}>
-          <Text size="sm" span fw={600}>
+          <PreviewText span fw={600}>
             {row.product_name}
-          </Text>
-          <Text size="sm" span>
+          </PreviewText>
+          <PreviewText span>
             {row.amount} {row.qu_name}
-          </Text>
-          <Text size="sm" span c="dimmed">
+          </PreviewText>
+          <PreviewText span c="dimmed">
             in {row.location_name}
-          </Text>
-          {row.amount_opened > 0 && (
-            <Badge size="sm" variant="outline">
-              {row.amount_opened} opened
-            </Badge>
-          )}
+          </PreviewText>
+          {row.amount_opened > 0 && <PreviewBadge variant="outline">{row.amount_opened} opened</PreviewBadge>}
         </Group>
       ))}
       <MoreLine count={result.length - rows.length} />
@@ -358,16 +349,14 @@ function NamedRowsResultView({ result, variant }: ResultPreviewProps<z.infer<typ
   const rows = variant === "compact" ? result.slice(0, COMPACT_ITEM_LIMIT) : result;
   return (
     <Stack gap={2}>
-      <Text size="sm" fw={600}>
-        {result.length} found
-      </Text>
+      <PreviewTitle>{result.length} found</PreviewTitle>
       {rows.map((row) => (
-        <Text key={row.id} size="sm">
+        <PreviewText key={row.id}>
           {row.name}{" "}
-          <Text size="sm" span c="dimmed">
+          <PreviewText span c="dimmed">
             #{row.id}
-          </Text>
-        </Text>
+          </PreviewText>
+        </PreviewText>
       ))}
       <MoreLine count={result.length - rows.length} />
     </Stack>
@@ -382,18 +371,18 @@ function ShoppingListGetResultView({ result, variant }: ResultPreviewProps<z.inf
   const rows = variant === "compact" ? result.items.slice(0, COMPACT_ITEM_LIMIT) : result.items;
   return (
     <Stack gap={4}>
-      <Text size="sm" fw={600}>
+      <PreviewTitle>
         {result.name} · {result.items.length} items
-      </Text>
+      </PreviewTitle>
       {rows.map((row) => (
         <Group gap={6} key={row.item_id}>
-          <Text size="sm" span td={row.done ? "line-through" : undefined}>
+          <PreviewText span td={row.done ? "line-through" : undefined}>
             {row.product_name ?? row.note ?? "(note)"}
-          </Text>
-          <Text size="sm" span c="dimmed">
+          </PreviewText>
+          <PreviewText span c="dimmed">
             × {row.amount}
             {row.qu_name ? ` ${row.qu_name}` : ""} · #{row.item_id}
-          </Text>
+          </PreviewText>
         </Group>
       ))}
       <MoreLine count={result.items.length - rows.length} />
@@ -405,12 +394,12 @@ function SystemInfoResultView({ result }: ResultPreviewProps<z.infer<typeof zSys
   return (
     <Stack gap={2}>
       {Object.entries(result).map(([key, value]) => (
-        <Text size="sm" key={key}>
-          <Text size="sm" span c="dimmed">
+        <PreviewText key={key}>
+          <PreviewText span c="dimmed">
             {key.replaceAll("_", " ")}:{" "}
-          </Text>
+          </PreviewText>
           {String(value)}
-        </Text>
+        </PreviewText>
       ))}
     </Stack>
   );

--- a/haku/console/frontend/tool_rendering/grocy/responses.tsx
+++ b/haku/console/frontend/tool_rendering/grocy/responses.tsx
@@ -18,7 +18,7 @@ import {
   PreviewText,
   PreviewTitle,
   type PreviewVariant,
-} from "../variant.tsx";
+} from "../vocabulary.tsx";
 import { defineResultPreview, type ResultPreviewProps, type ToolResultPreview } from "../result_entry.tsx";
 
 // A failed row: any kind other than "ok", with the server's error message. Matched after the

--- a/haku/console/frontend/tool_rendering/grocy/responses.tsx
+++ b/haku/console/frontend/tool_rendering/grocy/responses.tsx
@@ -182,15 +182,15 @@ function BatchResultView<Ok extends { kind: "ok" }>({
 function StockAddResultRow({ row }: { row: StockAddOkRow }) {
   return (
     <Group gap={6}>
-      <Text span fw={600}>
+      <Text size="sm" span fw={600}>
         {row.product_name}
       </Text>
       {row.amount_delta != null && (
-        <Text span>
+        <Text size="sm" span>
           +{row.amount_delta} {row.qu_name}
         </Text>
       )}
-      <Text span c="dimmed">
+      <Text size="sm" span c="dimmed">
         {row.new_amount != null ? `→ ${row.new_amount} ${row.qu_name} in ${row.location_name}` : row.location_name}
       </Text>
       {row.best_before_date && (
@@ -221,11 +221,11 @@ function productsCreateRowName(row: ProductsCreateOkRow): string {
 function ProductsCreateResultRow({ row }: { row: ProductsCreateOkRow }) {
   return (
     <Group gap={6}>
-      <Text span fw={600}>
+      <Text size="sm" span fw={600}>
         {productsCreateRowName(row)}
       </Text>
       {row.product_name != null && row.created_object_id != null && (
-        <Text span c="dimmed">
+        <Text size="sm" span c="dimmed">
           #{row.created_object_id}
         </Text>
       )}
@@ -252,13 +252,13 @@ function shoppingItemName(row: ShoppingListItemOkRow): string {
 function ShoppingListItemsAddResultRow({ row }: { row: ShoppingListItemOkRow }) {
   return (
     <Group gap={4}>
-      <Text span fw={600}>
+      <Text size="sm" span fw={600}>
         {shoppingItemName(row)}
       </Text>
-      <Text span c="dimmed">
+      <Text size="sm" span c="dimmed">
         ×
       </Text>
-      <Text span>
+      <Text size="sm" span>
         {row.amount}
         {row.qu_name ? ` ${row.qu_name}` : ""}
       </Text>
@@ -285,13 +285,13 @@ function StockEntryEditResultRow({ row }: { row: StockEntryEditOkRow }) {
   return (
     <Stack gap={2}>
       <Group gap={6}>
-        <Text span fw={600}>
+        <Text size="sm" span fw={600}>
           {row.entry.product_name}
         </Text>
-        <Text span>
+        <Text size="sm" span>
           {row.entry.amount} {row.entry.qu_name}
         </Text>
-        <Text span c="dimmed">
+        <Text size="sm" span c="dimmed">
           in {row.entry.location_name} · entry #{row.entry.entry_id}
         </Text>
         {row.entry.open && (
@@ -333,13 +333,13 @@ function StockGetResultView({ result, variant }: ResultPreviewProps<z.infer<type
       </Text>
       {rows.map((row, i) => (
         <Group gap={6} key={i}>
-          <Text span fw={600}>
+          <Text size="sm" span fw={600}>
             {row.product_name}
           </Text>
-          <Text span>
+          <Text size="sm" span>
             {row.amount} {row.qu_name}
           </Text>
-          <Text span c="dimmed">
+          <Text size="sm" span c="dimmed">
             in {row.location_name}
           </Text>
           {row.amount_opened > 0 && (
@@ -364,7 +364,7 @@ function NamedRowsResultView({ result, variant }: ResultPreviewProps<z.infer<typ
       {rows.map((row) => (
         <Text key={row.id} size="sm">
           {row.name}{" "}
-          <Text span c="dimmed">
+          <Text size="sm" span c="dimmed">
             #{row.id}
           </Text>
         </Text>
@@ -382,15 +382,15 @@ function ShoppingListGetResultView({ result, variant }: ResultPreviewProps<z.inf
   const rows = variant === "compact" ? result.items.slice(0, COMPACT_ITEM_LIMIT) : result.items;
   return (
     <Stack gap={4}>
-      <Text fw={600}>
+      <Text size="sm" fw={600}>
         {result.name} · {result.items.length} items
       </Text>
       {rows.map((row) => (
         <Group gap={6} key={row.item_id}>
-          <Text span td={row.done ? "line-through" : undefined}>
+          <Text size="sm" span td={row.done ? "line-through" : undefined}>
             {row.product_name ?? row.note ?? "(note)"}
           </Text>
-          <Text span c="dimmed">
+          <Text size="sm" span c="dimmed">
             × {row.amount}
             {row.qu_name ? ` ${row.qu_name}` : ""} · #{row.item_id}
           </Text>
@@ -406,7 +406,7 @@ function SystemInfoResultView({ result }: ResultPreviewProps<z.infer<typeof zSys
     <Stack gap={2}>
       {Object.entries(result).map(([key, value]) => (
         <Text size="sm" key={key}>
-          <Text span c="dimmed">
+          <Text size="sm" span c="dimmed">
             {key.replaceAll("_", " ")}:{" "}
           </Text>
           {String(value)}

--- a/haku/console/frontend/tool_rendering/haku_routine/requests.tsx
+++ b/haku/console/frontend/tool_rendering/haku_routine/requests.tsx
@@ -4,13 +4,12 @@
 // verbatim before approving. Its validator comes from the exact FastMCP input schema advertised
 // by tools/list, through the same generated catalog as the Gmail and Calendar previews.
 
-import { Text } from "@mantine/core";
 import { z } from "zod";
 
 import { Field } from "../../field.tsx";
 import { mcpToolSchema } from "../../mcp_tool_schema.ts";
 import { definePreview, type ToolPreview } from "../entry.tsx";
-import { clampBlock, type PreviewProps } from "../variant.tsx";
+import { clampBlock, PreviewText, type PreviewProps } from "../variant.tsx";
 
 export const HAKU_ROUTINE_SERVER_ID = "haku_routine";
 
@@ -22,13 +21,7 @@ function LaunchRoutinePreview({ args, variant }: PreviewProps<LaunchRoutineArgs>
   const shown = text ? (variant === "compact" ? clampBlock(text, 3) : text) : null;
   return (
     <Field label="Instructions">
-      {shown ? (
-        <pre className="haku-shell-json">{shown}</pre>
-      ) : (
-        <Text size="sm" c="dimmed">
-          (routine default)
-        </Text>
-      )}
+      {shown ? <pre className="haku-shell-json">{shown}</pre> : <PreviewText c="dimmed">(routine default)</PreviewText>}
     </Field>
   );
 }

--- a/haku/console/frontend/tool_rendering/haku_routine/requests.tsx
+++ b/haku/console/frontend/tool_rendering/haku_routine/requests.tsx
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { Field } from "../../field.tsx";
 import { mcpToolSchema } from "../../mcp_tool_schema.ts";
 import { definePreview, type ToolPreview } from "../entry.tsx";
-import { clampBlock, PreviewText, type PreviewProps } from "../variant.tsx";
+import { clampBlock, PreviewText, type PreviewProps } from "../vocabulary.tsx";
 
 export const HAKU_ROUTINE_SERVER_ID = "haku_routine";
 

--- a/haku/console/frontend/tool_rendering/index.tsx
+++ b/haku/console/frontend/tool_rendering/index.tsx
@@ -22,7 +22,7 @@ import { HAKU_ROUTINE_SERVER_ID, hakuRoutinePreviews } from "./haku_routine/requ
 import { KUBECTL_SERVER_ID, kubectlPreviews } from "./kubectl/requests.tsx";
 import { renderResultPreview, type ToolResultPreview } from "./result_entry.tsx";
 import { TANA_RW_SERVER_ID, tanaPreviews } from "./tana/requests.tsx";
-import type { PreviewVariant } from "./variant.tsx";
+import type { PreviewVariant } from "./vocabulary.tsx";
 
 const REGISTRY = {
   [GMAIL_SERVER_ID]: gmailPreviews,

--- a/haku/console/frontend/tool_rendering/kubectl/BUILD.bazel
+++ b/haku/console/frontend/tool_rendering/kubectl/BUILD.bazel
@@ -12,6 +12,7 @@ js_library(
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
         "//:node_modules/zod",
+        "//haku/console/frontend:field",
         "//haku/console/frontend/tool_rendering:entry",
         "//haku/console/frontend/tool_rendering:variant",
     ],

--- a/haku/console/frontend/tool_rendering/kubectl/requests.tsx
+++ b/haku/console/frontend/tool_rendering/kubectl/requests.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 import { Field } from "../../field.tsx";
 import { definePreview, type ToolPreview } from "../entry.tsx";
-import { clampBlock, PreviewText, type PreviewProps } from "../variant.tsx";
+import { clampBlock, PreviewText, type PreviewProps } from "../vocabulary.tsx";
 
 export const KUBECTL_SERVER_ID = "kubectl-passthrough-mcp";
 

--- a/haku/console/frontend/tool_rendering/kubectl/requests.tsx
+++ b/haku/console/frontend/tool_rendering/kubectl/requests.tsx
@@ -9,6 +9,7 @@
 import { Group, Stack, Text } from "@mantine/core";
 import { z } from "zod";
 
+import { Field } from "../../field.tsx";
 import { definePreview, type ToolPreview } from "../entry.tsx";
 import { clampBlock, type PreviewProps } from "../variant.tsx";
 
@@ -65,12 +66,14 @@ function DeleteTargetPreview({
   return (
     <Stack gap="xs">
       <Group gap={4} className="haku-shell-mono">
-        <Text span fw={600}>
+        <Text size="sm" span fw={600}>
           {kind}
         </Text>
-        <Text span>{name}</Text>
+        <Text size="sm" span>
+          {name}
+        </Text>
         {namespace && (
-          <Text span c="dimmed">
+          <Text size="sm" span c="dimmed">
             in {namespace}
           </Text>
         )}
@@ -101,12 +104,12 @@ function PodsDeletePreview({ args }: PreviewProps<PodsDeleteArgs>) {
 
 function PodsLogPreview({ args }: PreviewProps<PodsLogArgs>) {
   return (
-    <Stack gap={2}>
-      <Group gap={6} className="haku-shell-mono">
-        <Text fw={600}>{args.name}</Text>
-        {args.namespace && <Text c="dimmed">in {args.namespace}</Text>}
-        {args.container && <Text c="dimmed">container {args.container}</Text>}
-      </Group>
+    <Stack gap="xs">
+      <Field label="Pod" mono>
+        {args.namespace ? `${args.namespace}/` : ""}
+        {args.name}
+        {args.container ? ` · ${args.container}` : ""}
+      </Field>
       <Text size="sm" c="dimmed">
         {args.previous ? "Previous container logs" : "Current logs"} · last {args.tail ?? 100} lines
       </Text>

--- a/haku/console/frontend/tool_rendering/kubectl/requests.tsx
+++ b/haku/console/frontend/tool_rendering/kubectl/requests.tsx
@@ -6,12 +6,12 @@
 // identity (cluster_auth_mode=passthrough) once approved, so rendering the exact target
 // unambiguously matters more than for narrower-scoped tools.
 
-import { Group, Stack, Text } from "@mantine/core";
+import { Group, Stack } from "@mantine/core";
 import { z } from "zod";
 
 import { Field } from "../../field.tsx";
 import { definePreview, type ToolPreview } from "../entry.tsx";
-import { clampBlock, type PreviewProps } from "../variant.tsx";
+import { clampBlock, PreviewText, type PreviewProps } from "../variant.tsx";
 
 export const KUBECTL_SERVER_ID = "kubectl-passthrough-mcp";
 
@@ -66,22 +66,18 @@ function DeleteTargetPreview({
   return (
     <Stack gap="xs">
       <Group gap={4} className="haku-shell-mono">
-        <Text size="sm" span fw={600}>
+        <PreviewText span fw={600}>
           {kind}
-        </Text>
-        <Text size="sm" span>
-          {name}
-        </Text>
+        </PreviewText>
+        <PreviewText span>{name}</PreviewText>
         {namespace && (
-          <Text size="sm" span c="dimmed">
+          <PreviewText span c="dimmed">
             in {namespace}
-          </Text>
+          </PreviewText>
         )}
       </Group>
       {gracePeriodSeconds === 0 && (
-        <Text size="sm" c="red">
-          Immediate deletion (grace period 0) — no termination grace.
-        </Text>
+        <PreviewText c="red">Immediate deletion (grace period 0) — no termination grace.</PreviewText>
       )}
     </Stack>
   );
@@ -110,9 +106,9 @@ function PodsLogPreview({ args }: PreviewProps<PodsLogArgs>) {
         {args.name}
         {args.container ? ` · ${args.container}` : ""}
       </Field>
-      <Text size="sm" c="dimmed">
+      <PreviewText c="dimmed">
         {args.previous ? "Previous container logs" : "Current logs"} · last {args.tail ?? 100} lines
-      </Text>
+      </PreviewText>
     </Stack>
   );
 }

--- a/haku/console/frontend/tool_rendering/result_entry.tsx
+++ b/haku/console/frontend/tool_rendering/result_entry.tsx
@@ -6,7 +6,7 @@
 import type { ReactNode } from "react";
 import { z } from "zod";
 
-import type { PreviewVariant } from "./variant.tsx";
+import type { PreviewVariant } from "./vocabulary.tsx";
 
 export type ToolResultPreview<S extends z.ZodTypeAny = z.ZodTypeAny> = {
   schema: S;
@@ -17,7 +17,7 @@ export type ToolResultPreview<S extends z.ZodTypeAny = z.ZodTypeAny> = {
 };
 
 // The props every top-level result widget takes: the tool's parsed result payload plus the
-// variant to render — the result-side counterpart of variant.tsx's PreviewProps.
+// variant to render — the result-side counterpart of vocabulary.tsx's PreviewProps.
 export type ResultPreviewProps<Result> = { result: Result; variant: PreviewVariant };
 
 /** Bind a tool's result schema to the widget that renders it. `Widget` takes the schema's

--- a/haku/console/frontend/tool_rendering/tana/requests.tsx
+++ b/haku/console/frontend/tool_rendering/tana/requests.tsx
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { Field } from "../../field.tsx";
 import { fetchTanaNodePreviews, type TanaNodePreview } from "../../tana_client.ts";
 import { definePreview, type ToolPreview } from "../entry.tsx";
-import { clampBlock, PreviewBadge, PreviewText, type PreviewProps } from "../variant.tsx";
+import { clampBlock, PreviewBadge, PreviewText, type PreviewProps } from "../vocabulary.tsx";
 
 export const TANA_RW_SERVER_ID = "tana-rw";
 

--- a/haku/console/frontend/tool_rendering/tana/requests.tsx
+++ b/haku/console/frontend/tool_rendering/tana/requests.tsx
@@ -3,14 +3,14 @@
 // node-previews endpoint resolves names through the same operator credential that executes an
 // approved call. It deliberately does not parse Tana Paste or expose a generic MCP proxy.
 
-import { Anchor, Badge, Group, Stack, Text } from "@mantine/core";
+import { Anchor, Group, Stack } from "@mantine/core";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
 import { Field } from "../../field.tsx";
 import { fetchTanaNodePreviews, type TanaNodePreview } from "../../tana_client.ts";
 import { definePreview, type ToolPreview } from "../entry.tsx";
-import { clampBlock, type PreviewProps } from "../variant.tsx";
+import { clampBlock, PreviewBadge, PreviewText, type PreviewProps } from "../variant.tsx";
 
 export const TANA_RW_SERVER_ID = "tana-rw";
 
@@ -86,9 +86,9 @@ function TanaNodeLink({ nodeId, previews }: { nodeId: string; previews: Record<s
       {preview.name}
     </Anchor>
   ) : (
-    <Text size="sm" span className="haku-shell-mono" c="dimmed">
+    <PreviewText span className="haku-shell-mono" c="dimmed">
       {nodeId}
-    </Text>
+    </PreviewText>
   );
 }
 
@@ -108,13 +108,11 @@ function ImportTanaPastePreview({ args, variant }: PreviewProps<ImportTanaPasteA
 function GetOrCreateCalendarNodePreview({ args }: PreviewProps<GetOrCreateCalendarNodeArgs>) {
   return (
     <Group gap={6}>
-      <Badge size="sm" variant="outline">
-        {args.granularity}
-      </Badge>
-      {args.date && <Text size="sm">{args.date}</Text>}
-      <Text size="sm" c="dimmed" className="haku-shell-mono">
+      <PreviewBadge variant="outline">{args.granularity}</PreviewBadge>
+      {args.date && <PreviewText>{args.date}</PreviewText>}
+      <PreviewText c="dimmed" className="haku-shell-mono">
         {args.workspaceId}
-      </Text>
+      </PreviewText>
     </Group>
   );
 }
@@ -127,21 +125,19 @@ function TrashNodePreview({ args }: PreviewProps<TrashNodeArgs>) {
 function EditOperation({ label, edit }: { label: string; edit: z.infer<typeof zEditOperation> }) {
   return (
     <Stack gap={2}>
-      <Text size="sm" fw={600}>
-        {label}
-      </Text>
-      <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>
-        <Text size="sm" span c="dimmed">
+      <PreviewText fw={600}>{label}</PreviewText>
+      <PreviewText style={{ whiteSpace: "pre-wrap" }}>
+        <PreviewText span c="dimmed">
           {edit.old_string || "(empty)"}
-        </Text>
+        </PreviewText>
         {" → "}
         {edit.new_string || "(clear)"}
         {edit.replace_all && (
-          <Text size="sm" span c="dimmed">
+          <PreviewText span c="dimmed">
             {" · all matches"}
-          </Text>
+          </PreviewText>
         )}
-      </Text>
+      </PreviewText>
     </Stack>
   );
 }
@@ -167,26 +163,18 @@ function MoveNodePreview({ args }: PreviewProps<MoveNodeArgs>) {
     <Stack gap={4}>
       <Group gap={6}>
         <TanaNodeLink nodeId={args.nodeId} previews={previews} />
-        <Text size="sm" c="dimmed">
-          →
-        </Text>
+        <PreviewText c="dimmed">→</PreviewText>
         <TanaNodeLink nodeId={args.targetNodeId} previews={previews} />
       </Group>
       <Group gap={6}>
-        <Badge size="sm" variant="outline">
-          {args.position}
-        </Badge>
+        <PreviewBadge variant="outline">{args.position}</PreviewBadge>
         {args.referenceNodeId && <TanaNodeLink nodeId={args.referenceNodeId} previews={previews} />}
         {args.sourceParentId && (
-          <Text size="sm" c="dimmed">
+          <PreviewText c="dimmed">
             from <TanaNodeLink nodeId={args.sourceParentId} previews={previews} />
-          </Text>
+          </PreviewText>
         )}
-        {args.keepSourceReference && (
-          <Badge size="sm" variant="outline">
-            keep reference
-          </Badge>
-        )}
+        {args.keepSourceReference && <PreviewBadge variant="outline">keep reference</PreviewBadge>}
       </Group>
     </Stack>
   );
@@ -204,9 +192,7 @@ function SetFieldOptionPreview({ args }: PreviewProps<SetFieldOptionArgs>) {
       </Field>
       <Field label="Option">
         <Group gap={6}>
-          <Badge size="sm" variant="outline">
-            {args.mode}
-          </Badge>
+          <PreviewBadge variant="outline">{args.mode}</PreviewBadge>
           <TanaNodeLink nodeId={args.optionId} previews={previews} />
         </Group>
       </Field>

--- a/haku/console/frontend/tool_rendering/tana/requests.tsx
+++ b/haku/console/frontend/tool_rendering/tana/requests.tsx
@@ -86,7 +86,7 @@ function TanaNodeLink({ nodeId, previews }: { nodeId: string; previews: Record<s
       {preview.name}
     </Anchor>
   ) : (
-    <Text span className="haku-shell-mono" c="dimmed">
+    <Text size="sm" span className="haku-shell-mono" c="dimmed">
       {nodeId}
     </Text>
   );
@@ -108,9 +108,11 @@ function ImportTanaPastePreview({ args, variant }: PreviewProps<ImportTanaPasteA
 function GetOrCreateCalendarNodePreview({ args }: PreviewProps<GetOrCreateCalendarNodeArgs>) {
   return (
     <Group gap={6}>
-      <Badge variant="outline">{args.granularity}</Badge>
-      {args.date && <Text>{args.date}</Text>}
-      <Text c="dimmed" className="haku-shell-mono">
+      <Badge size="sm" variant="outline">
+        {args.granularity}
+      </Badge>
+      {args.date && <Text size="sm">{args.date}</Text>}
+      <Text size="sm" c="dimmed" className="haku-shell-mono">
         {args.workspaceId}
       </Text>
     </Group>
@@ -129,13 +131,13 @@ function EditOperation({ label, edit }: { label: string; edit: z.infer<typeof zE
         {label}
       </Text>
       <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>
-        <Text span c="dimmed">
+        <Text size="sm" span c="dimmed">
           {edit.old_string || "(empty)"}
         </Text>
         {" → "}
         {edit.new_string || "(clear)"}
         {edit.replace_all && (
-          <Text span c="dimmed">
+          <Text size="sm" span c="dimmed">
             {" · all matches"}
           </Text>
         )}
@@ -165,18 +167,26 @@ function MoveNodePreview({ args }: PreviewProps<MoveNodeArgs>) {
     <Stack gap={4}>
       <Group gap={6}>
         <TanaNodeLink nodeId={args.nodeId} previews={previews} />
-        <Text c="dimmed">→</Text>
+        <Text size="sm" c="dimmed">
+          →
+        </Text>
         <TanaNodeLink nodeId={args.targetNodeId} previews={previews} />
       </Group>
       <Group gap={6}>
-        <Badge variant="outline">{args.position}</Badge>
+        <Badge size="sm" variant="outline">
+          {args.position}
+        </Badge>
         {args.referenceNodeId && <TanaNodeLink nodeId={args.referenceNodeId} previews={previews} />}
         {args.sourceParentId && (
           <Text size="sm" c="dimmed">
             from <TanaNodeLink nodeId={args.sourceParentId} previews={previews} />
           </Text>
         )}
-        {args.keepSourceReference && <Badge variant="outline">keep reference</Badge>}
+        {args.keepSourceReference && (
+          <Badge size="sm" variant="outline">
+            keep reference
+          </Badge>
+        )}
       </Group>
     </Stack>
   );
@@ -185,16 +195,21 @@ function MoveNodePreview({ args }: PreviewProps<MoveNodeArgs>) {
 function SetFieldOptionPreview({ args }: PreviewProps<SetFieldOptionArgs>) {
   const previews = useTanaNodePreviews([args.nodeId, args.attributeId, args.optionId]);
   return (
-    <Stack gap={4}>
-      <Group gap={6}>
+    <Stack gap="xs">
+      <Field label="Node">
         <TanaNodeLink nodeId={args.nodeId} previews={previews} />
-        <Text c="dimmed">field</Text>
+      </Field>
+      <Field label="Field">
         <TanaNodeLink nodeId={args.attributeId} previews={previews} />
-      </Group>
-      <Group gap={6}>
-        <Badge variant="outline">{args.mode}</Badge>
-        <TanaNodeLink nodeId={args.optionId} previews={previews} />
-      </Group>
+      </Field>
+      <Field label="Option">
+        <Group gap={6}>
+          <Badge size="sm" variant="outline">
+            {args.mode}
+          </Badge>
+          <TanaNodeLink nodeId={args.optionId} previews={previews} />
+        </Group>
+      </Field>
     </Stack>
   );
 }

--- a/haku/console/frontend/tool_rendering/variant.tsx
+++ b/haku/console/frontend/tool_rendering/variant.tsx
@@ -4,13 +4,31 @@
 // first few lines. A **detailed** preview is the full form shown in the expanded detail
 // view. Leaf module (no widget deps) so index.tsx and every widget can import the type
 // without a cycle.
-import { Text } from "@mantine/core";
+import { Badge, type BadgeProps, Text, type TextProps } from "@mantine/core";
+import type { PropsWithChildren } from "react";
 
 export type PreviewVariant = "compact" | "detailed";
 
 // The props every top-level preview widget takes: the tool's parsed arguments plus the variant
 // to render. Shared so widgets (and `definePreview`) don't re-spell `{ args; variant }`.
 export type PreviewProps<Args> = { args: Args; variant: PreviewVariant };
+
+/** Tool-widget body copy. Keeping the default here prevents Mantine's larger application-level
+ * default from leaking back into one server when a renderer omits `size`. */
+export function PreviewText({ size = "sm", ...props }: PropsWithChildren<TextProps>) {
+  return <Text size={size} {...props} />;
+}
+
+/** A tool widget's primary identity: same type scale as its body, distinguished by weight rather
+ * than a one-off larger font. */
+export function PreviewTitle({ size = "sm", fw = 600, ...props }: PropsWithChildren<TextProps>) {
+  return <Text size={size} fw={fw} {...props} />;
+}
+
+/** Attribute/state pill for tool widgets. Variants and semantic colors remain call-site choices. */
+export function PreviewBadge({ size = "sm", ...props }: PropsWithChildren<BadgeProps>) {
+  return <Badge size={size} {...props} />;
+}
 
 // In compact previews, list-shaped arguments show only the first few items; the rest
 // collapse to a single "… +N more" line so a card stays scannable.
@@ -26,9 +44,9 @@ export function plural(count: number, noun: string): string {
 export function MoreLine({ count }: { count: number }) {
   if (count <= 0) return null;
   return (
-    <Text size="xs" c="dimmed">
+    <PreviewText size="xs" c="dimmed">
       … +{count} more
-    </Text>
+    </PreviewText>
   );
 }
 

--- a/haku/console/frontend/tool_rendering/vocabulary.test.ts
+++ b/haku/console/frontend/tool_rendering/vocabulary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { clampBlock, firstLines } from "./variant.tsx";
+import { clampBlock, firstLines } from "./vocabulary.tsx";
 
 describe("firstLines", () => {
   it("keeps the first n non-blank lines and flags that more was dropped", () => {

--- a/haku/console/frontend/tool_rendering/vocabulary.tsx
+++ b/haku/console/frontend/tool_rendering/vocabulary.tsx
@@ -1,4 +1,4 @@
-// Compact vs detailed rendering, shared by the per-server preview widgets. A **compact**
+// Shared vocabulary for per-server preview widgets, including compact vs detailed rendering. A **compact**
 // preview is the scannable form shown on a drawer approval card (and anywhere space is
 // tight): list-shaped arguments collapse to their first few items, long bodies to their
 // first few lines. A **detailed** preview is the full form shown in the expanded detail

--- a/haku/console/frontend/tool_result_field.tsx
+++ b/haku/console/frontend/tool_result_field.tsx
@@ -1,5 +1,5 @@
 import { Field } from "./field.tsx";
-import type { PreviewVariant } from "./tool_rendering/variant.tsx";
+import type { PreviewVariant } from "./tool_rendering/vocabulary.tsx";
 import { unwrapToolResult } from "./tool_rendering/result_entry.tsx";
 import { toolResultPreview } from "./tool_rendering/index.tsx";
 

--- a/haku/console/frontend/variant_control.tsx
+++ b/haku/console/frontend/variant_control.tsx
@@ -2,7 +2,7 @@ import { SegmentedControl } from "@mantine/core";
 import { useState } from "react";
 
 import { ListDetailsIcon, ListIcon } from "./icons.tsx";
-import type { PreviewVariant } from "./tool_rendering/variant.tsx";
+import type { PreviewVariant } from "./tool_rendering/vocabulary.tsx";
 
 // The per-view compact/detailed selection, shared by the history page's per-row control and the
 // drawer's cards so both spell it one way. `useVariant` owns the state; the owner threads the


### PR DESCRIPTION
## What changed

- standardize tool-renderer body and identity text on Mantine's `sm` scale
- standardize renderer badges on `size="sm"`
- replace hand-built label/value rows with the shared `Field` component for Grocy filters and IDs, Kubernetes Pod log targets, and Tana field-option edits
- document the typography, spacing, badge, and shared-component rules in the frontend `AGENTS.md`

## Why

Tool renderers had accumulated a mix of Mantine's default text size, explicit `sm`, and `xs`, plus several one-off label/value layouts. The same kind of content therefore changed size and alignment between tools.

## Validation

- `bbr test //haku/console/frontend:tsc_test //haku/console/frontend:bridge_test //haku/console/frontend:screenshots`
- visually inspected the complete light and dark tool-preview galleries from BuildBuddy invocation `4e7049fe-dac4-45c3-a79f-c0277febb9a1`
- pre-commit hooks
