### PR TITLE
Propagate AnkiWeb credentials to Haku

### DIFF
--- a/cluster/k8s/agents/shared-secrets/ankiweb-credentials.sops.yaml
+++ b/cluster/k8s/agents/shared-secrets/ankiweb-credentials.sops.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: ankiweb-credentials
+    namespace: claude-sandbox
+    annotations:
+        description: AnkiWeb account credentials
+type: Opaque
+stringData:
+    email: ENC[AES256_GCM,data:QHWUyiODpg5re2meFMf5MMxq1L1mU3gjxzRZ,iv:0ternkEKa67OwDwzYQNzdm/MA8fYXrPzFssGFiTtcg4=,tag:kyRLXgYPcrL9KOmpJGtQ+Q==,type:str]
+    password: ENC[AES256_GCM,data:31l3n8jVOHc=,iv:3FdOOnk8chhd9WFcGIAZOrDNFoDI5ncKCZNWos4xTnQ=,tag:F7gt5cPgvjqVcRCYlyqTSg==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFY3pjalhvRWZteUtmRWZV
+            VlFKTmtleXFrODZ5NHhPZDZhbVMyK3N0RkU4Ck1ucS9GNjBSMXJhUnZQYVFnZEZ5
+            U1NuaVF0YWluR2k4a2c4dU1oUFlJeDQKLS0tIGNVZkxITzF6VHNvSlJXT085RHAz
+            d1FUaEJkNkVQR0RuM0dNN3VmbDFpMUkK04l5fpLTVK44xMzOFXo+GsRnncxtHZnu
+            qQgdajLYBj+YWQrqWIzVMqROYmtkQxGjcflCo7z12Y0UZKZ2GSvl6g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkQnl1aFhrcU9zUmZydjNv
+            cDU4cFFPZlpzN3dVV2crUHlxbHJVa0VXYlNNCngwQ05CdE5vZTJkTUtUR3hzb25h
+            Wk5ReTdtd256NVFBL0c4eVB2VTVha0EKLS0tIGpYeDRTT1JLbGxrOXNMVlNDUWtk
+            dHl4WXM1cFpGWk1VRVZ4Wk5PRCtlMzQKf/mps0wfTKcV2spsCg81Cn7cWPD+Qngz
+            VjJsegVqQInmb0yyoFjdPcwwYfDg83Ead8Q1MKgSEeCjER08ngBFWA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-12T23:44:37Z"
+    mac: ENC[AES256_GCM,data:Ax8lDwqwhTVLRRp4aLQOE/2JNiulO6fGWN1IukTWGiobyhLHPFzZJUBJ3hF/CYVtTfAwuSVkbdAv+JpO1O1IEVfzvuhZ0U8jhFcdsfFZ4ianKWVMPIvK4Z/QxzjI8UdF+IuQqu3wQb/J/m9DkAtHncLakADmUAYFqVhyeUHpd+s=,iv:OoJ5a35Q9RVXQzzLqUYsgYWN2mW7/BXd54RcckeudLo=,tag:J/1M0hqsoqcBQHeasMOYOw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/agents/shared-secrets/kustomization.yaml
+++ b/cluster/k8s/agents/shared-secrets/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ankiweb-credentials.sops.yaml
   - attic-push-token.sops.yaml
   - buildbuddy-api-key.sops.yaml
   - github-token.sops.yaml

--- a/cluster/k8s/external-secrets/config/claude-sandbox-secret-store.yaml
+++ b/cluster/k8s/external-secrets/config/claude-sandbox-secret-store.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-claude-sandbox-secret-store
+spec:
+  provider:
+    kubernetes:
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: default
+      auth:
+        serviceAccount:
+          name: external-secrets
+          namespace: external-secrets-system
+      remoteNamespace: claude-sandbox

--- a/cluster/k8s/external-secrets/config/kustomization.yaml
+++ b/cluster/k8s/external-secrets/config/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - external-secrets-config.yaml
   - airlock-secret-store.yaml
+  - claude-sandbox-secret-store.yaml
   - flux-system-secret-store.yaml

--- a/cluster/k8s/haku/agent-worker/ankiweb-credentials-eso.yaml
+++ b/cluster/k8s/haku/agent-worker/ankiweb-credentials-eso.yaml
@@ -1,0 +1,25 @@
+# Copy the SOPS-managed AnkiWeb credentials from claude-sandbox into
+# haku-sandbox without duplicating the credential values in git.
+apiVersion: external-secrets.io/v1
+kind: ClusterExternalSecret
+metadata:
+  name: haku-ankiweb-credentials
+spec:
+  namespaces:
+    - haku-sandbox
+  externalSecretSpec:
+    refreshInterval: 1m
+    secretStoreRef:
+      name: kubernetes-claude-sandbox-secret-store
+      kind: ClusterSecretStore
+    target:
+      name: ankiweb-credentials
+    data:
+      - secretKey: email
+        remoteRef:
+          key: ankiweb-credentials
+          property: email
+      - secretKey: password
+        remoteRef:
+          key: ankiweb-credentials
+          property: password

--- a/cluster/k8s/haku/agent-worker/flux-kustomization.yaml
+++ b/cluster/k8s/haku/agent-worker/flux-kustomization.yaml
@@ -24,6 +24,8 @@ spec:
       name: haku-worker
       namespace: haku-sandbox
   dependsOn:
+    - name: agent-shared-secrets # provides ankiweb-credentials in claude-sandbox
+    - name: external-secrets-config # provides the claude-sandbox SecretStore
     - name: haku-namespace
     - name: haku-rbac
     - name: haku-state # provides the haku-state-git-write secret in haku-sandbox

--- a/cluster/k8s/haku/agent-worker/kustomization.yaml
+++ b/cluster/k8s/haku/agent-worker/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ankiweb-credentials-eso.yaml
   - serviceaccount.yaml
   - rolebinding.yaml
   - environment-key.sops.yaml


### PR DESCRIPTION
## Summary

- add a SOPS-encrypted `ankiweb-credentials` Secret in `claude-sandbox`
- add an ESO Kubernetes provider store for `claude-sandbox`
- mirror the credentials into `haku-sandbox` as `ankiweb-credentials`
- order the Haku worker reconciliation after the source Secret and ESO configuration

## Why

Haku needs access to the AnkiWeb account without duplicating plaintext credentials or maintaining a second encrypted copy. ESO copies the existing SOPS-managed Secret across the namespace boundary.

## Validation

- `bbr test //cluster/validation:test_flux_build //cluster/validation:test_sops_decryption`
- commit-time pre-commit suite, including kubeconform and Ducktape manifest validation
- `git diff --check`