### PR TITLE
fix(ci): repair PR visuals rollout wiring

### DIFF
--- a/cluster/k8s/seaweedfs/pr-visuals-bucket/flux-kustomization.yaml
+++ b/cluster/k8s/seaweedfs/pr-visuals-bucket/flux-kustomization.yaml
@@ -11,10 +11,13 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: ducktape
+    name: flux-system
   dependsOn:
     - name: seaweedfs-cluster
-  postBuild:
-    substituteFrom:
-      - kind: ConfigMap
-        name: cluster-settings
+      namespace: flux-system
+  wait: true
+  healthChecks:
+    - apiVersion: seaweed.seaweedfs.com/v1
+      kind: Bucket
+      name: pr-visuals
+      namespace: seaweedfs

--- a/tf/gitops/github-secrets-sync/main.tf
+++ b/tf/gitops/github-secrets-sync/main.tf
@@ -36,11 +36,17 @@ data "kubernetes_secret" "ci_age_key" {
 resource "random_password" "pr_visuals_access_key" {
   length  = 32
   special = false
+  keepers = {
+    rotation = "2026-07-12-1"
+  }
 }
 
 resource "random_password" "pr_visuals_secret_key" {
   length  = 64
   special = false
+  keepers = {
+    rotation = "2026-07-12-1"
+  }
 }
 
 resource "kubernetes_secret" "pr_visuals_s3_credentials" {


### PR DESCRIPTION
## What changed

- point the PR visuals bucket Kustomization at the cluster's real `flux-system` GitRepository
- match existing SeaweedFS bucket readiness and health-check conventions
- rotate the PR visuals writer identity after its credential was exposed during live verification

## Validation

- staged `pre-commit run`
- `bbr test //tf/gitops/github-secrets-sync:lint //tf/gitops/github-secrets-sync:validate //cluster/validation:test_flux_build`
